### PR TITLE
Fix /docs/category/* and /category/* redirects landing on 404

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -147,6 +147,26 @@
       "permanent": true
     },
     {
+      "source": "/docs/category/:path*",
+      "destination": "/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/docs/category",
+      "destination": "/",
+      "permanent": true
+    },
+    {
+      "source": "/category/:path*",
+      "destination": "/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/category",
+      "destination": "/",
+      "permanent": true
+    },
+    {
       "source": "/docs",
       "destination": "/",
       "permanent": true


### PR DESCRIPTION
## Summary

Docusaurus emitted category index URLs at `/docs/category/<section>` (e.g. `/docs/category/get-started`). External links to those URLs are dead post-migration: the existing `/docs/:path*` → `/:path*` rule strips just the `/docs/` prefix, leaving `/category/<section>` — which has no route in the fumadocs site, so the request returns **404** after a 308 chain.

Direct `/category/<section>` hits (already-stripped bookmarks) also 404.

This adds two more-specific rules **ahead** of the generic `/docs/:path*` strip so they fire first:

```jsonc
{ "source": "/docs/category/:path*", "destination": "/:path*", "permanent": true },
{ "source": "/category/:path*",       "destination": "/:path*", "permanent": true }
```

Plus bare `/category` and `/docs/category` roots → `/`.

## Reproduction (before)

```
$ curl -sIL -o /dev/null -w "%{http_code}\n" https://docs.resonatehq.io/docs/category/get-started
404
$ curl -sIL -o /dev/null -w "%{http_code}\n" https://docs.resonatehq.io/category/get-started
404
```

After: both 308 → `/get-started` → 200.

## Test plan

- [ ] Vercel preview returns 200 for `/docs/category/get-started`, `/docs/category/develop`, `/docs/category/deploy`, `/category/get-started`, `/category/develop`
- [ ] Existing redirects still work (regression check on `/docs/get-started/quickstart`, `/operate/errors`, `/learn`)