### PR TITLE
adding google analytics id to config

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -46,14 +46,11 @@ const config: Config = {
             './static/css/boxicons.min.css'
           ],
         },
-        
-      } satisfies Preset.Options,
-      {
         gtag: {
-          trackingID: 'G-0660YY8LZ',
+          trackingID: 'G-0660YY8LZF',
           anonymizeIP: true,
-        },
-      },
+        }
+      } satisfies Preset.Options,
     ],
   ],
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -46,7 +46,14 @@ const config: Config = {
             './static/css/boxicons.min.css'
           ],
         },
+        
       } satisfies Preset.Options,
+      {
+        gtag: {
+          trackingID: 'G-0660YY8LZ',
+          anonymizeIP: true,
+        },
+      },
     ],
   ],
 


### PR DESCRIPTION
This PR adding a gtag config to the docusaurus config so we can test Google analytics.