### PR TITLE
Clarify Python SDK status: legacy-server-only, Rust-server compat on roadmap

### DIFF
--- a/content/docs/develop/python.mdx
+++ b/content/docs/develop/python.mdx
@@ -114,7 +114,7 @@ The default configuration uses the Resonate Server as the promise store and uses
 A Resonate Client can receive messages from many different transports, such as HTTP, RabbitMQ, RedPanda, etc...
 The Poller is a great starting place however, as it will long-poll for messages from the Resonate Server without any additional setup.
 
-<Callout type="caution" title="Python SDK v0.6.7 works with the **legacy Resonate server** only. Support for server v0.9.x is coming in a future release.">
+<Callout type="caution" title="Python SDK v0.6.7 works with the **legacy Resonate server** only. Compatibility with the current-generation Rust server is on the roadmap.">
 
 </Callout>
 

--- a/content/docs/get-started/quickstart.mdx
+++ b/content/docs/get-started/quickstart.mdx
@@ -45,7 +45,7 @@ npm install @resonatehq/sdk
 
 <Callout type="caution" title="Legacy server required">
 
-The Python SDK (v0.6.7) currently requires the legacy Resonate server. It is not yet compatible with `resonate dev` (server v0.9.x). See the [Python SDK guide](/develop/python) for legacy server setup.
+The Python SDK (v0.6.7) currently requires the legacy Resonate server (Go-based). It is not yet compatible with the current-generation Rust server that `resonate dev` starts. See the [Python SDK guide](/develop/python) for legacy server setup.
 
 </Callout>
 


### PR DESCRIPTION
## Summary

Two Python callouts referenced "server v0.9.x" — which is confusing because the **v0.9.x release line on `github.com/resonatehq/resonate` IS the current-generation Rust server** (numbering follows the protocol generation, not the language). Read as-was, the callouts implied v0.9.x was the legacy target. Actually the opposite: v0.9.x is the new generation that the Python SDK hasn't caught up to yet.

Reframed both callouts to talk about *generations* instead of release-line numbers:

**`content/docs/develop/python.mdx:117`** — was:
> Python SDK v0.6.7 works with the **legacy Resonate server** only. Support for server v0.9.x is coming in a future release.

Now:
> Python SDK v0.6.7 works with the **legacy Resonate server** only. Compatibility with the current-generation Rust server is on the roadmap.

**`content/docs/get-started/quickstart.mdx:48`** — was:
> The Python SDK (v0.6.7) currently requires the legacy Resonate server. It is not yet compatible with \`resonate dev\` (server v0.9.x).

Now:
> The Python SDK (v0.6.7) currently requires the legacy Resonate server (Go-based). It is not yet compatible with the current-generation Rust server that \`resonate dev\` starts.

Also softened "support is coming in a future release" → "compatibility is on the roadmap." The Python SDK is "stalled" per Resonate's own internal AGENT.md; "coming" implies active progress, "on the roadmap" is honest about the gap without overpromising.

No implementation changes, no link changes, no factual drift — same content, less confusing language.