### PR TITLE
Land April 2026 positioning on docs landing + Why Resonate (iter 01)

### DIFF
--- a/docs/evaluate/why-resonate.mdx
+++ b/docs/evaluate/why-resonate.mdx
@@ -3,85 +3,82 @@ id: why-resonate
 title: Why Resonate
 sidebar_label: Why Resonate
 sidebar_position: 1
-description: There are a lot of reasons why you should consider adopting Resonate.
+description: Resonate is the durable execution engine that agents build with, deploy on, and operate — at a fraction of the cost of anything else.
 tags:
   - evaluate
+  - positioning
+  - agent-native
 ---
 
-**What problem does Resonate solve?**
+**Resonate is the durable execution engine that agents build with, deploy on, and operate &mdash; at a fraction of the cost of anything else.**
 
-## Complexity is pain
+It is the implementation of a [distributed async/await](https://distributed-async-await.io) programming model: a formal, language- and transport-agnostic protocol for writing functions that survive process restarts, run for hours or months, and coordinate across many machines.
 
-Resonate is fundamentally about reducing complexity for developers building reliable and scalable software systems.
+This page explains the three pillars that make Resonate different, the business model that ships those pillars, and what this means for agents and the humans who work with them.
 
-Developers still experience a great deal of pain from all the complexity that's crammed in at the application level —
-Complexity, which is added, to solve for reliability and scalability.
+## The three pillars
 
-Practically, this means that failure retry, crash recovery, idempotency, service discovery, load balancing, asynchronous messages, etc, are things that developers have to repeatedly think about and solve for alongside their use case.
+### 1. Agent-native
 
-More or less, the complexity and the pain, stem from a system's desire to be concurrent and distributed.
-_Why?_ So the system is scalable and reliable!
-Concurrency and distribution enable scalability and reliability.
-However, the more concurrency and distribution there is, the more complex the code becomes.
-When the code becomes distributed and complex - the system becomes hard to build, hard to maintain, and hard to reason about.
-These challenges can erode the confidence, speed, and joy of development.
+Agents are the new developers. Increasingly, software is selected, written, configured, and deployed by AI agents — not by humans choosing platforms and libraries by hand. The platform that agents reach for is the platform that wins.
 
-Resonate addresses this pain holistically.
-Resonate pushes all that complexity (failure retry, crash recovery, idempotency guarantees, service discovery, load balancing, asynchronous messages, etc.) into the platform and provides developers with a simple set of APIs to use at the application level.
+Resonate is built for that world from the ground up:
 
-_Using Resonate makes reliable and scalable applications dead simple to develop, dead simple to deploy, and dead simple to operate._
+- **The SDK is designed for agent consumption.** Predictable APIs, deterministic execution, clear failure modes. An agent reading the SDK reference can build correct distributed workflows on the first try.
+- **The docs are written for both humans and agents.** Skill files (machine-readable agent guidance) sit alongside human tutorials. The CLI reference is canonical and exhaustive.
+- **The operational surface is CLI-first, dashboard-never.** Agents do not click. They script. Every operation — provision, deploy, observe, scale, tear down — is a CLI command an agent can call.
+- **Tool definitions are first-class.** Resonate ships tool definitions agents can discover, including (planned) an MCP server for Resonate operations.
 
-**When to use Resonate?**
+When we say "agent-native," we mean: an autonomous coding agent should be able to build, deploy, and operate a Resonate application end to end without ever loading a web page.
 
-## Systems engineering for ...
+### 2. Generated &amp; optimized
 
-_Use Resonate as soon as you realize you need or have a software system!_
+Most durable execution platforms ship a single general-purpose server: hand-written code that has to handle every possible stack, every possible transport, every possible storage backend. Generality has a tax — every workflow pays for abstractions it doesn't use, in state transitions, network requests, and operational chatter.
 
-The [Distributed Async Await spec](https://distributed-async-await.io), and its underlying [Async RPC protocol](https://asynchronous-rpc.io), was intended to be a general-purpose programming and execution model for building reliable and scalable software systems.
-As an implementation of that spec, Resonate has successfully inherited that intended trait.
-For example...
+Resonate takes a different path. Components are **generated per-stack by AI**. You tell us your stack — Kafka or HTTP for transport, Postgres or DynamoDB for state, gRPC or REST for the wire — and we generate a complete Resonate server tailored to it. Zero hand-written code. Minimal state transitions. Exactly what your stack needs, nothing more.
 
-- **Autonomous systems & agentic applications**: Dominik Tornow breaks it all down in his online book [Systems Engineering for Agentic Applications](https://systems-engineering-for-agentic-applications.resonatehq.io/)
-- **Function-as-a-Service**: Whether you are building a Function-as-a-Service (FaaS) platform, see [Building a Demo FaaS Platform with Resonate](https://journal.resonatehq.io/p/building-a-demo-faas-platform-with) or using one, see [GCP countdown workflow example application](https://github.com/resonatehq-examples/example-countdown-ts-gcp), Resonate's execution model makes it ideal for both.
-- **Financial systems**:Resonate is well-suited for building distributed financial systems that require strong consistency and reliability, explored in depth in the article [Maintaining Consistency in the absence of transactions](https://maintaining-consistency-in-distributed-financial-systems.resonatehq.io/).
+This is only possible because the underlying [protocol](https://asynchronous-rpc.io) is fully formal: a JSON Schema specification that an AI can target as a code generation goal. The protocol is the contract; the implementation is generated.
 
-Resonate's programming model serves developers by offering a clean, simple, and reliable pattern for awaiting on things in your event loop, whether that is a function executing, a human verifying some work, or an AI agent taking the step next.
-This makes it great for basically anything relying on a system.
+### 3. Absurdly cheap
 
-## Incremental adoption
+Generated components plus serverless-native deployment produces a cost story that is not incremental — it is categorical.
 
-Resonate is designed to be adopted incrementally, if desired.
+Fewer state transitions means fewer database writes, fewer network round trips, fewer compute-seconds. Serverless-native architecture means you pay only for execution that is actually happening. Together, these effects compound.
 
-![crawl, walk, run diagram](/img/crawl-walk-run.png)
+**The extreme case:** a workload that costs roughly $80,000 per year on a hosted durable execution platform can run for under $100 per year on Resonate. That is not a rounding error, and it is not marketing — it is the consequence of removing unnecessary work from the critical path.
 
-Getting started or introducing Resonate into an existing system can be done in small steps, with very minimal dependencies.
+Cost is the ultimate forcing function. When an agent evaluates options, Resonate wins on cost by 100&ndash;800x.
 
-## Quality standards
+## How the business model ships the pillars
 
-There are at least two things that we do that should paint a picture of our commitment to quality.
+Resonate&apos;s revenue model has two phases that map directly onto the pillars.
 
-_First is formal modeling and formal verification._
+### Phase 1 &mdash; Licensed generated servers (available now)
 
-Resonate is an implementation of the [Distributed Async Await specification](https://distributed-async-await.io), which relies on the [Asynchronous RPC protocol](https://asynchronous-rpc.io).
-These underlying specs have been and continue to undergo formal modeling exercises, which probe their correctness.
+You tell us your stack. We generate a complete Resonate server tailored to it, run on your infrastructure. You receive the binary, the source, the tests, and the docs. Licensed per-stack-generation.
 
-_Second is simulation testing._
+This is the trust-building phase. Real Resonate servers running inside real companies, on real infra, processing real workloads.
 
-Each major component in Resonate, the Resonate Server and each of the SDKs, is subjected to Deterministic Simulation Testing (DST).
-This is of course on top of traditional unit testing and integration testing.
-DST identifies complex edge cases that may cause unexpected behavior in production, well before the code is ever released.
+### Phase 2 &mdash; Resonate Connect (Q3&ndash;Q4 2026)
 
-These two things set a foundation of quality that we build upon with every release.
+An agent-native PaaS. Provision, deploy, observe, scale, and tear down entirely from a CLI. Same SDK, same protocol, same cost story — but you stop running the infrastructure.
+
+Phase 1 customers migrate to Phase 2 without rewriting application code. Only the server endpoint changes.
+
+## Quality is not optional
+
+Two things should give you confidence in Resonate&apos;s correctness:
+
+**Formal modeling.** The [Distributed Async Await specification](https://distributed-async-await.io) and the [Async RPC protocol](https://asynchronous-rpc.io) underlying Resonate are formally modeled and continuously probed for correctness. The protocol is a contract, not a vibe.
+
+**Deterministic Simulation Testing.** Every major component &mdash; the Resonate Server and each SDK &mdash; is subjected to DST. This finds complex edge cases long before they reach production, on top of conventional unit and integration tests.
+
+The new server is also linearizable. Combined with DST, this is the foundation of the correctness story.
 
 ## Open everything
 
-The underlying Async RPC protocol, the Distributed Async Await specification, and Resonate are all fully open source.
+The Async RPC protocol, the Distributed Async Await specification, and the open-source Resonate server are all fully open. Adopting Resonate means adopting a protocol, not a vendor. Everything you need to fork or build your own is available to you.
 
-Adopting Resonate does mean that you are adopting Distributed Async Await.
-But it doesn't mean you are locked into Resonate specifically.
+## What we no longer say
 
-Everything you need to fork or build your own is available to you.
-
-But, the deeper philosophy is in imagining a world where every service, API, and distributed component used Durable Promises and Async RPC.
-Different implementations of the Distributed Async Await spec could interoperate seamlessly.
-And developers stay in control with far less complexity.
+If you find old material that frames Resonate as "simpler than Temporal, faster than hiring," or as a service that builds custom workflow components to your spec, or as a tool *only* for Python and TypeScript developers — that material is stale. The protocol is language-agnostic. The product is a generated server, not a consulting engagement. The customer is the agent (and the humans who work with them), not just human developers.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -2,7 +2,7 @@
 id: index
 slug: /
 title: Resonate Documentation
-description: Resonate — reliablility, scalability — and a delightful developer experience.
+description: Resonate — agent-native durable execution. Generated, optimized, absurdly cheap.
 tags:
   - overview
   - documentation
@@ -15,9 +15,15 @@ hide_title: true
 
 ![Resonate documentation banner](/img/resonate-documentation-banner.png)
 
-Resonate is a <span className="spooky">dead simple</span> durable execution framework for building reliable and scalable cloud applications with a delightful developer experience. Build agents, workflows, pipelines, and services without thinking about retries or recovery. Resonate handles the hard parts of distributed systems—you focus on your application logic.
+**Resonate is the durable execution engine that agents build with, deploy on, and operate.** It is the implementation of a distributed async/await programming model: a formal, language- and transport-agnostic protocol for writing functions that survive process restarts, run for hours or months, and coordinate across many machines.
 
-Complex problems, simple code. Write functions that scale across dozens or hundreds of machines and run for hours, days, weeks, or months, in just a few lines of code.
+Resonate is built on three pillars:
+
+- **Agent-native** — The SDK, docs, tool definitions, and operational surface are designed for agent consumption, not just human developers. CLIs over dashboards. Skill files over screenshots. Agents are the new developers, and Resonate is the platform they reach for.
+- **Generated & optimized** — Components are generated per-stack by AI. Zero hand-written code. Minimal state transitions, minimal network chatter. Exactly what your stack needs, nothing more.
+- **Absurdly cheap** — Serverless-native architecture means you pay only for active execution. Workloads that cost ~$80K/year on hosted alternatives can run for under $100/year on Resonate. Orders of magnitude, not percentages.
+
+Build agents, workflows, pipelines, and services without thinking about retries or recovery. Write functions that scale across dozens or hundreds of machines and run for hours, days, weeks, or months — in just a few lines of code.
 
 ```typescript
 // An AI agent that recursively spawns subagents


### PR DESCRIPTION
## Summary

First real iteration of the [Resonate alignment loop](https://github.com/resonatehq/resonate/tree/main/docs/board/iteration). Lands the April 2026 refocus positioning into the canonical docs surfaces Kapa indexes for \"what is Resonate\" / \"what does agent-native mean\" / \"how is Resonate different.\"

**Scope:** `surface=docs+marketing+kapa`, `axis=messaging`, `thread-pull=adjacent`.

## Why this PR exists

Iteration 00 of the alignment loop ran the Resonate eval set against Kapa Ask Echo and surfaced two findings that this PR fixes directly:

- **M4 \"What does agent-native mean in Resonate?\"** — Echo answered: *\"The knowledge sources do not explicitly use the term 'agent-native' as a defined concept in Resonate's documentation or marketing materials. I cannot confidently define what that specific phrase means without speculating.\"* The phrase exists in internal Zone 1 docs but not in any source Kapa indexes.
- **M1 \"What is Resonate?\"** — Echo led with *\"a durable execution framework for building reliable and scalable cloud applications in Python and TypeScript.\"* Exactly the framing REFOCUS retired.

Both phrases trace back to `docs/index.mdx` and the canonical \"Why Resonate\" page. This PR fixes both at the source.

## Files changed

- **`docs/index.mdx`** — Page description and opener replaced. New opener defines Resonate as \"the durable execution engine that agents build with, deploy on, and operate,\" and lists the three pillars (agent-native, generated & optimized, absurdly cheap) inline so Kapa has retrievable definitions for all three.
- **`docs/evaluate/why-resonate.mdx`** — Full rewrite. Sections:
  - Lead: one-sentence positioning + protocol context
  - The three pillars (each gets its own subsection with definition)
  - How the business model ships the pillars (Phase 1 licensed generated servers, Phase 2 Resonate Connect)
  - Quality (formal modeling + DST + linearizability — preserved from the prior page)
  - Open everything (preserved from the prior page)
  - **What we no longer say** — explicit disclaimer naming the retired phrases (\"simpler than Temporal, faster than hiring,\" \"Custom Components built to your spec,\" \"only Python and TypeScript\") so future Kapa queries that retrieve them land on a correction rather than a stale endorsement

## What this does NOT do

- Does not touch `coming-from/*` competitor pages (Dominik-sensitive, separate iteration).
- Does not add a new \"For Agents\" sidebar section. That's a planned initiative iteration once the `resonate-skills` repo is awakened. M4 (the immediate gap) is closed by the inline definition in why-resonate.
- Does not modify SDK reference pages, examples, or `develop/*` API docs. Those are technical-axis work for iteration 02.
- Does not scrub every incidental \"reliable and scalable\" phrase. Those are descriptive, not retired-positioning. Don't over-scrub.

## Expected eval impact (will be measured at start of iter 02)

- M1 (\"What is Resonate?\") — should pass once Kapa re-ingests `docs/index.mdx`
- M4 (\"What does agent-native mean?\") — should pass once Kapa re-ingests `why-resonate.mdx`
- M3 (\"How is Resonate different from Temporal/Restate?\") — partial; cost story is now retrievable
- M5 (\"Why is Resonate so much cheaper?\") — should pass; serverless + state transition story is on the page
- D1, D5 — should pass; \"what we no longer say\" disclaimer + protocol-agnostic framing
- M6 (\"Resonate's business model?\") — should pass; both phases named and explained

Kapa re-ingestion is asynchronous and out of our control. The honest measurement is at the start of iteration 02, not in this PR.

## Test plan

- [ ] `yarn && yarn build` succeeds
- [ ] `/` and `/evaluate/why-resonate` render correctly
- [ ] All anchor links and sidebar entries still work
- [ ] **DO NOT MERGE** without Cully + Dominik approval — strategic positioning needs CEO sign-off

🤖 Generated as part of [resonate alignment loop iteration 01](https://github.com/resonatehq/resonate/tree/main/docs/board/iteration) with [Claude Code](https://claude.com/claude-code)