### PR TITLE
Fix link to example apps in get-started.mdx

### DIFF
--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -45,4 +45,4 @@ resonate serve
 
 ### 4. Start customizing the template!
 
-From here, if you are familiar with Resonate you can make your way using the [feature development guides](/develop), [tutorials](/learn), and [example apps](https://github.com/resonatehq/awesome-examples).
+From here, if you are familiar with Resonate you can make your way using the [feature development guides](/develop), [tutorials](/learn), and [example apps](https://github.com/resonatehq-examples).


### PR DESCRIPTION
Fix the link to the example apps. It now points to: https://github.com/resonatehq-examples .