### PR TITLE
docs(errors): add missing TS SDK codes 1107/1108/1109/1198

### DIFF
--- a/content/docs/debug/errors.mdx
+++ b/content/docs/debug/errors.mdx
@@ -43,7 +43,7 @@ When an error occurs, the response body will contain the following information.
         "message": "attempt to write a readonly database",
         "domain": "server",
         "metadata": {
-          "url": "https://docs.resonatehq.io/reference/error-codes#5002"
+          "url": "https://docs.resonatehq.io/debug/errors#5002"
         }
       }
     ]
@@ -235,6 +235,30 @@ Dependency 'x' is not registered. Will drop.
 **ENCODING_ARGS_UNENCODEABLE**
 
 Function arguments cannot be encoded.
+
+### 1107
+
+**ENCODING_ARGS_UNDECODEABLE**
+
+Function arguments cannot be decoded.
+
+### 1108
+
+**ENCODING_RETV_UNENCODEABLE**
+
+The return value from a function cannot be encoded.
+
+### 1109
+
+**ENCODING_RETV_UNDECODEABLE**
+
+The return value from a function cannot be decoded.
+
+### 1198
+
+**PANIC**
+
+An unrecoverable internal error occurred in the SDK.
 
 ### 1199
 


### PR DESCRIPTION
## Summary

User report: clicking the error link emitted by `@resonatehq/sdk` for code 1108 lands at `docs.resonatehq.io/debug/errors#1108`, but the page had no entry for 1108. Confirmed against `resonate-sdk-ts/src/exceptions.ts` — codes 1107, 1108, 1109, and 1198 all exist in source but were undocumented.

## Changes

| Code | Constant | Source line |
|---|---|---|
| 1107 | `ENCODING_ARGS_UNDECODEABLE` | exceptions.ts:93 |
| 1108 | `ENCODING_RETV_UNENCODEABLE` | exceptions.ts:99 |
| 1109 | `ENCODING_RETV_UNDECODEABLE` | exceptions.ts:105 |
| 1198 | `PANIC` | exceptions.ts:111 |

Also: the JSON error-schema example referenced `/reference/error-codes#5002`, which 404s. Fixed to `/debug/errors#5002`.

## Out of scope (separate follow-up)

- The Python SDK section claims range 1000-1099 with "update required". Source (`resonate-sdk-py/resonate/errors/errors.py`) actually emits codes outside that range (100.x store, 200 canceled, 201 timed-out, 300 shutdown). Structural mismatch — needs product input on whether to renumber, document both schemes, or rewrite the section.
- Server-side 4XXXX/5XXXX codes were not re-verified against the current Rust server source (the docs page may be authored against the legacy Go server). Worth a dedicated audit.
- Rust SDK doesn't use numeric codes (string-named enum variants), so no docs section needed for it under the current scheme.

## Test plan

- [ ] Visit `https://docs.resonatehq.io/debug/errors#1108` after deploy and confirm anchor scrolls
- [ ] Same for 1107, 1109, 1198
- [ ] Confirm `rn8.io/e/1108` chain still resolves cleanly