### PR TITLE
docs: add worker concurrency semantics

### DIFF
--- a/docs/deploy/scaling.mdx
+++ b/docs/deploy/scaling.mdx
@@ -88,10 +88,19 @@ The pool size is controlled by the `workers` parameter:
 from resonate import Resonate
 
 # Default: min(32, os.cpu_count()) threads
-resonate = Resonate(url="http://resonate-server:8001")
+resonate = Resonate.remote(
+    host="http://resonate-server",
+    store_port="8001",
+    message_source_port="8001",
+)
 
 # Explicit: limit to 4 concurrent function executions
-resonate = Resonate(url="http://resonate-server:8001", workers=4)
+resonate = Resonate.remote(
+    host="http://resonate-server",
+    store_port="8001",
+    message_source_port="8001",
+    workers=4,
+)
 ```
 
 The default is `min(32, os.cpu_count())` — on a 4-core machine that's 4 threads, on a 16-core machine it's 16, with a hard cap at 32.
@@ -113,7 +122,12 @@ However, if your worker holds **in-process state** that cannot be shared across 
 from resonate import Resonate
 
 # Only one function runs at a time in this process
-resonate = Resonate(url="http://resonate-server:8001", workers=1)
+resonate = Resonate.remote(
+    host="http://resonate-server",
+    store_port="8001",
+    message_source_port="8001",
+    workers=1,
+)
 ```
 
 ```bash title="Scale horizontally with multiple single-threaded workers"

--- a/docs/deploy/scaling.mdx
+++ b/docs/deploy/scaling.mdx
@@ -56,6 +56,75 @@ resonate.rpc(
 
 The server automatically load-balances across workers. You don't need to implement distribution logic.
 
+## Worker concurrency
+
+A single worker process handles multiple tasks concurrently.
+When the server dispatches a task to a worker, the worker begins executing it immediately — it does not wait for prior tasks to finish first.
+Understanding this behavior is important for designing your application, especially when workers hold in-process state.
+
+### TypeScript
+
+The TypeScript SDK runs on the Node.js event loop.
+All incoming tasks are processed concurrently via `async/await` — each task progresses independently whenever it hits an `await` point.
+There is no built-in concurrency limit.
+
+```typescript title="Default: unlimited concurrent tasks"
+const resonate = new Resonate({
+  url: "http://resonate-server:8001",
+  group: "workers",
+  // No concurrency config — all tasks run concurrently on the event loop
+});
+```
+
+This means a single TypeScript worker can handle many tasks at once, which is efficient for I/O-bound work (HTTP calls, database queries, file reads).
+CPU-intensive tasks will block the event loop and starve other in-flight tasks — offload heavy computation to worker threads or separate processes.
+
+### Python
+
+The Python SDK uses a thread pool to execute functions concurrently.
+The pool size is controlled by the `workers` parameter:
+
+```python title="Configure thread pool size"
+from resonate import Resonate
+
+# Default: min(32, os.cpu_count()) threads
+resonate = Resonate(url="http://resonate-server:8001")
+
+# Explicit: limit to 4 concurrent function executions
+resonate = Resonate(url="http://resonate-server:8001", workers=4)
+```
+
+The default is `min(32, os.cpu_count())` — on a 4-core machine that's 4 threads, on a 16-core machine it's 16, with a hard cap at 32.
+Each thread executes one function at a time, so `workers=4` means up to 4 functions run in parallel within that single process.
+
+### When concurrency matters
+
+For most applications, per-worker concurrency is beneficial — it keeps the worker busy while individual tasks wait on I/O.
+
+However, if your worker holds **in-process state** that cannot be shared across tasks (for example, a browser automation session, a stateful protocol connection, or a GPU context), concurrent tasks will interfere with each other.
+
+**Strategies for stateful workers:**
+
+1. **Scale horizontally instead.** Run multiple single-purpose worker processes, each handling one task at a time. Resonate's load balancing distributes tasks across them automatically.
+2. **In Python, set `workers=1`** to limit the thread pool to a single thread. This ensures only one function executes at a time within the process.
+3. **Design for isolation.** If tasks can each create their own isolated state (for example, each task launches its own browser context), concurrency is safe.
+
+```python title="Single-threaded worker for stateful workloads"
+from resonate import Resonate
+
+# Only one function runs at a time in this process
+resonate = Resonate(url="http://resonate-server:8001", workers=1)
+```
+
+```bash title="Scale horizontally with multiple single-threaded workers"
+# Each process handles one task at a time
+# Resonate load-balances across all of them
+python worker.py &
+python worker.py &
+python worker.py &
+python worker.py &
+```
+
 ## When to scale workers
 
 Scale workers horizontally when you observe:

--- a/docs/develop/constraints.mdx
+++ b/docs/develop/constraints.mdx
@@ -173,14 +173,14 @@ function* getUserData(ctx: Context, userId: string) {
 
     <TabItem value="python" >
 
-```python title="Wrap external calls with ctx.lfc"
+```python title="Wrap external calls with ctx.run"
 @resonate.register
 def get_user_data(ctx: Context, user_id: str):
-    def fetch_user():
+    def fetch_user(ctx):
         response = requests.get(f"https://api.example.com/users/{user_id}")
         return response.json()
     
-    user_data = yield ctx.lfc(fetch_user)  # ✅ Result recorded, replays use recorded value
+    user_data = yield ctx.run(fetch_user)  # ✅ Result recorded, replays use recorded value
     # ...
 ```
 
