### PR TITLE
docs(sdk-rs): align Rust code samples to resonate-sdk 0.4.0 (iter-52)

### DIFF
--- a/content/docs/deploy/security.mdx
+++ b/content/docs/deploy/security.mdx
@@ -94,7 +94,7 @@ export default resonate;
 ### Rust SDK
 
 ```rust title="main.rs"
-use resonate::{Resonate, ResonateConfig};
+use resonate::prelude::*;
 
 let resonate = Resonate::new(ResonateConfig {
     token: std::env::var("RESONATE_TOKEN").ok(),

--- a/content/docs/develop/rust.mdx
+++ b/content/docs/develop/rust.mdx
@@ -30,7 +30,7 @@ Add it as a git dependency in your `Cargo.toml`:
 
 ```toml title="Cargo.toml"
 [dependencies]
-resonate = { git = "https://github.com/resonatehq/resonate-sdk-rs", branch = "master" }
+resonate = { package = "resonate-sdk", git = "https://github.com/resonatehq/resonate-sdk-rs", branch = "main" }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 ```


### PR DESCRIPTION
## Summary

iter-52 alignment loop. Closes PROPAGATION-BACKLOG #26 (`resonate::*` vs `resonate_sdk::*` drift). Aligns the Rust code samples in the docs to `resonate-sdk` 0.4.0 (git, not yet on crates.io) using the canonical alias pattern from `example-money-transfer-rs`.

## Patches

- `content/docs/develop/rust.mdx` — Cargo.toml dep entry: added `package = "resonate-sdk"`, changed `branch = "master"` to `branch = "main"`. The repo URL was already correct (`resonate-sdk-rs`).
- `content/docs/deploy/security.mdx` — Rust example switched from a non-prelude direct import (`use resonate::{Resonate, ResonateConfig};`, which would not compile because the crate root only re-exports the `function` macro) to the canonical alias-prelude pattern (`use resonate::prelude::*;`). The `Resonate` and `ResonateConfig` types are exported from `prelude` per `resonate/src/lib.rs:90`.

## Verified clean (no changes needed)

- `content/docs/get-started/quickstart.mdx` already had the canonical Cargo.toml entry (likely landed in iter-46).
- All other Rust code blocks already use `use resonate::prelude::*;` and the `#[resonate::function]` macro path — these match `example-money-transfer-rs/src/main.rs`.
- No `resonate-sdk-rust` (wrong repo URL) references found anywhere in `content/`.
- No `branch = "master"` references remaining anywhere in `content/`.
- API surface (`Resonate::new(ResonateConfig { ... })`, `Resonate::local()`, `ResonateConfig` fields `url`/`group`/`token`) verified against `/tmp/resonate-sdk-rs-tmp/resonate/src/resonate.rs` — no API drift between v0.3.x and v0.4.0 (the 0.4.0 release was a 409-protocol bug fix only).

## Source of truth

- SDK source: `https://github.com/resonatehq/resonate-sdk-rs` (default branch `main`, latest tag `0.4.0`).
- Crate name: `resonate-sdk` (Cargo.toml `[package].name`).
- Prelude: `resonate/src/lib.rs:90` — re-exports `Resonate`, `ResonateConfig`, `Context`, `Info`, `Result`, `function` macro, etc.
- Right-shape exemplar: `https://github.com/resonatehq-examples/example-money-transfer-rs/blob/main/Cargo.toml`.

## Test plan

- [ ] CI/Vercel preview build succeeds
- [ ] Rust code blocks render correctly on `/develop/rust` and `/deploy/security` preview
- [ ] Reviewer spot-checks against `example-money-transfer-rs` Cargo.toml + `src/main.rs`

Do not merge yet (alignment-loop convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)