### PR TITLE
docs(deploy): document v0.9.5 features — bash exec, per-transport enable/disable, outbound HTTP push auth

### DIFF
--- a/content/docs/deploy/message-transports.mdx
+++ b/content/docs/deploy/message-transports.mdx
@@ -8,41 +8,126 @@ keywords:
   - configuration
 ---
 
-Resonate supports transport plugins for message communication between Clients and Servers. In v0.9.5, the supported non-HTTP message transports are GCP Pub/Sub and bash exec. Kafka and SQS transports are not yet available in the current server release.
+The Resonate Server delivers task messages to workers over a configurable set of transports. As of v0.9.5, four transports ship in the server binary:
 
-### GCP Pub/Sub server plugin
+| Transport | Address scheme | Enable flag | Default |
+|---|---|---|---|
+| HTTP push | `http://` / `https://` | `--transports-http-push-enabled` | `true` |
+| HTTP poll (SSE) | (used by SDK clients that long-poll the server) | `--transports-http-poll-enabled` | `true` |
+| GCP Pub/Sub | `gcps://` | `--transports-gcps-enabled` | `false` |
+| Bash exec | `bash:///` | `--transports-bash-exec-enabled` | `false` |
 
-What does it do?
+Each transport can be turned on or off independently. The full CLI flag list is on the [Run a server](/deploy/run-server#cli-flags) page; the equivalent `resonate.toml` keys live under `[transports.<name>]`.
 
-This plugin enables the server to put messages (containing task information) onto GCP Pub/Sub topics for consumption by SDK Clients using the SDK's Pub/Sub transport plugin.
+## HTTP push
 
-Where to find it?
+The HTTP push transport delivers task messages by `POST`ing to a worker URL embedded in the task address (for example `https://workers.example.com/tasks`). It's enabled by default and needs no further configuration for unauthenticated targets.
 
-The GCP Pub/Sub transport is built into the v0.9.5 server binary — no rebuild required.
+For deployments where the target service requires authentication, the server can sign outbound requests with a static bearer token or a GCP OIDC ID token. See [Outbound HTTP push authentication](/deploy/security#outbound-http-push-authentication) on the Security page.
 
-Enable the plugin at runtime with the `--transports-gcps-project` flag:
+## HTTP poll (SSE)
+
+The HTTP poll transport lets SDK clients receive tasks over a long-lived Server-Sent Events stream instead of an inbound HTTP push. It's enabled by default and requires no per-deployment configuration; concurrency limits are tunable via `--transports-http-poll-max-connections` and `--transports-http-poll-buffer-size`.
+
+## GCP Pub/Sub
+
+The GCP Pub/Sub transport puts task messages onto Pub/Sub topics for consumption by SDK clients using the matching client-side plugin.
+
+Enable it at runtime with the GCP project ID:
 
 ```shell
-resonate serve --transports-gcps-project my-gcp-project-id
+resonate serve \
+  --transports-gcps-enabled true \
+  --transports-gcps-project my-gcp-project-id
 ```
 
 Or in `resonate.toml`:
 
 ```toml
 [transports.gcps]
+enabled = true
 project = "my-gcp-project-id"
 ```
 
-Or via env var: `RESONATE_TRANSPORTS__GCPS__PROJECT=my-gcp-project-id`.
+Or via env var: `RESONATE_TRANSPORTS__GCPS__ENABLED=true` and `RESONATE_TRANSPORTS__GCPS__PROJECT=my-gcp-project-id`.
 
-### Bash exec server plugin
+Authentication uses Application Default Credentials (ADC) — make sure the server process has access to credentials with publish rights on the target project.
 
-**New in v0.9.5.** The server can dispatch tasks by executing a configured shell command per message, useful for local-process workers and lightweight exec-driven workflows. Full docs forthcoming; for now, see the v0.9.5 release notes ([resonatehq/resonate#47](https://github.com/resonatehq/resonate/pull/47)) for the flag surface.
+## Bash exec
 
-### Kafka server plugin
+The bash exec transport runs a shell command on the server host for each delivered task. It's intended for local-process workers, lightweight wrappers around CLI tools, and self-hosted single-host deployments where running a separate worker process is overkill.
+
+The transport is **disabled by default**. Enable it explicitly:
+
+```shell
+resonate serve --transports-bash-exec-enabled true
+```
+
+Or in `resonate.toml`:
+
+```toml
+[transports.bash_exec]
+enabled = true
+# Required for named scripts; not required for inline scripts.
+root_dir = "/etc/resonate/scripts"
+# Working directory for named-script execution. One of:
+#   "<root>"   — CWD is set to root_dir (default)
+#   "<script>" — CWD is set to the script's parent directory
+#   any path   — CWD is set to that literal path
+working_dir = "<root>"
+```
+
+<Callout type="caution" title="Security">
+The bash exec transport runs arbitrary shell commands as the user running the server. Only enable it on hosts where every promise creator is trusted, and prefer named scripts (with `root_dir` set to a non-writable directory) over inline scripts in production.
+</Callout>
+
+### Address forms
+
+A task address controls how bash exec runs the command:
+
+| Address | Mode | What runs |
+|---|---|---|
+| `bash:///` | Inline | The script body is `param.data` on the promise (base64-encoded) |
+| `bash:///relative/path.sh` | Named script | The file at `<root_dir>/relative/path.sh` is invoked with arguments from `param.data` |
+
+In both modes the server sets `RESONATE_PROMISE_ID` in the script's environment so the script can correlate logs, metrics, or follow-on calls back to the originating promise.
+
+### Inline scripts
+
+For inline scripts, set the promise's `param.data` to the base64-encoded script body:
+
+```bash
+echo -n 'echo "hello from $RESONATE_PROMISE_ID"' | base64
+# ZWNobyAiaGVsbG8gZnJvbSAkUkVTT05BVEVfUFJPTUlTRV9JRCI=
+```
+
+Then create a task targeting `bash:///` with that base64 as `param.data`. The server invokes `bash -c "<decoded script>"`.
+
+### Named scripts
+
+Set `bash_exec.root_dir` in config, place an executable script at e.g. `<root_dir>/build/release.sh`, and target `bash:///build/release.sh`. Pass arguments by setting `param.data` to a JSON array of strings:
+
+```json
+["v1.2.3", "production"]
+```
+
+The server invokes `bash <root_dir>/build/release.sh v1.2.3 production` with `RESONATE_PROMISE_ID` in the environment.
+
+### Settle behavior
+
+The promise is settled from the script's exit status:
+
+- **Exit `0`** — the promise resolves with the script's `stdout` (trimmed of trailing whitespace) as the resolved value.
+- **Exit non-zero** — the promise rejects. The rejection reason is the script's `stderr` if non-empty, otherwise the literal string `exit code N`.
+
+A failure to spawn `bash`, a missing named script, or malformed `param.data` (e.g. non-array JSON for a named script) all cause the promise to reject with a descriptive reason.
+
+While the script runs, the server refreshes the task lease at one third of `tasks.lease_timeout` so long-running scripts don't lose their lease.
+
+## Kafka
 
 **Not available in v0.9.5.** Kafka transport support is planned for a future release. The Kafka SDK plugin ([resonatehq/resonate-transport-kafka-ts](https://github.com/resonatehq/resonate-transport-kafka-ts)) exists for use with future server versions once server-side support is added.
 
-### SQS server plugin
+## SQS
 
 **Not available in v0.9.5.** AWS SQS transport support is planned for a future release.

--- a/content/docs/deploy/run-server.mdx
+++ b/content/docs/deploy/run-server.mdx
@@ -154,12 +154,34 @@ Run `resonate serve --help` for the full list. Common flags:
 | `--tasks-lease-timeout` | `15000` (ms) | Task lease timeout |
 | `--tasks-retry-timeout` | `30000` (ms) | Suspend/wake retry interval. Lower values (e.g. `500`) significantly reduce latency for chained or recursive workflows |
 | `--observability-metrics-port` | `9090` | Prometheus metrics port (`0` to disable) |
-| `--transports-gcps-project` | — | GCP Pub/Sub project ID for message transport |
 
 <Callout type="tip" title="tasks-retry-timeout">
 The default `--tasks-retry-timeout` of 30 seconds adds significant latency to chained workflows (sagas, recursive fan-out).
 For most deployments, set this to `500` (milliseconds) to keep suspend/wake cycles fast.
 </Callout>
+
+#### Transport flags
+
+v0.9.5 added explicit enable/disable flags for every transport so operators can shape which delivery paths are live per deployment. See [Message transports](/deploy/message-transports) for the per-transport behaviour.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--transports-http-push-enabled` | `true` | Enable the `http://` / `https://` push transport |
+| `--transports-http-poll-enabled` | `true` | Enable the SSE poll transport used by long-polling SDK clients |
+| `--transports-gcps-enabled` | `false` | Enable the `gcps://` GCP Pub/Sub transport |
+| `--transports-gcps-project` | — | Default GCP project ID for the Pub/Sub transport |
+| `--transports-bash-exec-enabled` | `false` | Enable the `bash:///` local-script transport (see [Bash exec](/deploy/message-transports#bash-exec)) |
+
+#### Outbound HTTP push authentication flags
+
+v0.9.5 added outbound authentication for HTTP push deliveries so workers behind authenticated endpoints (for example GCP Cloud Run with `--no-allow-unauthenticated`) can verify the server's identity. See [Outbound HTTP push authentication](/deploy/security#outbound-http-push-authentication) for the full configuration guide.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--transports-http-push-auth-mode` | `none` | Outbound auth mode: `none`, `bearer`, or `gcp` |
+| `--transports-http-push-auth-token` | — | Static bearer token (used only when `mode = bearer`) |
+| `--transports-http-push-auth-aud` | delivery target URL | Fixed OIDC audience (used only when `mode = gcp`; defaults to the per-delivery target URL) |
+| `--transports-http-push-auth-header` | `Authorization` | Name of the request header that carries the token |
 
 ## Run with PostgreSQL
 

--- a/content/docs/deploy/security.mdx
+++ b/content/docs/deploy/security.mdx
@@ -105,6 +105,85 @@ let resonate = Resonate::new(ResonateConfig {
 
 `ResonateConfig::token` is `Option<String>`, so `std::env::var("RESONATE_TOKEN").ok()` is the idiomatic way to populate it from the environment. `Resonate::new` returns `Resonate` directly (not a `Result`).
 
+## Outbound HTTP push authentication
+
+Inbound JWT auth (above) protects the server from unauthenticated SDK clients. The matching server-side concern is **outbound** authentication: when the server pushes a task to a worker URL via HTTP push, the worker may itself sit behind an authenticated endpoint (for example a GCP Cloud Run service deployed with `--no-allow-unauthenticated`, or any internal service that validates a bearer token).
+
+v0.9.5 introduced three outbound auth modes for the HTTP push transport. All three apply only to the `http://` / `https://` push transport — they do not affect Pub/Sub or bash exec deliveries.
+
+| Mode | What the server sends |
+|---|---|
+| `none` (default) | No `Authorization` header. Suitable for unauthenticated workers or networks with trust enforced at another layer. |
+| `bearer` | A static `Authorization: Bearer <token>` header on every delivery. The token is configured once and never refreshed. |
+| `gcp` | A GCP-issued OIDC ID token, minted per-audience using Application Default Credentials. Suitable for Cloud Run, Cloud Functions, and other GCP services that natively validate Google-signed ID tokens. |
+
+The mode is set with `--transports-http-push-auth-mode`, the matching `[transports.http_push.auth].mode` TOML key, or `RESONATE_TRANSPORTS__HTTP_PUSH__AUTH__MODE`.
+
+### Static bearer token
+
+Use this mode when every worker shares a single secret you control end-to-end (an internal service mesh, a self-hosted deployment with a shared HMAC).
+
+```toml title="resonate.toml"
+[transports.http_push.auth]
+mode = "bearer"
+# Token is typically supplied by env var rather than checked-in config:
+#   RESONATE_TRANSPORTS__HTTP_PUSH__AUTH__TOKEN=<token>
+```
+
+```shell title="CLI form"
+resonate serve \
+  --transports-http-push-auth-mode bearer \
+  --transports-http-push-auth-token "$RESONATE_PUSH_TOKEN"
+```
+
+The token is sent verbatim as `Authorization: Bearer <token>` on every push. It is never rotated by the server — rotation is your responsibility.
+
+### GCP OIDC ID token
+
+Use this mode when workers run on GCP and validate Google-signed ID tokens (Cloud Run, Cloud Functions, IAP-protected services, etc.). The server mints an ID token per audience using the GCP credentials available to the server process (Application Default Credentials).
+
+```toml title="resonate.toml"
+[transports.http_push.auth]
+mode = "gcp"
+# Optional: override the audience used when minting tokens. When absent,
+# each delivery target URL is used as its own audience.
+# audience = "https://workers.example.com"
+```
+
+```shell title="CLI form"
+resonate serve --transports-http-push-auth-mode gcp
+```
+
+Two notes on audience handling:
+
+- **Default** — if you do not set `audience`, the server uses each delivery target URL verbatim as the audience. This is the right setting for Cloud Run services where each worker validates tokens against its own URL.
+- **Override** — set `audience` (or `--transports-http-push-auth-aud`) when every worker validates against a single shared audience (for example an API gateway in front of multiple workers).
+
+Tokens are cached per audience inside the server process, so audience reuse across deliveries does not re-mint on every call.
+
+<Callout type="caution" title="Token-mint failures">
+If the GCP credentials provider fails to mint a token (missing ADC, network failure, IAM misconfiguration), the server logs a warning and **delivers the request without an `Authorization` header**. The delivery is not retried at the auth layer; the worker will reject the unauthenticated request and the standard task-retry path applies. Watch server logs for `OIDC ID token mint failed` to detect this state.
+</Callout>
+
+### Custom header name
+
+By default the token is sent in the `Authorization` header. Override with `--transports-http-push-auth-header` (or the matching TOML / env key) when the worker expects a different header — for example `X-Goog-IAP-JWT-Assertion` for some IAP setups:
+
+```shell
+resonate serve \
+  --transports-http-push-auth-mode gcp \
+  --transports-http-push-auth-header X-Goog-IAP-JWT-Assertion
+```
+
+### Quick reference
+
+| TOML key | CLI flag | Env var |
+|---|---|---|
+| `[transports.http_push.auth].mode` | `--transports-http-push-auth-mode` | `RESONATE_TRANSPORTS__HTTP_PUSH__AUTH__MODE` |
+| `[transports.http_push.auth].token` | `--transports-http-push-auth-token` | `RESONATE_TRANSPORTS__HTTP_PUSH__AUTH__TOKEN` |
+| `[transports.http_push.auth].audience` | `--transports-http-push-auth-aud` | `RESONATE_TRANSPORTS__HTTP_PUSH__AUTH__AUDIENCE` |
+| `[transports.http_push.auth].header` | `--transports-http-push-auth-header` | `RESONATE_TRANSPORTS__HTTP_PUSH__AUTH__HEADER` |
+
 ## Production best practices
 
 ### Token management

--- a/content/docs/get-started/examples/schedule.mdx
+++ b/content/docs/get-started/examples/schedule.mdx
@@ -83,7 +83,7 @@ resonate.stop();
 
 <TabItem value="python">
 
-<Callout type="warn" title="Python schedule API status">
+<Callout type="caution" title="Python schedule API status">
 The high-level `resonate.schedule(...)` shown below is **not yet available in `resonate-sdk` v0.6.7** (current PyPI release). For v0.6.7, use the lower-level `resonate.schedules.create(id, cron, promise_id, promise_timeout, ...)` API, which fires a fresh durable promise on each cron tick and lets a registered worker handle it. The high-level shape is on the Python SDK roadmap.
 </Callout>
 


### PR DESCRIPTION
## Summary

Documents three user-visible v0.9.5 server features that were either undocumented or only teaser-level after iter-46:

- **Bash exec transport** (server PR [#47](https://github.com/resonatehq/resonate/pull/47)) — full section in `message-transports.mdx` covering inline vs named-script address forms, the base64 / JSON-array `param.data` convention, the `RESONATE_PROMISE_ID` env var, working-dir options, and exit-status settle semantics. Includes a security caveat that the transport runs arbitrary shell as the server user.
- **Per-transport enable/disable flags** (server PR [#51](https://github.com/resonatehq/resonate/pull/51)) — new "Transport flags" subsection on `run-server.mdx` with the four `--transports-{name}-enabled` flags + defaults. The intro table on `message-transports.mdx` makes the per-transport enable/disable model the framing.
- **Outbound HTTP push auth** (server PR [#46](https://github.com/resonatehq/resonate/pull/46)) — new \`## Outbound HTTP push authentication\` section in `security.mdx` covering the three modes (`none` / `bearer` / `gcp`), GCP audience defaulting, custom header support, and the token-mint failure path (delivery proceeds unauthenticated, no retry at the auth layer). New "Outbound HTTP push authentication flags" subsection on `run-server.mdx` with the four flags.

## Source-of-truth verification

All assertions verified against `resonatehq/resonate@9a0d86c` (Cargo.toml `version = "0.9.5"`):

- `src/cli.rs:108-167` — 4 enable flags + 4 outbound auth flags + GCP project flag
- `src/transport/transport_exec_bash.rs` — full bash transport semantics (note canonical filename is `transport_exec_bash.rs`, not `transport_bash_exec.rs`)
- `src/transport/transport_http_push.rs:55-115` — `Auth` enum + token-mint failure path; mock-token tests at `:401-419` confirm the unauthenticated-fallback behavior
- `src/config.rs:330-486` — TOML schema for `[transports.bash_exec]` and `[transports.http_push.auth]`

## Iteration

This is the alignment loop's iter-54 (`asset-creation` type, `draft-pr` blast radius). Carries forward the v0.9.5-feature deferral from iter-46 and the explicit \"new feature docs\" out-of-scope item from iter-53.

## Test plan

- [ ] Cully reads the bash exec section and confirms it matches his mental model of how he wants users to think about the transport (security caveat + named scripts > inline)
- [ ] Cully sanity-checks the outbound HTTP push auth narrative — particularly the GCP-audience-defaulting framing and the token-mint failure callout
- [ ] Local docs build (`npm run dev`) renders the three pages without MDX errors
- [ ] Anchor links resolve: `/deploy/run-server#cli-flags`, `/deploy/message-transports#bash-exec`, `/deploy/security#outbound-http-push-authentication`

🤖 Generated with [Claude Code](https://claude.com/claude-code)