### PR TITLE
docs(sdk-ts): align all TS code samples to v0.10.1 (iter-50)

### DIFF
--- a/content/docs/deploy/tracing.mdx
+++ b/content/docs/deploy/tracing.mdx
@@ -203,22 +203,21 @@ When one worker calls another, spans are linked across workers:
 
 ```typescript
 // Worker A
-resonate.register("orderWorkflow", async (ctx, order) => {
+resonate.register("orderWorkflow", function* (ctx, order) {
   // Span: "orderWorkflow" on Worker A
-  
-  const result = await resonate.rpc(
-    `inventory-${order.id}`,
+
+  const result = yield* ctx.rpc(
     "checkInventory",
     order.items,
-    resonate.options({ target: "poll://any@inventory-workers" })
+    ctx.options({ target: "poll://any@inventory-workers" })
   );
   // Creates linked span on Worker B
-  
+
   return result;
 });
 
 // Worker B (inventory-workers group)
-resonate.register("checkInventory", async (ctx, items) => {
+resonate.register("checkInventory", (ctx, items) => {
   // Span: "checkInventory" on Worker B
   // Parent: "orderWorkflow" on Worker A
 });

--- a/content/docs/get-started/examples/multi-agent-orchestration.mdx
+++ b/content/docs/get-started/examples/multi-agent-orchestration.mdx
@@ -132,8 +132,10 @@ To extend the pipeline with human approval, replace the inline `approved` calcul
 
 ```typescript
 // Suspend until an external system (HTTP handler, CLI, button click)
-// resolves the promise.
-const approved = yield* ctx.promise<boolean>({ id: `approval/${topic}` });
+// resolves the promise. ctx.promise() creates a child promise whose ID
+// is `${ctx.id}.<seq>` — deterministic from the orchestrator's execution ID.
+const approvalPromise = yield* ctx.promise<boolean>();
+const approved = yield* approvalPromise;
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary

Iter-50 alignment loop. Walked all 26 files in `content/` that import `@resonatehq/sdk` and patched drift from older API patterns to v0.10.1 idioms.

**Source of truth:** `resonate-sdk-ts` v0.10.1 (npm). Local `main` matches the tag exactly.
**Canonical doc reference:** `content/docs/develop/typescript.mdx`.

## Patterns fixed

Two real drifts surfaced (the other 24 files were already aligned from the iter-46 sweep):

1. **`content/docs/deploy/tracing.mdx`** — the cross-worker `orderWorkflow` + `checkInventory` examples were using:
   ```ts
   resonate.register("orderWorkflow", async (ctx, order) => {
     const result = await resonate.rpc(`inventory-${order.id}`, "checkInventory", ...);
   });
   ```
   This doesn't checkpoint — RPC inside a registered durable function must be `yield* ctx.rpc(...)` from a generator. Switched to `function*` + `yield* ctx.rpc(...)` matching the canonical idiom in `develop/typescript.mdx`. Dropped the now-stale id argument and aligned `resonate.options(...)` -> `ctx.options(...)`.

2. **`content/docs/get-started/examples/multi-agent-orchestration.mdx`** — the human-approval extension showed:
   ```ts
   const approved = yield* ctx.promise<boolean>({ id: `approval/${topic}` });
   ```
   In v0.10.1 `ctx.promise` only accepts `{ timeout, data, tags }` — no `id` field. IDs are auto-generated as `${ctx.id}.<seq>`. Replaced with the canonical pattern (matches `restate.mdx` and `develop/typescript.mdx`):
   ```ts
   const approvalPromise = yield* ctx.promise<boolean>();
   const approved = yield* approvalPromise;
   ```

## What was already clean

- `.settle()` API: 0 hits (iter-46 already swept).
- `Resonate.local()` / `Resonate.remote()` static factories: only appear in Python tab items (out of scope for this iteration).
- `ikey` / `strict` arguments: 1 hit, in a Python block (out of scope).
- All other TS code blocks already use `new Resonate({...})` plus `function*` + `yield*` for durable code.

## Anything ambiguous

None — both fixes were unambiguous v0.10.1 drift confirmed against the SDK source (`resonate-sdk-ts/src/context.ts` and `src/resonate.ts`).

One pattern I considered and left alone: in `tracing.mdx` line ~234 (`resonate.register("unreliableTask", async (ctx) => { /* empty body, just commentary about retry spans */ })`). The body is empty, so there's no API misuse — just a span-shape illustration.

## Test plan

- [ ] CI passes
- [ ] Spot-check rendered Mintlify pages for the two changed files
- [ ] Cully reviews and merges (pre-authorized for the sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)