### PR TITLE
Add schedule() API docs for Python and TypeScript

### DIFF
--- a/docs/develop/python.mdx
+++ b/docs/develop/python.mdx
@@ -304,12 +304,6 @@ resonate.schedule(
 )
 ```
 
-Registered functions can also schedule themselves directly:
-
-```py
-foo.schedule("scheduled-foo", "0 * * * *", arg)
-```
-
 ### `.options()`
 
 Options can be used preceding `.run()`, `.begin_run()`, `.rpc()`, `.begin_rpc()`, and `.schedule()`.

--- a/docs/develop/python.mdx
+++ b/docs/develop/python.mdx
@@ -290,9 +290,29 @@ handle = resonate.begin_rpc("invocation-id", "foo", arg)
 result = handle.result()
 ```
 
+### `.schedule()`
+
+Resonate's `.schedule()` method registers a function to be invoked on a cron schedule.
+The function will be invoked automatically until the schedule is deleted.
+
+```py
+resonate.schedule(
+    "scheduled-foo",  # schedule ID
+    foo,              # function to schedule
+    "0 * * * *",      # cron expression (every hour)
+    arg,              # arguments
+)
+```
+
+Registered functions can also schedule themselves directly:
+
+```py
+foo.schedule("scheduled-foo", "0 * * * *", arg)
+```
+
 ### `.options()`
 
-Options can be used preceding `.run()`, `.beginRun()`, `.rpc()`, and `.beginRpc()`.
+Options can be used preceding `.run()`, `.begin_run()`, `.rpc()`, `.begin_rpc()`, and `.schedule()`.
 
 ```py
 from resonate.retry_policies import Exponential, Constant, Linear, Never

--- a/docs/develop/typescript.mdx
+++ b/docs/develop/typescript.mdx
@@ -413,6 +413,14 @@ const schedule = await resonate.schedule(
 );
 ```
 
+Registered functions can also schedule themselves directly:
+
+```ts
+const foo = resonate.register("foo", async (ctx, ...args) => { /* ... */ });
+
+await foo.schedule("scheduled-foo", "0 * * * *", ...args);
+```
+
 ### `.options()`
 
 Options can be used with `.run()`, `.beginRun()`, `.rpc()`, `.beginRpc()`, and `.schedule()` as the final argument.

--- a/docs/develop/typescript.mdx
+++ b/docs/develop/typescript.mdx
@@ -413,14 +413,6 @@ const schedule = await resonate.schedule(
 );
 ```
 
-Registered functions can also schedule themselves directly:
-
-```ts
-const foo = resonate.register("foo", async (ctx, ...args) => { /* ... */ });
-
-await foo.schedule("scheduled-foo", "0 * * * *", ...args);
-```
-
 ### `.options()`
 
 Options can be used with `.run()`, `.beginRun()`, `.rpc()`, `.beginRpc()`, and `.schedule()` as the final argument.


### PR DESCRIPTION
## Summary

- Adds `.schedule()` section to Python SDK docs (was missing entirely)
- Updates Python `.options()` description to include `.schedule()`

Note: TypeScript `.schedule()` docs already exist on `main` (added in PR #123).

## Related

- Python SDK PR: https://github.com/resonatehq/resonate-sdk-py/pull/397
- TypeScript SDK PR: https://github.com/resonatehq/resonate-sdk-ts/pull/436
- Composite issue: https://github.com/resonatehq/resonatehq-workq/issues/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)