### PR TITLE
docs(server): align /debug/errors with Resonate Server v0.9.5 (iter-53)

### DIFF
--- a/content/docs/debug/errors.mdx
+++ b/content/docs/debug/errors.mdx
@@ -14,166 +14,91 @@ Known errors will likely have an error code associated with them and a short err
 
 Troubleshooting steps are categorized by error code ranges:
 
-- [Server request errors (40000-49999)](#server-request-errors)
-- [Server errors (50000-59999)](#server-errors)
+- [Server request errors (HTTP 4XX)](#server-request-errors)
+- [Server errors (HTTP 5XX)](#server-errors)
 - [Python SDK errors (100.x, 200, 201, 300)](#python-sdk-errors)
 - [TypeScript SDK errors (1100-1199)](#typescript-sdk-errors)
 
 ## Server request errors
 
-These are known errors you may encounter when making requests to the Resonate Server API.
+These are the errors you may encounter when making requests to Resonate Server v0.9.5.
+Request errors signify problems with the request itself — retrying the same request will not resolve the issue.
 
-**Range: 40000-49999**
+**Range: HTTP 4XX**
 
-Request errors signify problems with the request.
-Generally, retrying the request will not resolve the issue.
+**Error response shape**
 
-**Error Schema**
-
-When an error occurs, the response body will contain the following information.
+Every response from the server (success or error) carries this envelope. On error, `head.status` is the HTTP status code and `data` is the human-readable message.
 
 ```json
 {
-  "error": {
-    "code": 5002,
-    "message": "failed to update promise",
-    "details": [
-      {
-        "@type": "ServerError",
-        "message": "attempt to write a readonly database",
-        "domain": "server",
-        "metadata": {
-          "url": "https://docs.resonatehq.io/debug/errors#5002"
-        }
-      }
-    ]
-  }
+  "kind": "promises.get",
+  "head": {
+    "corrId": "<correlation id from the request>",
+    "status": 404,
+    "version": "2026-04-01"
+  },
+  "data": "Promise not found"
 }
 ```
 
-The `code` field can be used to programmatically identify the error.
-The message and details provide a human readable description of what went wrong.
-
-The `details` provide structured diagnostic data such as the originating subsystem and links to documentation which can assist in debugging and troubleshooting.
-
-If the problem persists, open a [GitHub issue](https://github.com/resonatehq/resonate/issues/new) with details, including the error code and steps to reproduce.
+If the problem persists, open a [GitHub issue](https://github.com/resonatehq/resonate/issues/new) with details, including the response envelope and steps to reproduce.
 Or reach out via [Discord](https://resonatehq.io/discord) for support.
 
-### 40000
+### 400 — Bad Request
 
-There was a validation error affecting one or more fields.
+The request is malformed. Common causes:
 
-### 40300
+- Invalid JSON body or missing required fields
+- Validation failure (`data` carries the failed field and reason)
+- Unrecognized operation kind
+- Invalid `resonate:target` address
+- Invalid listener address
+- `limit` outside the allowed range (1–1000)
 
-The promise has already been resolved. Once a promise is resolved it can no longer be modified.
+### 401 — Unauthorized
 
-### 40301
+The request did not carry a valid bearer token, or the token failed JWT verification.
 
-The promise has already been rejected. Once a promise is rejected it can no longer be modified.
+### 403 — Forbidden
 
-### 40302
+The request carried a valid token, but the principal is not permitted to perform the requested action.
 
-The promise has already been canceled. Once a promise is canceled it can no longer be modified.
+### 404 — Not Found
 
-### 40303
+The requested resource does not exist. Common cases: promise not found, schedule not found, task not found, awaited promise not found.
 
-The promise has already timed out. Once a promise is timed out it can no longer be modified.
+### 409 — Conflict
 
-### 40304
+The request would violate an existing resource's lifecycle invariants. Common cases:
 
-The lock has already been acquired. Once a lock is acquired it can no longer be acquired.
+- Promise already resolved, rejected, canceled, or timed out (cannot be modified again)
+- Schedule with the requested id already exists
+- Promise with the requested id already exists
+- Lock already acquired
+- Task already claimed or completed
+- Task claimed with the wrong counter
 
-### 40305
+### 422 — Unprocessable Entity
 
-The task has already been claimed. Once a task has been claimed it can no longer be claimed.
+The request was syntactically valid but semantically unprocessable. Common cases:
 
-### 40306
-
-The task has already been completed. Once a task has been completed it can no longer be claimed.
-
-### 40307
-
-A task was attempted to be claimed with the wrong counter.
-
-### 40308
-
-A task was attempted to be claimed or completed, but the task is in an invalid state.
-
-### 40400
-
-A promise with the provided id could not be found.
-
-### 40401
-
-A schedule with the provided id could not be found.
-
-### 40402
-
-A lock with the provided id could not be found.
-
-### 40403
-
-A task with the provided id could not be found.
-
-### 40404
-
-A promise with the provided id does not specify a required recv.
-
-### 40900
-
-A promise with the provided id already exists.
-
-### 40901
-
-A schedule with the provided id already exists. |
+- Awaiter promise not found or has no `resonate:target` tag
+- Task in invalid state for the requested transition
 
 ## Server errors
 
-These are
-
-**Range: 50000-59999**
+**Range: HTTP 5XX**
 
 Server errors represent transient or systemic problems that prevent the request from being processed.
 Retrying the request may resolve the issue.
 
-If the problem persists, open a [GitHub issue](https://github.com/resonatehq/resonate/issues/new) with details, including the error code and steps to reproduce.
+If the problem persists, open a [GitHub issue](https://github.com/resonatehq/resonate/issues/new) with details, including the response envelope and steps to reproduce.
 Or reach out via [Discord](https://resonatehq.io/discord) for support.
 
-### 50000
+### 500 — Internal Server Error
 
-An unknown internal server error occurred. Please open an issue.
-
-### 50001
-
-There was a failure related to the echo subsystem.
-
-### 50002
-
-There was a failure related to the match subsystem.
-
-### 50003
-
-There was a failure related to the queue subsystem.
-
-### 50004
-
-There was a failure related to the store subsystem.
-
-### 50300
-
-The system is shutting down.
-
-### 50301
-
-The API submission queue is full. Please try again later.
-
-### 50302
-
-The AIO submission queue is full. Please try again later.
-
-### 50303
-
-The scheduler queue is full. Please try again later.
+An unexpected server-side failure. Includes failures in the persistence layer (e.g. unrecoverable database lock contention), the scheduler, or any unhandled internal error path. The `data` field carries the failure description; the server logs carry the underlying cause.
 
 ## Python SDK errors
 
@@ -185,9 +110,16 @@ Or reach out via [Discord](https://resonatehq.io/discord) for support.
 
 ### `ResonateStoreError` (codes `100.x`)
 
-Raised when a store operation against the Resonate Server (or the in-process local store) fails. The fractional part embeds the server's request error code — e.g. `100.40400` corresponds to a server `40400` (promise/schedule not found), `100.40303` to `40303` (promise already timed out), `100.40305` to `40305` (task already claimed), `100.40403` to `40403` (task not found), `100.40399` to a state-machine transition error, and `100.0` to a transport-level failure (request timed out, failed to connect, or unknown exception).
+Raised when a store operation against the Resonate Server (or the in-process local store) fails. The fractional part embeds a structured sub-code from the **legacy Resonate Server** (which Python SDK v0.6.7 targets — see the legacy-server callout on the [Python SDK guide](/develop/python)). Common sub-codes:
 
-For the meaning of the embedded server code, see [Server request errors](#server-request-errors).
+- `100.40400` — promise/schedule not found
+- `100.40303` — promise already timed out
+- `100.40305` — task already claimed
+- `100.40403` — task not found
+- `100.40399` — state-machine transition error
+- `100.0` — transport-level failure (request timed out, failed to connect, unknown exception)
+
+The current Rust server (v0.9.5) does not emit these structured sub-codes — it returns standard HTTP status codes (see [Server request errors](#server-request-errors) above). When the Python SDK adds Rust-server compatibility, this section will be updated.
 
 ### `ResonateCanceledError` (code `200`)
 


### PR DESCRIPTION
## Summary

The `/debug/errors` page documented a **4XXXX/5XXXX structured-code scheme** that the current Rust server (v0.9.5) does not emit. That listing was inherited from the legacy Go server. Re-aligning to actual v0.9.5 emit semantics per the docs-must-match-latest-releases rule.

## Verification

Traced the error emit path through `resonatehq/resonate@v0.9.5`:

- `src/types.rs:728` defines `ResponseEnvelope::error(kind, corr_id, status, message)` where `status: i32`
- 60+ call sites across `src/oracle.rs` and `src/server.rs` pass standard HTTP statuses

Distinct status codes actually emitted by v0.9.5:

| Code | Times | Meaning |
|---|---|---|
| 400 | 88 | Bad request |
| 401 | 2 | Unauthorized |
| 403 | 6 | Forbidden |
| 404 | 33 | Not found |
| 409 | 24 | Conflict |
| 422 | 8 | Unprocessable entity |
| 500 | 24 | Internal server error |

No 4XXXX or 5XXXX literals appear in the v0.9.5 emit path.

## Changes

1. **TOC ranges**: `(40000-49999)` → `(HTTP 4XX)`, `(50000-59999)` → `(HTTP 5XX)`.

2. **Server request errors section**: replaced 17 stale `### 4XXXX` entries with 6 entries covering the actual emitted statuses (400, 401, 403, 404, 409, 422), each with a list of common causes derived from the v0.9.5 error message strings.

3. **Server errors section**: replaced 9 stale `### 5XXXX` entries with one `### 500 — Internal Server Error` entry covering the actual emit path.

4. **Response envelope example**: was `{ error: { code, message, details } }` (legacy shape); replaced with the actual v0.9.5 shape `{ kind, head: { corrId, status, version }, data }` confirmed in `types.rs:161-172` (note the `serde(rename = "corrId")` camelCase serialization).

5. **Python SDK section**: clarified that the `100.x` store-error sub-codes wrap the **legacy** server's structured codes (Python v0.6.7 is legacy-server-only per the existing callout on `/develop/python`). The current Rust server returns HTTP statuses, not 4XXXX codes — referenced in the section.

## Test plan

- [ ] After deploy, visit `/debug/errors` and confirm all anchors render
- [ ] Smoke-test that a real 404 from the server shows a `head.status: 404` envelope (matches the doc example)
- [ ] Confirm `/debug/errors#1108` (added in iter-49) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)