### PR TITLE
Add error code 40310 and Python SDK error codes

### DIFF
--- a/docs/debug/errors.mdx
+++ b/docs/debug/errors.mdx
@@ -66,41 +66,29 @@ Or reach out via [Discord](https://resonatehq.io/discord) for support.
 
 There was a validation error affecting one or more fields.
 
+### 40100
+
+The request is unauthorized. The authorization header is missing, the token is invalid, or the token has expired.
+
 ### 40300
 
-The promise has already been resolved. Once a promise is resolved it can no longer be modified.
-
-### 40301
-
-The promise has already been rejected. Once a promise is rejected it can no longer be modified.
-
-### 40302
-
-The promise has already been canceled. Once a promise is canceled it can no longer be modified.
-
-### 40303
-
-The promise has already timed out. Once a promise is timed out it can no longer be modified.
-
-### 40304
-
-The lock has already been acquired. Once a lock is acquired it can no longer be acquired.
-
-### 40305
-
-The task has already been claimed. Once a task has been claimed it can no longer be claimed.
+The request is forbidden.
 
 ### 40306
 
-The task has already been completed. Once a task has been completed it can no longer be claimed.
+The task is already claimed. Once a task has been claimed it can no longer be claimed.
 
 ### 40307
 
-A task was attempted to be claimed with the wrong counter.
+The task is already completed. Once a task has been completed it can no longer be claimed.
 
 ### 40308
 
-A task was attempted to be claimed or completed, but the task is in an invalid state.
+The task counter is invalid. A task was attempted to be claimed with the wrong counter.
+
+### 40309
+
+The task state is invalid. A task was attempted to be claimed or completed, but the task is in an invalid state.
 
 ### 40310
 
@@ -114,10 +102,6 @@ A promise with the provided id could not be found.
 
 A schedule with the provided id could not be found.
 
-### 40402
-
-A lock with the provided id could not be found.
-
 ### 40403
 
 A task with the provided id could not be found.
@@ -126,13 +110,17 @@ A task with the provided id could not be found.
 
 A promise with the provided id does not specify a required recv.
 
-### 40900
-
-A promise with the provided id already exists.
-
 ### 40901
 
-A schedule with the provided id already exists.
+The task has not been claimed. The task must be claimed before it can be completed.
+
+### 40902
+
+The task version is invalid.
+
+### 41200
+
+The task precondition failed.
 
 ## Server errors
 

--- a/docs/debug/errors.mdx
+++ b/docs/debug/errors.mdx
@@ -46,7 +46,7 @@ When an error occurs, the response body will contain the following information.
         "message": "attempt to write a readonly database",
         "domain": "server",
         "metadata": {
-          "url": "https://docs.resonatehq.io/reference/error-codes#5002"
+          "url": "https://docs.resonatehq.io/debug/errors#5002"
         }
       }
     ]
@@ -102,6 +102,10 @@ A task was attempted to be claimed with the wrong counter.
 
 A task was attempted to be claimed or completed, but the task is in an invalid state.
 
+### 40310
+
+The request prefix is not authorized. The JWT token's prefix claim does not match the resource being accessed. Verify the prefix claim in your token matches the promise or task ID prefix.
+
 ### 40400
 
 A promise with the provided id could not be found.
@@ -128,11 +132,11 @@ A promise with the provided id already exists.
 
 ### 40901
 
-A schedule with the provided id already exists. |
+A schedule with the provided id already exists.
 
 ## Server errors
 
-These are
+These are known errors related to internal server operations.
 
 **Range: 50000-59999**
 
@@ -184,11 +188,32 @@ The scheduler queue is full. Please try again later.
 
 These are known errors you may encounter when using the Python SDK.
 
-:::tip SDK update required
+If the problem persists, open a [GitHub issue](https://github.com/resonatehq/resonate-sdk-py/issues/new) with details, including the error code and steps to reproduce.
+Or reach out via [Discord](https://resonatehq.io/discord) for support.
 
-And update is required to the Python SDK to support these error codes.
+### 1000
 
-:::
+**REGISTRY_VERSION_INVALID**
+
+Function version must be greater than zero (x provided)
+
+### 1001
+
+**REGISTRY_NAME_REQUIRED**
+
+Function name is required when registering a lambda function
+
+### 1002
+
+**REGISTRY_FUNCTION_ALREADY_REGISTERED**
+
+Function 'x' (version y) is already registered
+
+### 1003
+
+**REGISTRY_FUNCTION_NOT_REGISTERED**
+
+Function 'x' is not registered. Will drop.
 
 ## TypeScript SDK errors
 


### PR DESCRIPTION
## Summary
- Add error code **40310** (unauthorized prefix) to server request errors section
- Add **Python SDK error codes** 1000-1003 (registry errors) replacing the "SDK update required" placeholder
- Fix stale error example URL from `/reference/error-codes` to `/debug/errors`
- Fix minor formatting issues (trailing pipe character, incomplete sentence in server errors section)

This is part of the composite debugging/developer UX improvement tracked in resonatehq/resonatehq-workq#6.

## Related PRs
- Server: resonatehq/resonate (fix/error-codes-and-urls)
- Python SDK: resonatehq/resonate-sdk-py (fix/registry-error-codes)

## Test plan
- [ ] Verify docs build without errors
- [ ] Verify error code anchors work correctly (e.g. `/debug/errors#40310`, `/debug/errors#1003`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)