### PR TITLE
docs: align with resonate v0.9.5 + sdk-ts v0.10.1 (iter-46)

### DIFF
--- a/content/docs/deploy/deployment-patterns.mdx
+++ b/content/docs/deploy/deployment-patterns.mdx
@@ -35,7 +35,7 @@ services:
       retries: 5
 
   resonate-server:
-    image: resonatehqio/resonate:v0.9.4
+    image: resonatehqio/resonate:v0.9.5
     ports:
       - "8001:8001"
       - "9090:9090"
@@ -105,7 +105,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: resonatehqio/resonate:v0.9.4
+          image: resonatehqio/resonate:v0.9.5
           ports:
             - containerPort: 8001
               name: http

--- a/content/docs/deploy/logging.mdx
+++ b/content/docs/deploy/logging.mdx
@@ -159,7 +159,7 @@ In production, collect logs from all servers and workers into a centralized syst
 ```yaml
 services:
   resonate-server:
-    image: resonatehqio/resonate:v0.9.4
+    image: resonatehqio/resonate:v0.9.5
     logging:
       driver: "json-file"
       options:
@@ -182,7 +182,7 @@ metadata:
 spec:
   containers:
   - name: server
-    image: resonatehqio/resonate:v0.9.4
+    image: resonatehqio/resonate:v0.9.5
 ```
 
 Or use Fluent Bit / Fluentd as a DaemonSet to forward logs to your aggregation system.

--- a/content/docs/deploy/message-transports.mdx
+++ b/content/docs/deploy/message-transports.mdx
@@ -8,7 +8,7 @@ keywords:
   - configuration
 ---
 
-Resonate supports transport plugins for message communication between Clients and Servers. In v0.9.4, the only supported non-HTTP message transport is GCP Pub/Sub. Kafka and SQS transports are not yet available in the current server release.
+Resonate supports transport plugins for message communication between Clients and Servers. In v0.9.5, the supported non-HTTP message transports are GCP Pub/Sub and bash exec. Kafka and SQS transports are not yet available in the current server release.
 
 ### GCP Pub/Sub server plugin
 
@@ -18,7 +18,7 @@ This plugin enables the server to put messages (containing task information) ont
 
 Where to find it?
 
-The GCP Pub/Sub transport is built into the v0.9.4 server binary — no rebuild required.
+The GCP Pub/Sub transport is built into the v0.9.5 server binary — no rebuild required.
 
 Enable the plugin at runtime with the `--transports-gcps-project` flag:
 
@@ -35,10 +35,14 @@ project = "my-gcp-project-id"
 
 Or via env var: `RESONATE_TRANSPORTS__GCPS__PROJECT=my-gcp-project-id`.
 