@@ -411,7 +411,7 @@ def approval_workflow(ctx: Context, request_id: str):
     approval_promise = yield ctx.promise()
     
     # Send approval request email with promise ID
-    yield ctx.lfc(send_approval_email, approval_promise.id)
+    yield ctx.run(send_approval_email, approval_promise.id)
     
     # Wait for human to resolve the promise (could be hours/days)
     approved = yield approval_promise  # ✅ Survives process restarts

--- a/docs/develop/python.mdx
+++ b/docs/develop/python.mdx
@@ -139,14 +139,27 @@ The pool size is controlled by the `workers` parameter:
 ```py
 from resonate import Resonate
 
-# Default: min(32, os.cpu_count()) threads
-resonate = Resonate()
+# Local mode — default: min(32, os.cpu_count()) threads
+resonate = Resonate.local()
+
+# Remote mode — same default thread pool
+resonate = Resonate.remote(host="http://localhost", store_port="8001", message_source_port="8001")
 
 # Limit to 4 concurrent function executions
-resonate = Resonate(workers=4)
+resonate = Resonate.remote(
+    host="http://localhost",
+    store_port="8001",
+    message_source_port="8001",
+    workers=4,
+)
 
 # Single-threaded: one function at a time
-resonate = Resonate(workers=1)
+resonate = Resonate.remote(
+    host="http://localhost",
+    store_port="8001",
+    message_source_port="8001",
+    workers=1,
+)
 ```
 
 Setting `workers=1` is useful when your worker holds in-process state that cannot be shared across concurrent tasks (for example, a browser automation session or a stateful protocol connection).

--- a/docs/develop/python.mdx
+++ b/docs/develop/python.mdx
@@ -131,6 +131,28 @@ resonate = Resonate.remote(
 )
 ```
 
+### Concurrency
+
+A single Python worker process executes multiple functions concurrently using a thread pool.
+The pool size is controlled by the `workers` parameter:
+
+```py
+from resonate import Resonate
+
+# Default: min(32, os.cpu_count()) threads
+resonate = Resonate()
+
+# Limit to 4 concurrent function executions
+resonate = Resonate(workers=4)
+
+# Single-threaded: one function at a time
+resonate = Resonate(workers=1)
+```
+
+Setting `workers=1` is useful when your worker holds in-process state that cannot be shared across concurrent tasks (for example, a browser automation session or a stateful protocol connection).
+
+See [Scaling — Worker concurrency](/deploy/scaling#worker-concurrency) for more on concurrency strategies.
+
 ## Client APIs
 
 Registration

--- a/docs/develop/typescript.mdx
+++ b/docs/develop/typescript.mdx
@@ -140,6 +140,17 @@ const resonate = new Resonate({
 Token-based authentication is recommended for production. See the [Security & Authentication](/deploy/security) guide for detailed configuration, best practices, and server setup.
 :::
 
+### Concurrency
+
+A single TypeScript worker handles multiple tasks concurrently on the Node.js event loop.
+When the server dispatches tasks to a worker, each one starts executing immediately — tasks do not queue behind each other.
+There is no concurrency limit configuration; all tasks run concurrently via `async/await`.
+
+This is efficient for I/O-bound work but means CPU-intensive tasks will block the event loop and starve other in-flight tasks.
+If your worker holds in-process state that cannot be shared across tasks, consider running multiple single-purpose worker processes instead.
+
+See [Scaling — Worker concurrency](/deploy/scaling#worker-concurrency) for concurrency strategies and patterns for stateful workers.
+
 ### Message sources
 
 A Resonate Client receives messages by making HTTP Long Polling requests to a Resonate Server.


### PR DESCRIPTION
## Summary

- Adds a "Worker concurrency" section to the scaling page explaining that single workers handle multiple tasks concurrently, with per-SDK details
- Adds "Concurrency" subsections to both the Python and TypeScript SDK pages with cross-links
- Documents the Python `workers` parameter (thread pool size control) and TypeScript's unlimited event loop concurrency
- Includes strategies for stateful workers (horizontal scaling, `workers=1`, design for isolation)

## Context

A real user on Kapa (April 17) asked ~25 questions about whether tasks interleave within a single worker. Echo (our AI assistant) couldn't answer — it said "the knowledge sources do not explicitly address this" across 6+ attempts. This was the biggest gap in our docs coverage identified from organic traffic.

All claims verified against SDK source code:
- Python `processor.py:14-16` — thread pool formula `min(32, workers or cpu_count())`
- Python `resonate.py:103` — `workers` parameter on `Resonate.__init__`
- TypeScript `remote.ts:634` — SSE dispatch with no throttling/gating

## Test plan

- [ ] Verify scaling page renders correctly with new section
- [ ] Verify Python SDK page concurrency subsection renders
- [ ] Verify TypeScript SDK page concurrency subsection renders
- [ ] Cross-links from SDK pages to scaling page work
- [ ] After Kapa re-index, ask Echo "do tasks in a single worker run concurrently?" and verify accurate response

🤖 Generated with [Claude Code](https://claude.com/claude-code)