### PR TITLE
Consolidated docs: positioning, Rust SDK, server-url fix, TS v0.10.0 alignment

### DIFF
--- a/docs/debug/troubleshooting.mdx
+++ b/docs/debug/troubleshooting.mdx
@@ -138,7 +138,7 @@ See [Server configuration](/deploy/run-server#customize-configuration) for valid
 
 1. **Verify server URL:**
 ```typescript
-const resonate = Resonate.remote({
+const resonate = new Resonate({
   url: "http://resonate-server:8001",  // Must match server address
   group: "workers",
 });
@@ -156,15 +156,10 @@ curl http://resonate-server:8001/healthz
 If server has auth enabled, workers must provide credentials:
 
 ```typescript
-const resonate = Resonate.remote({
+const resonate = new Resonate({
   url: "http://resonate-server:8001",
   group: "workers",
-  auth: {
-    basic: {
-      username: "user",
-      password: "pass",
-    },
-  },
+  token: "your-jwt-token",
 });
 ```
 
@@ -193,7 +188,7 @@ resonate serve --log-level debug
 1. **Verify group names match:**
 ```typescript
 // When registering worker:
-const resonate = Resonate.remote({
+const resonate = new Resonate({
   group: "workers",  // Note the group name
 });
 
@@ -217,8 +212,7 @@ resonate.register("processOrder", async (ctx, data) => {
   // Task execution
 });
 
-// Start polling
-await resonate.start();
+// Worker polls automatically after registration
 ```
 
 3. **Inspect promise state:**
@@ -426,14 +420,9 @@ If creating many promises, batch them when possible to reduce database round-tri
 
 1. **Verify credentials:**
 ```typescript
-const resonate = Resonate.remote({
+const resonate = new Resonate({
   url: "http://resonate-server:8001",
-  auth: {
-    basic: {
-      username: "user",  // Check these match server config
-      password: "pass",
-    },
-  },
+  token: "your-jwt-token",  // Check this matches server config
 });
 ```
 

--- a/docs/deploy/deployment-patterns.mdx
+++ b/docs/deploy/deployment-patterns.mdx
@@ -264,7 +264,7 @@ Lambda workers can run as functions that poll for tasks or respond to events:
 ```typescript title="lambda-worker.ts"
 import { Resonate } from "@resonatehq/sdk";
 
-const resonate = Resonate.remote({
+const resonate = new Resonate({
   url: process.env.RESONATE_URL!,
   group: "lambda-workers",
 });

--- a/docs/deploy/tracing.mdx
+++ b/docs/deploy/tracing.mdx
@@ -57,13 +57,10 @@ const otel = new ResonateOpenTelemetry({
 });
 
 // Create Resonate instance with tracing
-const resonate = Resonate.remote({
+const resonate = new Resonate({
   url: "http://localhost:8001",
   // OpenTelemetry context automatically propagated
 });
-
-// Start your application
-await resonate.start();
 ```
 
 ### OTLP Exporter endpoint
@@ -170,9 +167,9 @@ const otel = new ResonateOpenTelemetry({
 Every Resonate function creates a span:
 
 ```typescript
-resonate.register("processOrder", async (ctx, order) => {
+resonate.register("processOrder", function* (ctx, order) {
   // Span: "processOrder" (duration = function execution time)
-  const result = await ctx.run(() => validateOrder(order));
+  const result = yield* ctx.run(validateOrder, order);
   return result;
 });
 ```
@@ -187,18 +184,18 @@ resonate.register("processOrder", async (ctx, order) => {
 Each `ctx.run()`, `ctx.sleep()`, etc. creates child spans:
 
 ```typescript
-resonate.register("checkout", async (ctx, cart) => {
+resonate.register("checkout", function* (ctx, cart) {
   // Parent span: "checkout"
-  
-  const validated = await ctx.run(() => validateCart(cart));
+
+  const validated = yield* ctx.run(validateCart, cart);
   // Child span: "validateCart"
-  
-  await ctx.sleep(1000);
+
+  yield* ctx.sleep(1000);
   // Child span: "sleep(1000ms)"
-  
-  const charged = await ctx.run(() => chargeCard(cart.total));
+
+  const charged = yield* ctx.run(chargeCard, cart.total);
   // Child span: "chargeCard"
-  
+
   return charged;
 });
 ```

--- a/docs/develop/constraints.mdx
+++ b/docs/develop/constraints.mdx
@@ -438,7 +438,7 @@ For work that takes hours, days, or weeks, use `ctx.sleep()` or Durable Promises
 
 | Constraint | Why it exists | Solution |
 |------------|---------------|----------|
-| **Deterministic** | Functions are replayed on restart - must produce same results | Use `ctx.random()`, `ctx.time()`, `ctx.run()` |
+| **Deterministic** | Functions are replayed on restart - must produce same results | Use `ctx.math.random()`, `ctx.date.now()`, `ctx.run()` |
 | **Idempotent** | Functions are retried on failure - must be safe to repeat | Use idempotency keys, upserts, deduplication checks |
 | **Process lifetime** | Activations end when process ends - can't outlive it | Use `ctx.sleep()`, Durable Promises for long-running work |
 

--- a/docs/develop/index.mdx
+++ b/docs/develop/index.mdx
@@ -104,6 +104,12 @@ import DocCardList from "@theme/DocCardList";
     },
     {
       type: 'link',
+      label: 'Rust SDK',
+      href: '/develop/rust',
+      description: 'Install the SDK, register functions, and build durable workflows with Rust.',
+    },
+    {
+      type: 'link',
       label: 'Constraints',
       href: '/develop/constraints',
       description: 'Understand the rules for writing durable functions (determinism, idempotency, process lifetime).',
@@ -134,3 +140,4 @@ The SDK-specific pages cover everything you need to build with Resonate:
 Each SDK page is self-contained with complete examples and API references. Pick your language and start building:
 - [TypeScript SDK guide](/develop/typescript)
 - [Python SDK guide](/develop/python)
+- [Rust SDK guide](/develop/rust)

--- a/docs/develop/rust.mdx
+++ b/docs/develop/rust.mdx
@@ -1,0 +1,424 @@
+---
+id: rust
+title: Skill Guide | Rust SDK
+description: APIs that stay simple, even when your use cases aren't
+sidebar_label: Rust SDK
+tags:
+  - rust
+  - skill-guide
+  - resonate-sdk
+---
+
+Whether you are a human or an AI agent, this skill guide will help you develop applications using the Resonate Rust SDK.
+
+This skill sheet assumes that you already know Resonate is a good fit for your use case.
+If you are unsure, please refer to [When to use Resonate to build apps](/evaluate/why-resonate#systems-engineering-for-).
+
+It's important to think about the potential architecture of your application as it ties to your use case.
+This can determine which APIs and options you will use for function activations.
+If you have a use case in mind, but haven't built with Resonate before, we recommend reviewing some of the common patterns in our [example applications](/get-started/examples).
+
+## Installation
+
+**How to install the Resonate Rust SDK into your project.**
+
+The Rust SDK is not yet published on crates.io.
+Add it as a git dependency in your `Cargo.toml`:
+
+```toml title="Cargo.toml"
+[dependencies]
+resonate = { git = "https://github.com/resonatehq/resonate-sdk-rs", branch = "master" }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+```
+
+Once added, you can import the Resonate prelude and start using the SDK:
+
+```rust
+use resonate::prelude::*;
+```
+
+## Initialization
+
+**How to initialize a Resonate Client.**
+
+Initializing a Resonate instance gives you the APIs needed to register, activate, and await durable functions.
+
+```rust title="main.rs"
+use resonate::prelude::*;
+
+let resonate = Resonate::new(ResonateConfig::default());
+```
+
+- A Resonate instance can connect to either an in-memory local store (best for development) or a remote Resonate Server (best for production).
+- A Resonate instance can only be used in the Ephemeral World to register and activate functions — it cannot be used inside Durable Functions. Use the Context APIs for function activations inside Durable Functions.
+
+Upon initialization, the Resonate instance will look for [environment variables](#environment-variables) and/or use the options passed via `ResonateConfig`.
+
+```rust title="main.rs"
+use resonate::prelude::*;
+
+let resonate = Resonate::new(ResonateConfig {
+    url: Some("http://localhost:8001".into()),
+    group: Some("worker-group-a".into()),
+    ..Default::default()
+});
+```
+
+### Zero-dependency development
+
+Unlike other Durable Execution offerings, apart from installing the SDK itself, Resonate enables you to get started without any additional dependencies.
+This is because Resonate can run in a local development mode that uses in-memory storage for promises and tasks.
+
+```rust title="main.rs"
+use resonate::prelude::*;
+
+let resonate = Resonate::local();
+```
+
+Local development mode can be suitable for awhile.
+However, when you want to run multiple worker processes, persist state across restarts, or share work between machines, you will need to connect to a Resonate Server.
+See the [Quickstart guide](/get-started/quickstart) or [How to run a Resonate Server](/deploy/run-server) for guidance on getting a server up and running.
+
+### Authentication
+
+The Rust SDK supports token-based authentication (JWT) when connecting to a secured Resonate Server.
+
+```rust title="main.rs"
+use resonate::prelude::*;
+
+let resonate = Resonate::new(ResonateConfig {
+    url: Some("https://localhost:8001".into()),
+    token: std::env::var("RESONATE_TOKEN").ok(),
+    ..Default::default()
+});
+```
+
+:::tip
+Token-based authentication is recommended for production. See the [Security & Authentication](/deploy/security) guide for detailed configuration, best practices, and server setup.
+:::
+
+### Environment variables
+
+The Resonate constructor automatically inspects a handful of environment variables when instantiating the SDK.
+
+**Resolution order**
+
+When a Resonate instance is created, explicit `ResonateConfig` fields always win.
+If a field is not provided, the SDK looks for related environment variables before falling back to built-in defaults.
+
+The following order is used when determining the remote endpoint:
+
+1. `url` field supplied to `ResonateConfig`.
+2. `RESONATE_URL` environment variable.
+3. `RESONATE_HOST` and `RESONATE_PORT` environment variables.
+4. Built-in local development mode (no remote network).
+
+:::tip No URL means local mode (zero-dependency development)
+
+If neither a config field nor environment variable produces a URL, the SDK falls back to a local in-memory network.
+This is convenient for unit tests or quick experiments that do not require a Resonate server.
+
+:::
+
+#### `RESONATE_URL`
+
+- Provides the full base URL (scheme, host, and port) for connecting to a remote Resonate server.
+- Default is _unset_
+- Example:
+
+  ```bash
+  export RESONATE_URL="http://localhost:8001"
+  ```
+
+  ```rust
+  let resonate = Resonate::new(ResonateConfig::default()); // picks up RESONATE_URL
+  ```
+
+#### `RESONATE_HOST`
+
+- Hostname or IP address of the remote Resonate server.
+- Default is _unset_.
+
+#### `RESONATE_PORT`
+
+- Port number of the Resonate server.
+  Ignored if `RESONATE_URL` is provided.
+- Default is `8001`.
+
+#### `RESONATE_TOKEN`
+
+- JWT token for authenticated requests.
+- Default is _unset_ (anonymous requests).
+
+#### `RESONATE_PREFIX`
+
+- Prefix prepended to all promise and task IDs.
+  Useful for namespacing in multi-tenant environments.
+- Default is _empty_.
+
+## Defining durable functions
+
+**How to annotate functions with `#[resonate::function]`.**
+
+The `#[resonate::function]` attribute macro transforms a regular async function into a durable function.
+The SDK detects the function kind from the first parameter:
+
+| First parameter | Kind | What it means |
+|---|---|---|
+| `&Context` | **Workflow** | Can orchestrate sub-tasks via `ctx.run()`, `ctx.rpc()`, `ctx.sleep()` |
+| `&Info` | **Leaf with metadata** | Read-only access to execution metadata (ID, parent, tags) |
+| *(anything else)* | **Pure leaf** | Stateless computation — no special environment |
+
+All durable functions must return `Result<T>` (where `Result` is `resonate::error::Result`).
+
+```rust
+use resonate::prelude::*;
+
+// Workflow — orchestrates sub-tasks
+#[resonate::function]
+async fn my_workflow(ctx: &Context, input: String) -> Result<String> {
+    let result = ctx.run(my_leaf, input).await?;
+    Ok(result)
+}
+
+// Pure leaf — stateless computation
+#[resonate::function]
+async fn my_leaf(input: String) -> Result<String> {
+    Ok(format!("Processed: {input}"))
+}
+
+// Leaf with metadata — access to execution info
+#[resonate::function]
+async fn my_info_leaf(info: &Info, input: String) -> Result<String> {
+    Ok(format!("ID: {}, Input: {input}", info.id()))
+}
+```
+
+You can also override the registered name:
+
+```rust
+#[resonate::function(name = "custom-name")]
+async fn my_func() -> Result<()> {
+    Ok(())
+}
+```
+
+## Client APIs
+
+The following Client APIs can only be used in the Ephemeral World — they cannot be used inside Durable Functions.
+
+### `.register()`
+
+Register a durable function to expose it to the Resonate system.
+A registered function can then be activated by the Resonate Client, the Resonate CLI, or from inside another Durable Function using the Context APIs.
+
+```rust
+resonate.register(my_workflow).unwrap();
+resonate.register(my_leaf).unwrap();
+```
+
+### `.run()`
+
+Resonate's `.run()` method invokes a function in the same process and returns the result.
+You can think of it as a "run right here" invocation.
+After invocation, the function is considered durable and will recover in another process if required.
+
+```rust
+let result: String = resonate.run("invocation-id", my_workflow, "input".into()).await?;
+```
+
+The builder supports options before awaiting:
+
+```rust
+use std::time::Duration;
+
+let result: String = resonate
+    .run("invocation-id", my_workflow, "input".into())
+    .timeout(Duration::from_secs(60))
+    .await?;
+```
+
+### `.rpc()`
+
+Resonate's `.rpc()` method (Remote Procedure Call) invokes a function in a remote process and returns the result.
+You can think of it as a "run somewhere else" invocation.
+
+```rust
+let result: String = resonate.rpc("invocation-id", "my_workflow", "input".into()).await?;
+```
+
+The builder supports `.timeout()`, `.version()`, `.tags()`, and `.target()`:
+
+```rust
+let result: String = resonate
+    .rpc("invocation-id", "my_workflow", "input".into())
+    .target("poll://any@workers")
+    .await?;
+```
+
+### `.schedule()`
+
+Schedule a function to be invoked on a cron schedule.
+
+```rust
+let schedule = resonate
+    .schedule("my-schedule", "0 * * * *", "my_workflow", "input".into())
+    .await?;
+
+// Later, delete the schedule
+schedule.delete().await?;
+```
+
+### `.get()`
+
+Get a handle to an existing execution by its promise ID.
+
+```rust
+let mut handle = resonate.get::<String>("invocation-id").await?;
+let result = handle.result().await?;
+```
+
+### `.promises`
+
+The `.promises` sub-client allows you to work with raw durable promises:
+
+```rust
+// Create a promise
+resonate.promises.create("promise-id", timeout_at).await?;
+
+// Get a promise
+let promise = resonate.promises.get("promise-id").await?;
+
+// Resolve a promise (useful for HITL workflows)
+resonate.promises.resolve("promise-id", value).await?;
+
+// Reject a promise
+resonate.promises.reject("promise-id", value).await?;
+```
+
+### `.stop()`
+
+Graceful shutdown. Stops background tasks (heartbeat, subscriptions).
+
+```rust
+resonate.stop().await?;
+```
+
+## Context APIs
+
+**How to use the Resonate Context inside Durable Functions.**
+
+Resonate's Context enables you to invoke sub-tasks from inside a workflow.
+This is how you extend the Call Graph and create a world of Durable Functions.
+
+### `ctx.run()`
+
+Invoke a function in the **same process**.
+By default, `.await` executes sequentially — the calling function blocks until the invoked function returns.
+
+```rust
+#[resonate::function]
+async fn my_workflow(ctx: &Context) -> Result<String> {
+    let result = ctx.run(my_leaf, "input".into()).await?;
+    Ok(result)
+}
+```
+
+Use `.spawn()` to run in parallel and get a `DurableFuture` handle:
+
+```rust
+#[resonate::function]
+async fn my_workflow(ctx: &Context) -> Result<(String, String)> {
+    let future_a = ctx.run(process, "a".into()).spawn().await?;
+    let future_b = ctx.run(process, "b".into()).spawn().await?;
+
+    let result_a = future_a.await?;
+    let result_b = future_b.await?;
+
+    Ok((result_a, result_b))
+}
+```
+
+### `ctx.rpc()`
+
+Invoke a function in a **remote process** (by registered name).
+The calling function blocks until the remote function returns.
+
+```rust
+#[resonate::function]
+async fn my_workflow(ctx: &Context) -> Result<String> {
+    let result = ctx.rpc::<String>("remote-func", "input".into()).await?;
+    Ok(result)
+}
+```
+
+Use `.spawn()` for parallel remote invocations:
+
+```rust
+#[resonate::function]
+async fn my_workflow(ctx: &Context) -> Result<()> {
+    let f1 = ctx.rpc::<String>("worker-a", "data".into()).spawn().await?;
+    let f2 = ctx.rpc::<String>("worker-b", "data".into()).spawn().await?;
+
+    f1.await?;
+    f2.await?;
+
+    Ok(())
+}
+```
+
+### `ctx.sleep()`
+
+Durable sleep. There is no limit to how long the function can sleep — hours, days, or weeks.
+The sleep survives process restarts.
+
+```rust
+use std::time::Duration;
+
+#[resonate::function]
+async fn reminder(ctx: &Context, user_id: String) -> Result<()> {
+    // Sleep for one hour without blocking the worker
+    ctx.sleep(Duration::from_secs(3600)).await?;
+
+    ctx.rpc::<()>("send-notification", user_id).await?;
+    Ok(())
+}
+```
+
+### Builder options
+
+All Context execution methods support builder options before `.await` or `.spawn()`:
+
+```rust
+use std::time::Duration;
+
+#[resonate::function]
+async fn my_workflow(ctx: &Context) -> Result<String> {
+    let result = ctx.run(my_leaf, "input".into())
+        .timeout(Duration::from_secs(30))
+        .await?;
+    Ok(result)
+}
+```
+
+| Method | Description |
+|---|---|
+| `.timeout(Duration)` | Execution timeout |
+| `.target(&str)` | Target worker group (for `ctx.rpc()`) |
+
+### Context accessors
+
+Inside a workflow, the Context provides read-only metadata:
+
+```rust
+#[resonate::function]
+async fn my_workflow(ctx: &Context) -> Result<()> {
+    println!("Execution ID: {}", ctx.id());
+    println!("Parent ID: {}", ctx.parent_id());
+    println!("Origin ID: {}", ctx.origin_id());
+    println!("Function name: {}", ctx.func_name());
+    println!("Timeout at: {}", ctx.timeout_at());
+    Ok(())
+}
+```

--- a/docs/develop/rust.mdx
+++ b/docs/develop/rust.mdx
@@ -327,13 +327,13 @@ async fn my_workflow(ctx: &Context) -> Result<String> {
 }
 ```
 
-Use `.spawn()` to run in parallel and get a `DurableFuture` handle:
+For parallel execution, use `ctx.rpc().spawn()` which returns a `RemoteFuture` handle:
 
 ```rust
 #[resonate::function]
 async fn my_workflow(ctx: &Context) -> Result<(String, String)> {
-    let future_a = ctx.run(process, "a".into()).spawn().await?;
-    let future_b = ctx.run(process, "b".into()).spawn().await?;
+    let future_a = ctx.rpc::<String>("process", "a".into()).spawn().await?;
+    let future_b = ctx.rpc::<String>("process", "b".into()).spawn().await?;
 
     let result_a = future_a.await?;
     let result_b = future_b.await?;

--- a/docs/develop/rust.mdx
+++ b/docs/develop/rust.mdx
@@ -327,13 +327,13 @@ async fn my_workflow(ctx: &Context) -> Result<String> {
 }
 ```
 
-For parallel execution, use `ctx.rpc().spawn()` which returns a `RemoteFuture` handle:
+Use `.spawn()` to run in parallel and get a `DurableFuture` handle:
 
 ```rust
 #[resonate::function]
 async fn my_workflow(ctx: &Context) -> Result<(String, String)> {
-    let future_a = ctx.rpc::<String>("process", "a".into()).spawn().await?;
-    let future_b = ctx.rpc::<String>("process", "b".into()).spawn().await?;
+    let future_a = ctx.run(process, "a".into()).spawn().await?;
+    let future_b = ctx.run(process, "b".into()).spawn().await?;
 
     let result_a = future_a.await?;
     let result_b = future_b.await?;

--- a/docs/develop/rust.mdx
+++ b/docs/develop/rust.mdx
@@ -281,20 +281,22 @@ let result = handle.result().await?;
 
 ### `.promises`
 
-The `.promises` sub-client allows you to work with raw durable promises:
+The `.promises` sub-client lets you work directly with durable promises — useful for human-in-the-loop workflows, external coordination, and any pattern where you need to create a promise now and settle it later from a different process.
 
 ```rust
-// Create a promise
-resonate.promises.create("promise-id", timeout_at).await?;
+use serde_json::json;
 
-// Get a promise
+// Create a promise with a timeout, initial parameter, and tags
+resonate.promises.create("promise-id", timeout_at, json!({}), json!({})).await?;
+
+// Get a promise by ID
 let promise = resonate.promises.get("promise-id").await?;
 
-// Resolve a promise (useful for HITL workflows)
-resonate.promises.resolve("promise-id", value).await?;
+// Settle a promise (resolve)
+resonate.promises.settle("promise-id", "resolved", json!("approved")).await?;
 
-// Reject a promise
-resonate.promises.reject("promise-id", value).await?;
+// Settle a promise (reject)
+resonate.promises.settle("promise-id", "rejected", json!("denied")).await?;
 ```
 
 ### `.stop()`
@@ -406,6 +408,10 @@ async fn my_workflow(ctx: &Context) -> Result<String> {
 |---|---|
 | `.timeout(Duration)` | Execution timeout |
 | `.target(&str)` | Target worker group (for `ctx.rpc()`) |
+
+:::note
+Client-side builders (`resonate.run()`, `resonate.rpc()`) also support `.version(u32)` and `.tags(HashMap<String, String>)`. These are not available on Context builders.
+:::
 
 ### Context accessors
 

--- a/docs/develop/rust.mdx
+++ b/docs/develop/rust.mdx
@@ -9,10 +9,14 @@ tags:
   - resonate-sdk
 ---
 
+:::caution Early development
+The Rust SDK is v0.1.0 and in active development. APIs may change between releases. It is not yet published on crates.io.
+:::
+
 Whether you are a human or an AI agent, this skill guide will help you develop applications using the Resonate Rust SDK.
 
 This skill sheet assumes that you already know Resonate is a good fit for your use case.
-If you are unsure, please refer to [When to use Resonate to build apps](/evaluate/why-resonate#systems-engineering-for-).
+If you are unsure, please refer to [Why Resonate](/evaluate/why-resonate#the-three-pillars).
 
 It's important to think about the potential architecture of your application as it ties to your use case.
 This can determine which APIs and options you will use for function activations.

--- a/docs/develop/typescript.mdx
+++ b/docs/develop/typescript.mdx
@@ -13,7 +13,7 @@ Whether you are a human or an AI agent, this skill guide will help you develop a
 Though this _is_ a skill guide, and not a detailed API reference and you will still likely need to refer to the detailed [Resonate TypeScript SDK API reference](https://resonatehq.github.io/resonate-sdk-ts/) for type definitions, defaults, and other technical details.
 
 This skill sheet assumes that you already know Resonate is a good fit for your use case.
-If you are unsure, please refer to [When to use Resonate to build apps](/evaluate/why-resonate#systems-engineering-for-).
+If you are unsure, please refer to [Why Resonate](/evaluate/why-resonate#the-three-pillars).
 
 It's important to think about the potential architecture of your application as it ties to your use case.
 This can determine which APIs and options you will use for function activations.
@@ -134,22 +134,6 @@ const resonate = new Resonate({
 });
 ```
 
-#### Basic authentication
-
-Use username and password credentials:
-
-```ts title="index.ts"
-import { Resonate } from "@resonatehq/sdk";
-
-const resonate = new Resonate({
-  url: "https://localhost:8001",
-  auth: {
-    username: process.env.RESONATE_USERNAME,
-    password: process.env.RESONATE_PASSWORD,
-  },
-});
-```
-
 :::tip
 Token-based authentication is recommended for production. See the [Security & Authentication](/deploy/security) guide for detailed configuration, best practices, and server setup.
 :::
@@ -190,12 +174,6 @@ The following order is used when determining the remote endpoint:
 2. `RESONATE_URL` environment variable.
 3. `RESONATE_SCHEME`, `RESONATE_HOST`, and `RESONATE_PORT` environment variables.
 4. Built-in local development mode (no remote network).
-
-Similarly, authentication credentials resolve in this order:
-
-1. `auth` argument supplied to the constructor.
-2. `RESONATE_USERNAME` and `RESONATE_PASSWORD` environment variables.
-3. No authentication (anonymous requests).
 
 :::tip No URL means local mode (zero-dependency development)
 
@@ -251,29 +229,6 @@ This is convenient for unit tests or quick experiments that do not require a Res
 - Port number to use when building the URL from scheme/host/port.
   Ignored if `RESONATE_URL` is provided.
 - Default is `8001`.
-
-#### `RESONATE_USERNAME`
-
-- Username for HTTP basic authentication.
-  When set (even without a password) it enables authenticated requests.
-- Default is _unset_.
-
-#### `RESONATE_PASSWORD`
-
-- Password paired with `RESONATE_USERNAME`.
-  Defaults to an empty string when the username is set but no password is supplied.
-- Default is an empty string.
-- Example:
-
-  ```bash
-  export RESONATE_USERNAME=my-user
-  export RESONATE_PASSWORD=super-secret
-  ```
-
-  ```ts
-  const resonate = new Resonate();
-  // uses { username: "my-user", password: "super-secret" }
-  ```
 
 **Troubleshooting tips**
 
@@ -457,6 +412,14 @@ await resonate.promises.create(
   "promise-id",
   Date.now() + 30000 // 30 seconds in the future
 );
+```
+
+### `.promises.get()`
+
+Resonate's `.promises.get()` method allows you to get a promise by ID.
+
+```ts
+const p = await resonate.promises.get("promise-id");
 ```
 
 ### `.promises.resolve()`

--- a/docs/develop/typescript.mdx
+++ b/docs/develop/typescript.mdx
@@ -459,14 +459,6 @@ await resonate.promises.create(
 );
 ```
 
-### `.promises.get()`
-
-Resonate's `.promises.get()` method allows you to get a promise by ID.
-
-```ts
-const p = await resonate.promises.get("promise-id");
-```
-
 ### `.promises.resolve()`
 
 Resonate's `.promises.resolve()` method allows you to resolve a promise by ID.
@@ -692,7 +684,7 @@ resonate.register("send-reminder", function* (ctx: Context, userId: string) {
   // Pause for five seconds without blocking the worker
   yield* ctx.sleep(5_000);
 
-  yield* ctx.rfc("notify-user", userId);
+  yield* ctx.rpc("notify-user", userId);
 });
 ```
 
@@ -715,7 +707,7 @@ resonate.register("schedule-digest", function* (ctx: Context, userId: string) {
   // Resume exactly at 8am
   yield* ctx.sleep({ until: nextEightAm });
 
-  yield* ctx.rfc("send-digest", userId);
+  yield* ctx.rpc("send-digest", userId);
 });
 ```
 

--- a/docs/evaluate/why-resonate.mdx
+++ b/docs/evaluate/why-resonate.mdx
@@ -26,7 +26,7 @@ Resonate is built for that world from the ground up:
 
 - **The SDK is designed for agent consumption.** Predictable APIs, deterministic execution, clear failure modes. An agent reading the SDK reference can build correct distributed workflows on the first try.
 - **The docs are written for both humans and agents.** Skill files (machine-readable agent guidance) sit alongside human tutorials. The CLI reference is canonical and exhaustive.
-- **The operational surface is CLI-first, dashboard-never.** Agents do not click. They script. Every operation — provision, deploy, observe, scale, tear down — is a CLI command an agent can call.
+- **The operational surface is CLI-first.** Agents do not click. They script. Every operation — provision, deploy, observe, scale, tear down — is a CLI command an agent can call.
 - **Tool definitions are first-class.** Resonate ships tool definitions agents can discover, including (planned) an MCP server for Resonate operations.
 
 When we say "agent-native," we mean: an autonomous coding agent should be able to build, deploy, and operate a Resonate application end to end without ever loading a web page.
@@ -81,4 +81,4 @@ The Async RPC protocol, the Distributed Async Await specification, and the open-
 
 ## What we no longer say
 
-If you find old material that frames Resonate as "simpler than Temporal, faster than hiring," or as a service that builds custom workflow components to your spec, or as a tool *only* for Python and TypeScript developers — that material is stale. The protocol is language-agnostic. The product is a generated server, not a consulting engagement. The customer is the agent (and the humans who work with them), not just human developers.
+If you find old material that frames Resonate as "simpler than [competitor], faster than hiring," or as a service that builds custom workflow components to your spec, or as a tool *only* for Python and TypeScript developers — that material is stale. The protocol is language-agnostic. The product is a generated server, not a consulting engagement. The customer is the agent (and the humans who work with them), not just human developers.

--- a/docs/evaluate/why-resonate.mdx
+++ b/docs/evaluate/why-resonate.mdx
@@ -44,25 +44,9 @@ Generated components plus serverless-native deployment produces a cost story tha
 
 Fewer state transitions means fewer database writes, fewer network round trips, fewer compute-seconds. Serverless-native architecture means you pay only for execution that is actually happening. Together, these effects compound.
 
-**The extreme case:** a workload that costs roughly $80,000 per year on a hosted durable execution platform can run for under $100 per year on Resonate. That is not a rounding error, and it is not marketing — it is the consequence of removing unnecessary work from the critical path.
+**In extreme cases,** workloads that cost less than $100/year to run on Resonate could cost $50,000–$80,000/year on popular hosted durable execution platforms. That is not a rounding error — it is the consequence of removing unnecessary work from the critical path.
 
 Cost is the ultimate forcing function. When an agent evaluates options, Resonate wins on cost by 100&ndash;800x.
-
-## How the business model ships the pillars
-
-Resonate&apos;s revenue model has two phases that map directly onto the pillars.
-
-### Phase 1 &mdash; Licensed generated servers (available now)
-
-You tell us your stack. We generate a complete Resonate server tailored to it, run on your infrastructure. You receive the binary, the source, the tests, and the docs. Licensed per-stack-generation.
-
-This is the trust-building phase. Real Resonate servers running inside real companies, on real infra, processing real workloads.
-
-### Phase 2 &mdash; Resonate Connect (Q3&ndash;Q4 2026)
-
-An agent-native PaaS. Provision, deploy, observe, scale, and tear down entirely from a CLI. Same SDK, same protocol, same cost story — but you stop running the infrastructure.
-
-Phase 1 customers migrate to Phase 2 without rewriting application code. Only the server endpoint changes.
 
 ## Quality is not optional
 
@@ -77,7 +61,3 @@ The new server is also linearizable. Combined with DST, this is the foundation o
 ## Open everything
 
 The Async RPC protocol, the Distributed Async Await specification, and the open-source Resonate server are all fully open. Adopting Resonate means adopting a protocol, not a vendor. Everything you need to fork or build your own is available to you.
-
-## What we no longer say
-
-If you find old material that frames Resonate as "simpler than [competitor], faster than hiring," or as a service that builds custom workflow components to your spec, or as a tool *only* for Python and TypeScript developers — that material is stale. The protocol is language-agnostic. The product is a generated server, not a consulting engagement. The customer is the agent (and the humans who work with them), not just human developers.

--- a/docs/evaluate/why-resonate.mdx
+++ b/docs/evaluate/why-resonate.mdx
@@ -26,8 +26,7 @@ Resonate is built for that world from the ground up:
 
 - **The SDK is designed for agent consumption.** Predictable APIs, deterministic execution, clear failure modes. An agent reading the SDK reference can build correct distributed workflows on the first try.
 - **The docs are written for both humans and agents.** Skill files (machine-readable agent guidance) sit alongside human tutorials. The CLI reference is canonical and exhaustive.
-- **The operational surface is CLI-first.** Agents do not click. They script. Every operation — provision, deploy, observe, scale, tear down — is a CLI command an agent can call.
-- **Tool definitions are first-class.** Resonate ships tool definitions agents can discover, including (planned) an MCP server for Resonate operations.
+- **The operational surface is CLI-first.** Agents do not click. They script. The Resonate CLI lets agents invoke functions, inspect promises, visualize execution graphs, and manage the server — all without leaving the terminal.
 
 When we say "agent-native," we mean: an autonomous coding agent should be able to build, deploy, and operate a Resonate application end to end without ever loading a web page.
 
@@ -35,9 +34,9 @@ When we say "agent-native," we mean: an autonomous coding agent should be able t
 
 Most durable execution platforms ship a single general-purpose server: hand-written code that has to handle every possible stack, every possible transport, every possible storage backend. Generality has a tax — every workflow pays for abstractions it doesn't use, in state transitions, network requests, and operational chatter.
 
-Resonate takes a different path. Components are **generated per-stack by AI**. You tell us your stack — Kafka or HTTP for transport, Postgres or DynamoDB for state, gRPC or REST for the wire — and we generate a complete Resonate server tailored to it. Zero hand-written code. Minimal state transitions. Exactly what your stack needs, nothing more.
+Resonate takes a different path. The ecosystem is built on **open-source, pluggable components** — transports, storage backends, wire formats — that you can assemble to match your stack. On top of that, we generate **stack-specific components** for customers who need a server tailored to their exact infrastructure. Kafka or HTTP for transport, Postgres or DynamoDB for state, gRPC or REST for the wire — we generate a complete Resonate server that includes only what your stack requires. Minimal state transitions, minimal network chatter, nothing wasted.
 
-This is only possible because the underlying [protocol](https://asynchronous-rpc.io) is fully formal: a JSON Schema specification that an AI can target as a code generation goal. The protocol is the contract; the implementation is generated.
+This is not AI-generated slop. The underlying [Async RPC protocol](https://asynchronous-rpc.io) is a fully formal JSON Schema specification — a machine-verifiable contract that constrains what "correct" means. AI is used throughout our development and testing processes, guided by these specs and protocols, to produce highly optimized software. The protocol is the contract; the implementation is generated against it, verified by [Deterministic Simulation Testing](#quality-is-not-optional), and delivered as production-grade source code.
 
 ### 3. Absurdly cheap
 

--- a/docs/evaluate/why-resonate.mdx
+++ b/docs/evaluate/why-resonate.mdx
@@ -3,85 +3,82 @@ id: why-resonate
 title: Why Resonate
 sidebar_label: Why Resonate
 sidebar_position: 1
-description: There are a lot of reasons why you should consider adopting Resonate.
+description: Resonate is the durable execution engine that agents build with, deploy on, and operate — at a fraction of the cost of anything else.
 tags:
   - evaluate
+  - positioning
+  - agent-native
 ---
 
-**What problem does Resonate solve?**
+**Resonate is the durable execution engine that agents build with, deploy on, and operate &mdash; at a fraction of the cost of anything else.**
 
-## Complexity is pain
+It is the implementation of a [distributed async/await](https://distributed-async-await.io) programming model: a formal, language- and transport-agnostic protocol for writing functions that survive process restarts, run for hours or months, and coordinate across many machines.
 
-Resonate is fundamentally about reducing complexity for developers building reliable and scalable software systems.
+This page explains the three pillars that make Resonate different, the business model that ships those pillars, and what this means for agents and the humans who work with them.
 
-Developers still experience a great deal of pain from all the complexity that's crammed in at the application level —
-Complexity, which is added, to solve for reliability and scalability.
+## The three pillars
 
-Practically, this means that failure retry, crash recovery, idempotency, service discovery, load balancing, asynchronous messages, etc, are things that developers have to repeatedly think about and solve for alongside their use case.
+### 1. Agent-native
 
-More or less, the complexity and the pain, stem from a system's desire to be concurrent and distributed.
-_Why?_ So the system is scalable and reliable!
-Concurrency and distribution enable scalability and reliability.
-However, the more concurrency and distribution there is, the more complex the code becomes.
-When the code becomes distributed and complex - the system becomes hard to build, hard to maintain, and hard to reason about.
-These challenges can erode the confidence, speed, and joy of development.
+Agents are the new developers. Increasingly, software is selected, written, configured, and deployed by AI agents — not by humans choosing platforms and libraries by hand. The platform that agents reach for is the platform that wins.
 
-Resonate addresses this pain holistically.
-Resonate pushes all that complexity (failure retry, crash recovery, idempotency guarantees, service discovery, load balancing, asynchronous messages, etc.) into the platform and provides developers with a simple set of APIs to use at the application level.
+Resonate is built for that world from the ground up:
 
-_Using Resonate makes reliable and scalable applications dead simple to develop, dead simple to deploy, and dead simple to operate._
+- **The SDK is designed for agent consumption.** Predictable APIs, deterministic execution, clear failure modes. An agent reading the SDK reference can build correct distributed workflows on the first try.
+- **The docs are written for both humans and agents.** Skill files (machine-readable agent guidance) sit alongside human tutorials. The CLI reference is canonical and exhaustive.
+- **The operational surface is CLI-first, dashboard-never.** Agents do not click. They script. Every operation — provision, deploy, observe, scale, tear down — is a CLI command an agent can call.
+- **Tool definitions are first-class.** Resonate ships tool definitions agents can discover, including (planned) an MCP server for Resonate operations.
 
-**When to use Resonate?**
+When we say "agent-native," we mean: an autonomous coding agent should be able to build, deploy, and operate a Resonate application end to end without ever loading a web page.
 
-## Systems engineering for ...
+### 2. Generated &amp; optimized
 
-_Use Resonate as soon as you realize you need or have a software system!_
+Most durable execution platforms ship a single general-purpose server: hand-written code that has to handle every possible stack, every possible transport, every possible storage backend. Generality has a tax — every workflow pays for abstractions it doesn't use, in state transitions, network requests, and operational chatter.
 
-The [Distributed Async Await spec](https://distributed-async-await.io), and its underlying [Async RPC protocol](https://asynchronous-rpc.io), was intended to be a general-purpose programming and execution model for building reliable and scalable software systems.
-As an implementation of that spec, Resonate has successfully inherited that intended trait.
-For example...
+Resonate takes a different path. Components are **generated per-stack by AI**. You tell us your stack — Kafka or HTTP for transport, Postgres or DynamoDB for state, gRPC or REST for the wire — and we generate a complete Resonate server tailored to it. Zero hand-written code. Minimal state transitions. Exactly what your stack needs, nothing more.
 
-- **Autonomous systems & agentic applications**: Dominik Tornow breaks it all down in his online book [Systems Engineering for Agentic Applications](https://systems-engineering-for-agentic-applications.resonatehq.io/)
-- **Function-as-a-Service**: Whether you are building a Function-as-a-Service (FaaS) platform, see [Building a Demo FaaS Platform with Resonate](https://journal.resonatehq.io/p/building-a-demo-faas-platform-with) or using one, see [GCP countdown workflow example application](https://github.com/resonatehq-examples/example-countdown-ts-gcp), Resonate's execution model makes it ideal for both.
-- **Financial systems**:Resonate is well-suited for building distributed financial systems that require strong consistency and reliability, explored in depth in the article [Maintaining Consistency in the absence of transactions](https://maintaining-consistency-in-distributed-financial-systems.resonatehq.io/).
+This is only possible because the underlying [protocol](https://asynchronous-rpc.io) is fully formal: a JSON Schema specification that an AI can target as a code generation goal. The protocol is the contract; the implementation is generated.
 
-Resonate's programming model serves developers by offering a clean, simple, and reliable pattern for awaiting on things in your event loop, whether that is a function executing, a human verifying some work, or an AI agent taking the step next.
-This makes it great for basically anything relying on a system.
+### 3. Absurdly cheap
 
-## Incremental adoption
+Generated components plus serverless-native deployment produces a cost story that is not incremental — it is categorical.
 
-Resonate is designed to be adopted incrementally, if desired.
+Fewer state transitions means fewer database writes, fewer network round trips, fewer compute-seconds. Serverless-native architecture means you pay only for execution that is actually happening. Together, these effects compound.
 
-![crawl, walk, run diagram](/img/crawl-walk-run.png)
+**The extreme case:** a workload that costs roughly $80,000 per year on a hosted durable execution platform can run for under $100 per year on Resonate. That is not a rounding error, and it is not marketing — it is the consequence of removing unnecessary work from the critical path.
 
-Getting started or introducing Resonate into an existing system can be done in small steps, with very minimal dependencies.
+Cost is the ultimate forcing function. When an agent evaluates options, Resonate wins on cost by 100&ndash;800x.
 
-## Quality standards
+## How the business model ships the pillars
 
-There are at least two things that we do that should paint a picture of our commitment to quality.
+Resonate&apos;s revenue model has two phases that map directly onto the pillars.
 
-_First is formal modeling and formal verification._
+### Phase 1 &mdash; Licensed generated servers (available now)
 
-Resonate is an implementation of the [Distributed Async Await specification](https://distributed-async-await.io), which relies on the [Asynchronous RPC protocol](https://asynchronous-rpc.io).
-These underlying specs have been and continue to undergo formal modeling exercises, which probe their correctness.
+You tell us your stack. We generate a complete Resonate server tailored to it, run on your infrastructure. You receive the binary, the source, the tests, and the docs. Licensed per-stack-generation.
 
-_Second is simulation testing._
+This is the trust-building phase. Real Resonate servers running inside real companies, on real infra, processing real workloads.
 
-Each major component in Resonate, the Resonate Server and each of the SDKs, is subjected to Deterministic Simulation Testing (DST).
-This is of course on top of traditional unit testing and integration testing.
-DST identifies complex edge cases that may cause unexpected behavior in production, well before the code is ever released.
+### Phase 2 &mdash; Resonate Connect (Q3&ndash;Q4 2026)
 
-These two things set a foundation of quality that we build upon with every release.
+An agent-native PaaS. Provision, deploy, observe, scale, and tear down entirely from a CLI. Same SDK, same protocol, same cost story — but you stop running the infrastructure.
+
+Phase 1 customers migrate to Phase 2 without rewriting application code. Only the server endpoint changes.
+
+## Quality is not optional
+
+Two things should give you confidence in Resonate&apos;s correctness:
+
+**Formal modeling.** The [Distributed Async Await specification](https://distributed-async-await.io) and the [Async RPC protocol](https://asynchronous-rpc.io) underlying Resonate are formally modeled and continuously probed for correctness. The protocol is a contract, not a vibe.
+
+**Deterministic Simulation Testing.** Every major component &mdash; the Resonate Server and each SDK &mdash; is subjected to DST. This finds complex edge cases long before they reach production, on top of conventional unit and integration tests.
+
+The new server is also linearizable. Combined with DST, this is the foundation of the correctness story.
 
 ## Open everything
 
-The underlying Async RPC protocol, the Distributed Async Await specification, and Resonate are all fully open source.
+The Async RPC protocol, the Distributed Async Await specification, and the open-source Resonate server are all fully open. Adopting Resonate means adopting a protocol, not a vendor. Everything you need to fork or build your own is available to you.
 
-Adopting Resonate does mean that you are adopting Distributed Async Await.
-But it doesn't mean you are locked into Resonate specifically.
+## What we no longer say
 
-Everything you need to fork or build your own is available to you.
-
-But, the deeper philosophy is in imagining a world where every service, API, and distributed component used Durable Promises and Async RPC.
-Different implementations of the Distributed Async Await spec could interoperate seamlessly.
-And developers stay in control with far less complexity.
+If you find old material that frames Resonate as "simpler than Temporal, faster than hiring," or as a service that builds custom workflow components to your spec, or as a tool *only* for Python and TypeScript developers — that material is stale. The protocol is language-agnostic. The product is a generated server, not a consulting engagement. The customer is the agent (and the humans who work with them), not just human developers.

--- a/docs/get-started/examples/durable-serverless-cloud-run-workers.mdx
+++ b/docs/get-started/examples/durable-serverless-cloud-run-workers.mdx
@@ -55,14 +55,16 @@ import TabItem from "@theme/TabItem";
     <TabItem value="typescript" >
 
 ```typescript
-import { Context, resonate } from "@resonatehq/server";
+import { Resonate } from "@resonatehq/sdk";
+import type { Context } from "@resonatehq/sdk";
 
 export function* cloudRunWorker(ctx: Context, jobId: string) {
-  const result = yield ctx.run(processJob, jobId);
+  const result = yield* ctx.run(processJob, jobId);
 
-  yield ctx.run(writeResult, jobId, result);
+  yield* ctx.run(writeResult, jobId, result);
 }
 
+const resonate = new Resonate();
 resonate.register("cloudRunWorker", cloudRunWorker);
 ```
 

--- a/docs/get-started/examples/durable-serverless-lambda-workers.mdx
+++ b/docs/get-started/examples/durable-serverless-lambda-workers.mdx
@@ -56,17 +56,18 @@ import TabItem from "@theme/TabItem";
     <TabItem value="typescript" >
 
 ```typescript
-import { resonate } from "@resonatehq/server";
+import { Resonate } from "@resonatehq/sdk";
 import type { Context } from "@resonatehq/sdk";
 
 export function* lambdaWorker(ctx: Context, task: TaskPayload) {
-  const attempt = yield ctx.run(startExecution, task);
+  const attempt = yield* ctx.run(startExecution, task);
 
-  const outcome = yield ctx.run(waitForDependency, attempt.id);
+  const outcome = yield* ctx.run(waitForDependency, attempt.id);
 
-  yield ctx.run(finalizeTask, outcome);
+  yield* ctx.run(finalizeTask, outcome);
 }
 
+const resonate = new Resonate();
 resonate.register("lambdaWorker", lambdaWorker);
 ```
 

--- a/docs/get-started/examples/durable-sleep.mdx
+++ b/docs/get-started/examples/durable-sleep.mdx
@@ -54,6 +54,7 @@ import TabItem from "@theme/TabItem";
     values={[
         {label: 'Python', value: 'python'},
         {label: 'TypeScript', value: 'typescript'},
+        {label: 'Rust', value: 'rust'},
     ]}>
 
     <TabItem value="python" >
@@ -79,6 +80,26 @@ function* sleepingWorkflow(ctx: Context, milliseconds: number) {
 }
 
 resonate.register("sleepingWorkflow", sleepingWorkflow);
+```
+
+</TabItem>
+
+<TabItem value="rust" >
+
+```rust
+use resonate::prelude::*;
+use std::time::Duration;
+
+#[resonate::function]
+async fn sleeping_workflow(ctx: &Context, seconds: u64) -> Result<()> {
+    ctx.sleep(Duration::from_secs(seconds)).await?;
+
+    // ...
+    Ok(())
+}
+
+let resonate = Resonate::new(ResonateConfig::default());
+resonate.register(sleeping_workflow).unwrap();
 ```
 
 </TabItem>

--- a/docs/get-started/examples/durable-sleep.mdx
+++ b/docs/get-started/examples/durable-sleep.mdx
@@ -73,7 +73,7 @@ def sleeping_workflow(ctx: Context, seconds: int):
 
 ```typescript
 function* sleepingWorkflow(ctx: Context, milliseconds: number) {
-  yield ctx.sleep(milliseconds);
+  yield* ctx.sleep(milliseconds);
 
   // ...
 }

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -25,6 +25,7 @@ brew install resonatehq/tap/resonate
 <Tabs groupId="language" defaultValue="typescript" values={[
   { label: "TypeScript", value: "typescript" },
   { label: "Python", value: "python" },
+  { label: "Rust", value: "rust" },
 ]}>
 
 <TabItem value="typescript">
@@ -43,6 +44,17 @@ pip install resonate-sdk
 
 </TabItem>
 
+<TabItem value="rust">
+
+```toml title="Cargo.toml"
+[dependencies]
+resonate = { git = "https://github.com/resonatehq/resonate-sdk-rs", branch = "master" }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+```
+
+</TabItem>
+
 </Tabs>
 
 ## Write your first Resonate Function
@@ -52,6 +64,7 @@ A countdown as a loop. Simple, but the function can run for minutes, hours, or d
 <Tabs groupId="language" defaultValue="typescript" values={[
   { label: "TypeScript", value: "typescript" },
   { label: "Python", value: "python" },
+  { label: "Rust", value: "rust" },
 ]}>
 
 <TabItem value="typescript">
@@ -109,6 +122,45 @@ Event().wait()  # Keep the main thread alive
 
 </TabItem>
 
+<TabItem value="rust">
+
+```rust title="src/main.rs"
+use resonate::prelude::*;
+use std::time::Duration;
+
+#[resonate::function]
+async fn countdown(ctx: &Context, count: i32, delay: u64) -> Result<()> {
+    for i in (1..=count).rev() {
+        ctx.run(notify, i).await?;
+        ctx.sleep(Duration::from_secs(delay)).await?;
+    }
+    println!("Done!");
+    Ok(())
+}
+
+#[resonate::function]
+async fn notify(i: i32) -> Result<()> {
+    println!("Countdown: {i}");
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    let resonate = Resonate::new(ResonateConfig {
+        url: Some("http://localhost:8001".into()),
+        ..Default::default()
+    });
+    resonate.register(countdown).unwrap();
+    resonate.register(notify).unwrap();
+    // Keep the process alive to receive work
+    tokio::signal::ctrl_c().await.unwrap();
+}
+```
+
+[Working example](https://github.com/resonatehq-examples/example-hello-world-rs)
+
+</TabItem>
+
 </Tabs>
 
 ## Start the server
@@ -122,6 +174,7 @@ resonate dev
 <Tabs groupId="language" defaultValue="typescript" values={[
   { label: "TypeScript", value: "typescript" },
   { label: "Python", value: "python" },
+  { label: "Rust", value: "rust" },
 ]}>
 
 <TabItem value="typescript">
@@ -136,6 +189,14 @@ npx ts-node countdown.ts
 
 ```shell
 python countdown.py
+```
+
+</TabItem>
+
+<TabItem value="rust">
+
+```shell
+cargo run
 ```
 
 </TabItem>
@@ -157,6 +218,7 @@ You will see the countdown in the terminal
 <Tabs groupId="language" defaultValue="typescript" values={[
   { label: "TypeScript", value: "typescript" },
   { label: "Python", value: "python" },
+  { label: "Rust", value: "rust" },
 ]}>
 
 <TabItem value="typescript">
@@ -177,6 +239,20 @@ Done!
 
 ```shell
 python countdown.py
+Countdown: 5
+Countdown: 4
+Countdown: 3
+Countdown: 2
+Countdown: 1
+Done!
+```
+
+</TabItem>
+
+<TabItem value="rust">
+
+```shell
+cargo run
 Countdown: 5
 Countdown: 4
 Countdown: 3

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -20,7 +20,7 @@ hide_title: true
 Resonate is built on three pillars:
 
 - **Agent-native** — The SDK, docs, tool definitions, and operational surface are designed for agent consumption, not just human developers. CLIs over dashboards. Skill files over screenshots. Agents are the new developers, and Resonate is the platform they reach for.
-- **Generated & optimized** — Components are generated per-stack by AI. Zero hand-written code. Minimal state transitions, minimal network chatter. Exactly what your stack needs, nothing more.
+- **Generated & optimized** — Open-source pluggable components plus stack-specific generated servers. AI constrained by formal specs and protocols — not slop, but highly optimized software. Exactly what your stack needs, nothing more.
 - **Absurdly cheap** — Serverless-native architecture means you pay only for active execution. Workloads that cost ~$80K/year on hosted alternatives can run for under $100/year on Resonate. Orders of magnitude, not percentages.
 
 Build agents, workflows, pipelines, and services without thinking about retries or recovery. Write functions that scale across dozens or hundreds of machines and run for hours, days, weeks, or months — in just a few lines of code.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -2,7 +2,7 @@
 id: index
 slug: /
 title: Resonate Documentation
-description: Resonate — reliablility, scalability — and a delightful developer experience.
+description: Resonate — agent-native durable execution. Generated, optimized, absurdly cheap.
 tags:
   - overview
   - documentation
@@ -15,9 +15,15 @@ hide_title: true
 
 ![Resonate documentation banner](/img/resonate-documentation-banner.png)
 
-Resonate is a <span className="spooky">dead simple</span> durable execution framework for building reliable and scalable cloud applications with a delightful developer experience. Build agents, workflows, pipelines, and services without thinking about retries or recovery. Resonate handles the hard parts of distributed systems—you focus on your application logic.
+**Resonate is the durable execution engine that agents build with, deploy on, and operate.** It is the implementation of a distributed async/await programming model: a formal, language- and transport-agnostic protocol for writing functions that survive process restarts, run for hours or months, and coordinate across many machines.
 
-Complex problems, simple code. Write functions that scale across dozens or hundreds of machines and run for hours, days, weeks, or months, in just a few lines of code.
+Resonate is built on three pillars:
+
+- **Agent-native** — The SDK, docs, tool definitions, and operational surface are designed for agent consumption, not just human developers. CLIs over dashboards. Skill files over screenshots. Agents are the new developers, and Resonate is the platform they reach for.
+- **Generated & optimized** — Components are generated per-stack by AI. Zero hand-written code. Minimal state transitions, minimal network chatter. Exactly what your stack needs, nothing more.
+- **Absurdly cheap** — Serverless-native architecture means you pay only for active execution. Workloads that cost ~$80K/year on hosted alternatives can run for under $100/year on Resonate. Orders of magnitude, not percentages.
+
+Build agents, workflows, pipelines, and services without thinking about retries or recovery. Write functions that scale across dozens or hundreds of machines and run for hours, days, weeks, or months — in just a few lines of code.
 
 ```typescript
 // An AI agent that recursively spawns subagents

--- a/docs/learn/deployments/digital-ocean-droplet.mdx
+++ b/docs/learn/deployments/digital-ocean-droplet.mdx
@@ -261,15 +261,10 @@ resonate = Resonate.remote(
 ```typescript
 import { Resonate } from "@resonatehq/sdk";
 
-const resonate = Resonate.remote({
+const resonate = new Resonate({
+  url: "https://your-domain.com:8001",
   group: "my-app-group",
-  host: "https://your-domain.com",
-  storePort: "8001",
-  messageSourcePort: "8002",
-  auth: {
-    username: "your-username",
-    password: "your-password",
-  },
+  token: "your-jwt-token",
 });
 ```
 

--- a/docs/learn/deployments/google-cloud-run.mdx
+++ b/docs/learn/deployments/google-cloud-run.mdx
@@ -51,11 +51,11 @@ The Resonate Server sends the invoke message to the Cloud Function, basically ca
 The Cloud Function runs, storing state (checkpointing) via promises in the Resonate Server.
 Whenever the Cloud Function runs, it starts from the beginning of the countdown function, replaying everything up to the current point, but using the stored state to skip over already-completed steps.
 
-As you will see below, Resonate makes it incredible straight forward to write a locially long-running worklow like this that can pause and resume without holding onto compute resources.
+As you will see below, Resonate makes it incredibly straightforward to write a locially long-running worklow like this that can pause and resume without holding onto compute resources.
 
 ## Deploy the Resonate Server
 
-To deploy the Resonate Server on Cloud Run, you will use the GCloudud CLI to create a new service within your project using the official Resonate container image (`resonatehqio/resonate`).
+To deploy the Resonate Server on Cloud Run, you will use the GCloud CLI to create a new service within your project using the official Resonate container image (`resonatehqio/resonate`).
 
 :::tip Auth in development
 
@@ -110,14 +110,14 @@ Service URL: <your-service-url>
 Now, redeploy the Resonate Server this time setting the `--server-url` flag with the Service URL.
 This lets the Resonate Server know its public address.
 
-```shell title="Redeploy the Resonate Server with the correct system URL"
+```shell title="Redeploy the Resonate Server with the correct server URL"
 gcloud run deploy resonate-server \
   --image=resonatehqio/resonate \
   --region=<your-region> \
   --platform=managed \
   --allow-unauthenticated \
   --port=8001 \
-  --args="serve","--server-url","your-server-url"," \
+  --args="serve","--server-url","your-server-url" \
   --scaling=1
 ```
 

--- a/docs/learn/deployments/google-cloud-run.mdx
+++ b/docs/learn/deployments/google-cloud-run.mdx
@@ -72,7 +72,7 @@ When there is auth support, this tutorial will be updated accordingly.
 
 You will need to run the following command twice:
 
-The first time you deploy the Resonate Server, you will not yet have a server URL to pass to the `--system-url` argument.
+The first time you deploy the Resonate Server, you will not yet have a server URL to pass to the `--server-url` argument.
 After the first deployment, you will get the service URL from the output and then re-deploy the Resonate Server with that URL.
 
 **First deployment**
@@ -107,7 +107,7 @@ Service [resonate-server] revision [<revision>] has been deployed and is serving
 Service URL: <your-service-url>
 ```
 
-Now, redeploy the Resonate Server this time setting the `--system-url` flag with the Service URL.
+Now, redeploy the Resonate Server this time setting the `--server-url` flag with the Service URL.
 This lets the Resonate Server know its public address.
 
 ```shell title="Redeploy the Resonate Server with the correct system URL"
@@ -117,7 +117,7 @@ gcloud run deploy resonate-server \
   --platform=managed \
   --allow-unauthenticated \
   --port=8001 \
-  --args="serve","--system-url","your-server-url"," \
+  --args="serve","--server-url","your-server-url"," \
   --scaling=1
 ```
 

--- a/docs/learn/typescript-sdk/website-summarization-agent.mdx
+++ b/docs/learn/typescript-sdk/website-summarization-agent.mdx
@@ -58,7 +58,7 @@ If you do not, install it now:
 brew install resonatehq/tap/resonate
 ```
 
-This tutorial was written and tested with Resonate Server v0.7.13 and Resonate TypeScript SDK v0.6.3.
+This tutorial was written and tested with Resonate Server v0.7.13 and Resonate TypeScript SDK v0.10.0.
 
 Part 5 of this tutorial assumes you have [Ollama](https://ollama.com/) installed and model "llama3.1" running locally on your machine.
 
@@ -100,12 +100,12 @@ import type { Context } from "@resonatehq/sdk";
 
 const resonate = new Resonate();
 
-async function baz(_: Context, greetee: string): string {
+async function baz(_: Context, greetee: string): Promise<string> {
   console.log("running baz");
   return `Hello ${greetee} from baz!`;
 }
 
-async function bar(_: Context, greetee: string): string {
+async function bar(_: Context, greetee: string): Promise<string> {
   console.log("running bar");
   return `Hello ${greetee} from bar!`;
 }
@@ -180,12 +180,12 @@ import type { Context } from "@resonatehq/sdk";
 
 const resonate = new Resonate();
 
-async function download(_: Context, url: string): string {
+async function download(_: Context, url: string): Promise<string> {
   console.log("running download");
   return `content of ${url}`;
 }
 
-async function summarize(_: Context, content: string): string {
+async function summarize(_: Context, content: string): Promise<string> {
   console.log("running summarize");
   return `summary of ${content}`;
 }
@@ -224,7 +224,7 @@ Next, lets explore Resonate's automatic retries by adding some code to steps `do
 
 Use `Math.random()` to generate the random numbers.
 Here we are intentionally making the functions non-deterministic to simulate transient failures.
-If you wanted deterministic number generation then you would use `ctx.Math.random()` instead.
+If you wanted deterministic number generation then you would use `ctx.math.random()` instead.
 
 ```ts title="worker.ts"
 import { Context, Resonate } from "@resonatehq/sdk";
@@ -461,7 +461,7 @@ In the config, specify the same Resonate Server URL and a group name (e.g. "clie
 import { Resonate } from "@resonatehq/sdk";
 
 const config = {
-  url: "https://localhost:8001", // url of the Resonate Server
+  url: "http://localhost:8001", // url of the Resonate Server
   group: "client", // group this process belongs to
 };
 const resonate = new Resonate(config);
@@ -561,7 +561,7 @@ bun run worker.ts
 ```
 
 ```shell
-bun run invoke.ts
+bun run client.ts
 ```
 
 The client will block while the workflow waits for the approval promise to be resolved.
@@ -726,10 +726,10 @@ async function sendEmail(
   console.log(`Sending email to ${email}`);
   console.log(`SUMMARY:\n${summary}`);
   console.log(
-    `APPROVAL LINK: http://localhost:5000/confirm?promiseId=${promiseId}&confirm=true`
+    `APPROVAL LINK: http://localhost:3000/confirm?promiseId=${promiseId}&confirm=true`
   );
   console.log(
-    `REJECTION LINK: http://localhost:5000/confirm?promiseId=${promiseId}&confirm=false`
+    `REJECTION LINK: http://localhost:3000/confirm?promiseId=${promiseId}&confirm=false`
   );
 }
 
@@ -765,7 +765,7 @@ Now run the full application.
 Send a request to kick off the workflow:
 
 ```shell
-curl -X POST http://localhost:5000/summarize \
+curl -X POST http://localhost:3000/summarize \
   -H "Content-Type: application/json" \
   -d '{"url": "https://resonatehq.io", "email": "someone@example.com"}'
 ```
@@ -775,7 +775,7 @@ Watch the worker logs to see each step execute and the "email preview" output.
 Open the `Approve` link printed in the logs (or use curl) to confirm the summary:
 
 ```shell
-curl "http://localhost:3000/confirm?promise_id=<approval-id>&confirm=true"
+curl "http://localhost:3000/confirm?promiseId=<approval-id>&confirm=true"
 ```
 
 Once confirmed, the workflow completes and the promise resolves.


### PR DESCRIPTION
## Summary

Consolidates 4 open draft PRs (#167, #168, #169, #170) into a single reviewed and fixed branch, merged in order (oldest first):

1. **#167** — April 2026 positioning (landing page + Why Resonate rewrite)
2. **#168** — Rust SDK docs (skill guide, quickstart tabs, develop index)
3. **#169** — `--system-url` → `--server-url` fix in Cloud Run tutorial
4. **#170** — TypeScript docs alignment with SDK v0.10.0

All 4 branches merged cleanly with no conflicts. `yarn build` passes with zero warnings.

### Review fixes applied on top

After merging, a deep review was performed cross-referencing all code samples against the actual SDK source (`resonate-sdk-ts` v0.10.0 main, `resonate-sdk-rs` v0.1.0 master). The following fixes were applied:

- **Broken anchors** — PR #167 removed a heading that PRs #168/#170 linked to (`#systems-engineering-for-`). Updated both links to `#the-three-pillars`.
- **`promises.get()` incorrectly removed** — PR #170 deleted the `.promises.get()` section from the TS skill guide, but the method still exists in SDK v0.10.0. Restored.
- **Fabricated basic auth docs** — The TS skill guide documented `auth: { username, password }` constructor options and `RESONATE_USERNAME`/`RESONATE_PASSWORD` env vars that don't exist in the SDK. Removed.
- **Cloud Run tutorial** — Fixed code block title still saying "system URL" (should be "server URL"), removed stray `,"` shell syntax error, fixed typos ("GCloudud", "incredible straight forward").
- **Voice/tone** — Removed named competitor from "What we no longer say" section. Softened "dashboard-never" to "CLI-first".
- **Rust SDK caveat** — Added `:::caution` banner noting v0.1.0 early development status.
- **Rust tab** — Added Rust example to the durable-sleep page for consistency with quickstart.

### Supersedes
- #167, #168, #169, #170 (can be closed after this merges)

## Test plan
- [x] `yarn build` passes with zero warnings (broken anchors resolved)
- [x] All TS code samples verified against `resonate-sdk-ts` v0.10.0 source
- [x] All Rust code samples verified against `resonate-sdk-rs` v0.1.0 source
- [x] No remaining `--system-url` references in docs
- [x] No named competitors outside of dedicated "Coming from" comparison pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)