+### Bash exec server plugin
+
+**New in v0.9.5.** The server can dispatch tasks by executing a configured shell command per message, useful for local-process workers and lightweight exec-driven workflows. Full docs forthcoming; for now, see the v0.9.5 release notes ([resonatehq/resonate#47](https://github.com/resonatehq/resonate/pull/47)) for the flag surface.
+
 ### Kafka server plugin
 
-**Not available in v0.9.4.** Kafka transport support is planned for a future release. The Kafka SDK plugin ([resonatehq/resonate-transport-kafka-ts](https://github.com/resonatehq/resonate-transport-kafka-ts)) exists for use with future server versions once server-side support is added.
+**Not available in v0.9.5.** Kafka transport support is planned for a future release. The Kafka SDK plugin ([resonatehq/resonate-transport-kafka-ts](https://github.com/resonatehq/resonate-transport-kafka-ts)) exists for use with future server versions once server-side support is added.
 
 ### SQS server plugin
 
-**Not available in v0.9.4.** AWS SQS transport support is planned for a future release.
+**Not available in v0.9.5.** AWS SQS transport support is planned for a future release.

--- a/content/docs/deploy/metrics.mdx
+++ b/content/docs/deploy/metrics.mdx
@@ -119,7 +119,7 @@ Open http://localhost:9091 to query metrics and build dashboards.
 version: '3.8'
 services:
   resonate-server:
-    image: resonatehqio/resonate:v0.9.4
+    image: resonatehqio/resonate:v0.9.5
     ports:
       - "8001:8001"
       - "9090:9090"  # Metrics endpoint

--- a/content/docs/deploy/run-server.mdx
+++ b/content/docs/deploy/run-server.mdx
@@ -47,10 +47,10 @@ Both default ports can be changed.
 ## Run with Docker
 
 The Resonate Server is published as an official image on Docker Hub at [`resonatehqio/resonate`](https://hub.docker.com/r/resonatehqio/resonate).
-Tags track the server release versions (e.g. `v0.9.4`) plus a rolling `latest`.
+Tags track the server release versions (e.g. `v0.9.5`) plus a rolling `latest`.
 
 ```shell title="Run the Resonate Server in Docker"
-docker run --rm -p 8001:8001 -p 9090:9090 resonatehqio/resonate:v0.9.4
+docker run --rm -p 8001:8001 -p 9090:9090 resonatehqio/resonate:v0.9.5
 ```
 
 `resonate serve` is the default command. Override only when you need to change behavior:
@@ -59,7 +59,7 @@ docker run --rm -p 8001:8001 -p 9090:9090 resonatehqio/resonate:v0.9.4
 docker run --rm -p 8001:8001 -p 9090:9090 \
   -e RESONATE_STORAGE__TYPE=postgres \
   -e RESONATE_STORAGE__POSTGRES__URL="postgres://user:pass@host:5432/resonate" \
-  resonatehqio/resonate:v0.9.4
+  resonatehqio/resonate:v0.9.5
 ```
 
 The image exposes both `8001` (HTTP API) and `9090` (Prometheus metrics).
@@ -195,7 +195,7 @@ Cloud Run can pull the official image directly:
 
 ```shell
 gcloud run deploy resonate-server \
-  --image=resonatehqio/resonate:v0.9.4 \
+  --image=resonatehqio/resonate:v0.9.5 \
   --region=<your-region> \
   --port=8001 \
   --allow-unauthenticated \
@@ -241,7 +241,7 @@ spec:
     spec:
       containers:
         - name: resonate
-          image: resonatehqio/resonate:v0.9.4
+          image: resonatehqio/resonate:v0.9.5
           env:
             - name: RESONATE_SERVER__BIND
               value: "0.0.0.0"

--- a/content/docs/develop/rust.mdx
+++ b/content/docs/develop/rust.mdx
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <Callout type="caution" title="Early development">
-The Rust SDK is v0.1.0 and in active development. APIs may change between releases. It is not yet published on crates.io.
+The Rust SDK is at 0.4.0 and in active development. APIs may change between releases. It is not yet published on crates.io.
 </Callout>
 
 Whether you are a human or an AI agent, this skill guide will help you develop applications using the Resonate Rust SDK.

--- a/content/docs/get-started/examples/async-agent-tools.mdx
+++ b/content/docs/get-started/examples/async-agent-tools.mdx
@@ -16,7 +16,7 @@ keywords:
 A FastMCP server exposes three tools — start, probe, await — backed by a durable Resonate workflow. The LLM kicks off long jobs, polls them, and collects results without blocking on the work.
 
 <Callout type="info" title="SDK versions">
-Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: v0.1.0, in active development. TypeScript SDK example repo is forthcoming.
+Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: 0.4.0, in active development. TypeScript SDK example repo is forthcoming.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/async-http-api-endpoints.mdx
+++ b/content/docs/get-started/examples/async-http-api-endpoints.mdx
@@ -16,7 +16,7 @@ keywords:
 A FastAPI gateway converts every inbound request into a durable workflow, returns a promise ID immediately, and exposes a `/wait` endpoint clients poll for completion.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: v0.1.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/deep-research-agent.mdx
+++ b/content/docs/get-started/examples/deep-research-agent.mdx
@@ -17,7 +17,7 @@ keywords:
 A research agent receives a broad topic, asks an LLM to break it into 2–3 subtopics, and recursively dispatches each subtopic to itself. Every LLM call and every recursive subagent is a durable promise — kill the worker mid-research, the tree resumes from the last unanswered branch.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: v0.1.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/durable-sleep.mdx
+++ b/content/docs/get-started/examples/durable-sleep.mdx
@@ -15,7 +15,7 @@ keywords:
 A workflow yields `ctx.sleep` and the runtime suspends it. Hours, days, or weeks later the worker wakes the workflow up exactly where it stopped — no cron, no scheduler, no external state.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: v0.1.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/fan-out-fan-in.mdx
+++ b/content/docs/get-started/examples/fan-out-fan-in.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow spawns four notification channels (email, SMS, Slack, push) in parallel and joins their results. Total wall time approaches the slowest channel, not the sum. If one channel fails and retries, the others stay checkpointed — they don't re-send.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: v0.1.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/hello-world.mdx
+++ b/content/docs/get-started/examples/hello-world.mdx
@@ -15,7 +15,7 @@ keywords:
 The smallest example that exercises the durable execution loop. A registered workflow function calls two leaf functions through `ctx.run`, and Resonate checkpoints each return value.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x. Rust: v0.1.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x. Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/human-in-the-loop.mdx
+++ b/content/docs/get-started/examples/human-in-the-loop.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow blocks on a durable promise, prints a callback URL, and resumes the moment a human resolves it — from any process, any machine, any time.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: v0.1.0, in active development — pulled as a git dependency from `resonate-sdk-rs` until it ships on crates.io.
+TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: 0.4.0, in active development — pulled as a git dependency from `resonate-sdk-rs` until it ships on crates.io.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/kafka-worker.mdx
+++ b/content/docs/get-started/examples/kafka-worker.mdx
@@ -16,7 +16,7 @@ keywords:
 A consumer pulls messages from a Kafka topic and dispatches each one through a durable Resonate workflow. Per-message state lives in durable promises, so a worker that dies mid-batch resumes cleanly without redoing completed steps.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: v0.1.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: 0.4.0, in active development.
 </Callout>
 
 <Callout type="note" title="Kafka or Redpanda — same code">

--- a/content/docs/get-started/examples/load-balancing.mdx
+++ b/content/docs/get-started/examples/load-balancing.mdx
@@ -15,7 +15,7 @@ keywords:
 Run several workers in the same group. Calls to `target: "poll://any@<group>"` get dispatched to whichever worker claims them first. When a worker dies mid-execution, Resonate reassigns the work to a survivor — no service registry, no leader election, no glue.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: v0.1.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/money-transfer.mdx
+++ b/content/docs/get-started/examples/money-transfer.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow debits the source account, credits the target account, and returns confirmations. Each account update is a durable checkpoint, the transfer ID is the idempotency key, and the same ID retried in seconds, hours, or days returns the cached result instead of double-spending.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x. Rust: v0.1.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x. Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/recursive-factorial.mdx
+++ b/content/docs/get-started/examples/recursive-factorial.mdx
@@ -15,7 +15,7 @@ keywords:
 A workflow that computes `n!` by calling itself with `n-1`. Each recursive call dispatches via `ctx.rpc` to whichever worker in the group claims it — recursion ends up distributed across machines without any explicit coordination, and every step is checkpointed so a worker crash mid-recursion resumes cleanly.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: v0.1.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/schedule.mdx
+++ b/content/docs/get-started/examples/schedule.mdx
@@ -16,7 +16,7 @@ keywords:
 Register a function to run on a cron expression and Resonate handles the rest. Every fired execution is a durable workflow — a worker that crashes mid-run hands off to a survivor, and a missed run because all workers were down still gets dispatched when one comes back.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: v0.1.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.1 (current). Python: `resonate-sdk` v0.6.x against the legacy Resonate Server. Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>


### PR DESCRIPTION
## Summary

Iteration 46 of the Resonate Alignment Loop — release-alignment maintenance pass.

**Server v0.9.4 → v0.9.5** (released 2026-04-28 22:50 UTC, ~5h after iter-45 closed):
- Bumps image-tag pins across `deploy/*` (deployment-patterns, logging, metrics, run-server, message-transports) — 14 hits.
- Updates `message-transports.mdx` prose to reflect that GCP Pub/Sub + bash exec are the supported non-HTTP transports in v0.9.5 (was: GCP Pub/Sub only in v0.9.4).
- Adds a brief "Bash exec server plugin" section pointing at [PR #47](https://github.com/resonatehq/resonate/pull/47) for the flag surface; full docs deferred to a dedicated `asset-creation` iteration per Phase 0 maintenance/asset-creation split.
- Bumps "Not available in v0.9.4" → "Not available in v0.9.5" for Kafka and SQS sections.

**Deferred to dedicated asset-creation iterations** (per iter-45 + iter-46 pattern):
- Server v0.9.5 outbound HTTP push auth ([PR #46](https://github.com/resonatehq/resonate/pull/46))
- Server v0.9.5 per-transport enable/disable flags ([PR #51](https://github.com/resonatehq/resonate/pull/51))
- Server v0.9.4 CORS support (still pending from iter-45)
- Server v0.9.4 MySQL persistence (still pending from iter-45)
- TS SDK v0.10.1 non-retryable errors (still pending from iter-45)

## Test plan

- [ ] Site builds clean on `flossy/iter46-release-alignment`
- [ ] `grep -rn 'v0\.9\.4' content/` returns 0 hits ✓ (verified pre-push)
- [ ] message-transports page renders the new "Bash exec server plugin" section between GCP Pub/Sub and Kafka
- [ ] Echo source list re-index will pick up the v0.9.5 changes on next crawl (no manual trigger needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)