### PR TITLE
fix: align TypeScript docs with SDK v0.10.0

### DIFF
--- a/docs/debug/troubleshooting.mdx
+++ b/docs/debug/troubleshooting.mdx
@@ -138,7 +138,7 @@ See [Server configuration](/deploy/run-server#customize-configuration) for valid
 
 1. **Verify server URL:**
 ```typescript
-const resonate = Resonate.remote({
+const resonate = new Resonate({
   url: "http://resonate-server:8001",  // Must match server address
   group: "workers",
 });
@@ -156,15 +156,10 @@ curl http://resonate-server:8001/healthz
 If server has auth enabled, workers must provide credentials:
 
 ```typescript
-const resonate = Resonate.remote({
+const resonate = new Resonate({
   url: "http://resonate-server:8001",
   group: "workers",
-  auth: {
-    basic: {
-      username: "user",
-      password: "pass",
-    },
-  },
+  token: "your-jwt-token",
 });
 ```
 
@@ -193,7 +188,7 @@ resonate serve --log-level debug
 1. **Verify group names match:**
 ```typescript
 // When registering worker:
-const resonate = Resonate.remote({
+const resonate = new Resonate({
   group: "workers",  // Note the group name
 });
 
@@ -217,8 +212,7 @@ resonate.register("processOrder", async (ctx, data) => {
   // Task execution
 });
 
-// Start polling
-await resonate.start();
+// Worker polls automatically after registration
 ```
 
 3. **Inspect promise state:**
@@ -426,14 +420,9 @@ If creating many promises, batch them when possible to reduce database round-tri
 
 1. **Verify credentials:**
 ```typescript
-const resonate = Resonate.remote({
+const resonate = new Resonate({
   url: "http://resonate-server:8001",
-  auth: {
-    basic: {
-      username: "user",  // Check these match server config
-      password: "pass",
-    },
-  },
+  token: "your-jwt-token",  // Check this matches server config
 });
 ```
 

--- a/docs/deploy/deployment-patterns.mdx
+++ b/docs/deploy/deployment-patterns.mdx
@@ -264,7 +264,7 @@ Lambda workers can run as functions that poll for tasks or respond to events:
 ```typescript title="lambda-worker.ts"
 import { Resonate } from "@resonatehq/sdk";
 
-const resonate = Resonate.remote({
+const resonate = new Resonate({
   url: process.env.RESONATE_URL!,
   group: "lambda-workers",
 });

--- a/docs/deploy/tracing.mdx
+++ b/docs/deploy/tracing.mdx
@@ -57,13 +57,10 @@ const otel = new ResonateOpenTelemetry({
 });
 
 // Create Resonate instance with tracing
-const resonate = Resonate.remote({
+const resonate = new Resonate({
   url: "http://localhost:8001",
   // OpenTelemetry context automatically propagated
 });
-
-// Start your application
-await resonate.start();
 ```
 
 ### OTLP Exporter endpoint
@@ -170,9 +167,9 @@ const otel = new ResonateOpenTelemetry({
 Every Resonate function creates a span:
 
 ```typescript
-resonate.register("processOrder", async (ctx, order) => {
+resonate.register("processOrder", function* (ctx, order) {
   // Span: "processOrder" (duration = function execution time)
-  const result = await ctx.run(() => validateOrder(order));
+  const result = yield* ctx.run(validateOrder, order);
   return result;
 });
 ```
@@ -187,18 +184,18 @@ resonate.register("processOrder", async (ctx, order) => {
 Each `ctx.run()`, `ctx.sleep()`, etc. creates child spans:
 
 ```typescript
-resonate.register("checkout", async (ctx, cart) => {
+resonate.register("checkout", function* (ctx, cart) {
   // Parent span: "checkout"
-  
-  const validated = await ctx.run(() => validateCart(cart));
+
+  const validated = yield* ctx.run(validateCart, cart);
   // Child span: "validateCart"
-  
-  await ctx.sleep(1000);
+
+  yield* ctx.sleep(1000);
   // Child span: "sleep(1000ms)"
-  
-  const charged = await ctx.run(() => chargeCard(cart.total));
+
+  const charged = yield* ctx.run(chargeCard, cart.total);
   // Child span: "chargeCard"
-  
+
   return charged;
 });
 ```

--- a/docs/develop/constraints.mdx
+++ b/docs/develop/constraints.mdx
@@ -438,7 +438,7 @@ For work that takes hours, days, or weeks, use `ctx.sleep()` or Durable Promises
 
 | Constraint | Why it exists | Solution |
 |------------|---------------|----------|
-| **Deterministic** | Functions are replayed on restart - must produce same results | Use `ctx.random()`, `ctx.time()`, `ctx.run()` |
+| **Deterministic** | Functions are replayed on restart - must produce same results | Use `ctx.math.random()`, `ctx.date.now()`, `ctx.run()` |
 | **Idempotent** | Functions are retried on failure - must be safe to repeat | Use idempotency keys, upserts, deduplication checks |
 | **Process lifetime** | Activations end when process ends - can't outlive it | Use `ctx.sleep()`, Durable Promises for long-running work |
 

--- a/docs/develop/typescript.mdx
+++ b/docs/develop/typescript.mdx
@@ -459,14 +459,6 @@ await resonate.promises.create(
 );
 ```
 
-### `.promises.get()`
-
-Resonate's `.promises.get()` method allows you to get a promise by ID.
-
-```ts
-const p = await resonate.promises.get("promise-id");
-```
-
 ### `.promises.resolve()`
 
 Resonate's `.promises.resolve()` method allows you to resolve a promise by ID.
@@ -692,7 +684,7 @@ resonate.register("send-reminder", function* (ctx: Context, userId: string) {
   // Pause for five seconds without blocking the worker
   yield* ctx.sleep(5_000);
 
-  yield* ctx.rfc("notify-user", userId);
+  yield* ctx.rpc("notify-user", userId);
 });
 ```
 
@@ -715,7 +707,7 @@ resonate.register("schedule-digest", function* (ctx: Context, userId: string) {
   // Resume exactly at 8am
   yield* ctx.sleep({ until: nextEightAm });
 
-  yield* ctx.rfc("send-digest", userId);
+  yield* ctx.rpc("send-digest", userId);
 });
 ```
 

--- a/docs/get-started/examples/durable-serverless-cloud-run-workers.mdx
+++ b/docs/get-started/examples/durable-serverless-cloud-run-workers.mdx
@@ -55,14 +55,16 @@ import TabItem from "@theme/TabItem";
     <TabItem value="typescript" >
 
 ```typescript
-import { Context, resonate } from "@resonatehq/server";
+import { Resonate } from "@resonatehq/sdk";
+import type { Context } from "@resonatehq/sdk";
 
 export function* cloudRunWorker(ctx: Context, jobId: string) {
-  const result = yield ctx.run(processJob, jobId);
+  const result = yield* ctx.run(processJob, jobId);
 
-  yield ctx.run(writeResult, jobId, result);
+  yield* ctx.run(writeResult, jobId, result);
 }
 
+const resonate = new Resonate();
 resonate.register("cloudRunWorker", cloudRunWorker);
 ```
 

--- a/docs/get-started/examples/durable-serverless-lambda-workers.mdx
+++ b/docs/get-started/examples/durable-serverless-lambda-workers.mdx
@@ -56,17 +56,18 @@ import TabItem from "@theme/TabItem";
     <TabItem value="typescript" >
 
 ```typescript
-import { resonate } from "@resonatehq/server";
+import { Resonate } from "@resonatehq/sdk";
 import type { Context } from "@resonatehq/sdk";
 
 export function* lambdaWorker(ctx: Context, task: TaskPayload) {
-  const attempt = yield ctx.run(startExecution, task);
+  const attempt = yield* ctx.run(startExecution, task);
 
-  const outcome = yield ctx.run(waitForDependency, attempt.id);
+  const outcome = yield* ctx.run(waitForDependency, attempt.id);
 
-  yield ctx.run(finalizeTask, outcome);
+  yield* ctx.run(finalizeTask, outcome);
 }
 
+const resonate = new Resonate();
 resonate.register("lambdaWorker", lambdaWorker);
 ```
 

--- a/docs/get-started/examples/durable-sleep.mdx
+++ b/docs/get-started/examples/durable-sleep.mdx
@@ -73,7 +73,7 @@ def sleeping_workflow(ctx: Context, seconds: int):
 
 ```typescript
 function* sleepingWorkflow(ctx: Context, milliseconds: number) {
-  yield ctx.sleep(milliseconds);
+  yield* ctx.sleep(milliseconds);
 
   // ...
 }

--- a/docs/learn/deployments/digital-ocean-droplet.mdx
+++ b/docs/learn/deployments/digital-ocean-droplet.mdx
@@ -261,15 +261,10 @@ resonate = Resonate.remote(
 ```typescript
 import { Resonate } from "@resonatehq/sdk";
 
-const resonate = Resonate.remote({
+const resonate = new Resonate({
+  url: "https://your-domain.com:8001",
   group: "my-app-group",
-  host: "https://your-domain.com",
-  storePort: "8001",
-  messageSourcePort: "8002",
-  auth: {
-    username: "your-username",
-    password: "your-password",
-  },
+  token: "your-jwt-token",
 });
 ```
 

--- a/docs/learn/typescript-sdk/website-summarization-agent.mdx
+++ b/docs/learn/typescript-sdk/website-summarization-agent.mdx
@@ -58,7 +58,7 @@ If you do not, install it now:
 brew install resonatehq/tap/resonate
 ```
 
-This tutorial was written and tested with Resonate Server v0.7.13 and Resonate TypeScript SDK v0.6.3.
+This tutorial was written and tested with Resonate Server v0.7.13 and Resonate TypeScript SDK v0.10.0.
 
 Part 5 of this tutorial assumes you have [Ollama](https://ollama.com/) installed and model "llama3.1" running locally on your machine.
 
@@ -100,12 +100,12 @@ import type { Context } from "@resonatehq/sdk";
 
 const resonate = new Resonate();
 
-async function baz(_: Context, greetee: string): string {
+async function baz(_: Context, greetee: string): Promise<string> {
   console.log("running baz");
   return `Hello ${greetee} from baz!`;
 }
 
-async function bar(_: Context, greetee: string): string {
+async function bar(_: Context, greetee: string): Promise<string> {
   console.log("running bar");
   return `Hello ${greetee} from bar!`;
 }
@@ -180,12 +180,12 @@ import type { Context } from "@resonatehq/sdk";
 
 const resonate = new Resonate();
 
-async function download(_: Context, url: string): string {
+async function download(_: Context, url: string): Promise<string> {
   console.log("running download");
   return `content of ${url}`;
 }
 
-async function summarize(_: Context, content: string): string {
+async function summarize(_: Context, content: string): Promise<string> {
   console.log("running summarize");
   return `summary of ${content}`;
 }
@@ -224,7 +224,7 @@ Next, lets explore Resonate's automatic retries by adding some code to steps `do
 
 Use `Math.random()` to generate the random numbers.
 Here we are intentionally making the functions non-deterministic to simulate transient failures.
-If you wanted deterministic number generation then you would use `ctx.Math.random()` instead.
+If you wanted deterministic number generation then you would use `ctx.math.random()` instead.
 
 ```ts title="worker.ts"
 import { Context, Resonate } from "@resonatehq/sdk";
@@ -461,7 +461,7 @@ In the config, specify the same Resonate Server URL and a group name (e.g. "clie
 import { Resonate } from "@resonatehq/sdk";
 
 const config = {
-  url: "https://localhost:8001", // url of the Resonate Server
+  url: "http://localhost:8001", // url of the Resonate Server
   group: "client", // group this process belongs to
 };
 const resonate = new Resonate(config);
@@ -561,7 +561,7 @@ bun run worker.ts
 ```
 
 ```shell
-bun run invoke.ts
+bun run client.ts
 ```
 
 The client will block while the workflow waits for the approval promise to be resolved.
@@ -726,10 +726,10 @@ async function sendEmail(
   console.log(`Sending email to ${email}`);
   console.log(`SUMMARY:\n${summary}`);
   console.log(
-    `APPROVAL LINK: http://localhost:5000/confirm?promiseId=${promiseId}&confirm=true`
+    `APPROVAL LINK: http://localhost:3000/confirm?promiseId=${promiseId}&confirm=true`
   );
   console.log(
-    `REJECTION LINK: http://localhost:5000/confirm?promiseId=${promiseId}&confirm=false`
+    `REJECTION LINK: http://localhost:3000/confirm?promiseId=${promiseId}&confirm=false`
   );
 }
 
@@ -765,7 +765,7 @@ Now run the full application.
 Send a request to kick off the workflow:
 
 ```shell
-curl -X POST http://localhost:5000/summarize \
+curl -X POST http://localhost:3000/summarize \
   -H "Content-Type: application/json" \
   -d '{"url": "https://resonatehq.io", "email": "someone@example.com"}'
 ```
@@ -775,7 +775,7 @@ Watch the worker logs to see each step execute and the "email preview" output.
 Open the `Approve` link printed in the logs (or use curl) to confirm the summary:
 
 ```shell
-curl "http://localhost:3000/confirm?promise_id=<approval-id>&confirm=true"
+curl "http://localhost:3000/confirm?promiseId=<approval-id>&confirm=true"
 ```
 
 Once confirmed, the workflow completes and the promise resolves.


### PR DESCRIPTION
## Summary
- Fixes critical issues: wrong package imports (`@resonatehq/server` → `@resonatehq/sdk`), missing `yield*`, wrong auth config
- Fixes high issues: non-existent `resonate.start()`, `Resonate.remote()`, stale version pins, wrong API names
- Fixes medium issues: inconsistent method names (`ctx.rfc` → `ctx.rpc`), duplicate sections, port mismatches, wrong context API names in summary table

## Changes across files
- **4 critical fixes** across 4 files (D1, D2, D3, D5)
- **7 high fixes** across 4 files (D6, D7, D8, D9, D10, D11, D12)
- **7 medium fixes** across 4 files (D13, D14, D15, D16, D17, D18, D19)

D4 was retracted (skipped) per instructions — `logLevel` is valid.

## Files changed
- `docs/get-started/examples/durable-serverless-lambda-workers.mdx`
- `docs/get-started/examples/durable-serverless-cloud-run-workers.mdx`
- `docs/get-started/examples/durable-sleep.mdx`
- `docs/debug/troubleshooting.mdx`
- `docs/deploy/tracing.mdx`
- `docs/deploy/deployment-patterns.mdx`
- `docs/develop/typescript.mdx`
- `docs/develop/constraints.mdx`
- `docs/learn/typescript-sdk/website-summarization-agent.mdx`
- `docs/learn/deployments/digital-ocean-droplet.mdx`

## Context
Part of the Resonate v0.10.0 alignment sweep. Full findings log at `docs/board/iteration/iteration-06.md`.

## Test plan
- [x] `yarn build` passes
- [x] All code examples use `yield*` (not bare `yield`) for context methods
- [x] No references to `@resonatehq/server` (doesn't exist)
- [x] No references to `resonate.start()` (doesn't exist)
- [x] No `Resonate.remote()` or `Resonate.local()` (use `new Resonate()`)
- [x] Auth uses `token` option (not `auth: { basic: ... }`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)