### PR TITLE
docs(deploy): document CORS support (server v0.9.4 / v0.9.5)

### DIFF
--- a/content/docs/deploy/run-server.mdx
+++ b/content/docs/deploy/run-server.mdx
@@ -151,6 +151,7 @@ Run `resonate serve --help` for the full list. Common flags:
 | `--storage-postgres-url` | — | Postgres connection string |
 | `--storage-postgres-pool-size` | `10` | Postgres connection pool size |
 | `--auth-publickey` | — | Path to JWT public key (PEM format) for authentication |
+| `--server-cors-allow-origin` | — | Allowed CORS origin (repeatable; use `*` for permissive). See [Security › CORS](/deploy/security#cors-cross-origin-resource-sharing) |
 | `--tasks-lease-timeout` | `15000` (ms) | Task lease timeout |
 | `--tasks-retry-timeout` | `30000` (ms) | Suspend/wake retry interval. Lower values (e.g. `500`) significantly reduce latency for chained or recursive workflows |
 | `--observability-metrics-port` | `9090` | Prometheus metrics port (`0` to disable) |

--- a/content/docs/deploy/security.mdx
+++ b/content/docs/deploy/security.mdx
@@ -105,6 +105,73 @@ let resonate = Resonate::new(ResonateConfig {
 
 `ResonateConfig::token` is `Option<String>`, so `std::env::var("RESONATE_TOKEN").ok()` is the idiomatic way to populate it from the environment. `Resonate::new` returns `Resonate` directly (not a `Result`).
 
+## CORS (Cross-Origin Resource Sharing)
+
+Browser-based clients — SDK applications running in a tab, internal dashboards, agent UIs — need CORS headers to call the Resonate Server from a different origin. CORS is **disabled by default**; the server only emits CORS headers when you configure one or more allowed origins.
+
+### Why CORS matters
+
+If your server is at `https://resonate.yourcompany.com` and your client runs at `https://app.example.com`, the browser will block the request unless the server returns the appropriate `Access-Control-Allow-Origin` headers. CORS configuration covers the HTTP API and the long-poll/SSE delivery endpoint together — both are served from the same router.
+
+Server-to-server traffic (workers calling the API from a backend process) is not affected by CORS. Configure it only if a browser is in the request path.
+
+### Server configuration
+
+Configure allowed origins in `resonate.toml`:
+
+```toml title="resonate.toml — CORS"
+[server.cors]
+allow_origins = ["https://app.example.com"]
+```
+
+Or via environment variable:
+
+```bash title="Environment variable"
+RESONATE_SERVER__CORS__ALLOW_ORIGINS=https://app.example.com
+```
+
+Or via repeatable CLI flag:
+
+```bash title="CLI flags"
+resonate serve \
+  --server-cors-allow-origin https://app.example.com \
+  --server-cors-allow-origin https://admin.example.com
+```
+
+### Behavior
+
+| Configuration | Result |
+|---|---|
+| `allow_origins` empty (default) | No CORS headers emitted; browser cross-origin requests are blocked. |
+| `allow_origins = ["https://app.example.com", ...]` | Server reflects the request `Origin` header only when it matches an entry in the list. |
+| `allow_origins = ["*"]` | Permissive mode: any origin is accepted, and `Access-Control-Allow-Credentials: true` is also set. |
+
+Allowed methods: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`.
+Allowed request headers: `Origin`, `Content-Length`, `Content-Type`, `Authorization`.
+
+Preflight `OPTIONS` requests are handled by the server automatically — no additional configuration required.
+
+<Callout type="caution" title="Wildcard origins and credentials">
+Setting `allow_origins = ["*"]` enables permissive mode, which also sends `Access-Control-Allow-Credentials: true`. This combination is broadly accepting and should generally be reserved for development. For production, list each trusted origin explicitly.
+</Callout>
+
+### Example: production with explicit origins
+
+```toml title="resonate.toml — production"
+[auth]
+publickey = "/etc/resonate/auth/public.pem"
+
+[server.cors]
+allow_origins = [
+  "https://app.example.com",
+  "https://admin.example.com",
+]
+```
+
+Combined with JWT authentication, this restricts the server to a known set of browser origins while still requiring a valid token on every request.
+
+CORS support was introduced in Resonate Server v0.9.4.
+
 ## Outbound HTTP push authentication
 
 Inbound JWT auth (above) protects the server from unauthenticated SDK clients. The matching server-side concern is **outbound** authentication: when the server pushes a task to a worker URL via HTTP push, the worker may itself sit behind an authenticated endpoint (for example a GCP Cloud Run service deployed with `--no-allow-unauthenticated`, or any internal service that validates a bearer token).


### PR DESCRIPTION
## Summary
Adds docs for CORS support shipped in Resonate Server v0.9.4 (PR resonatehq/resonate#42).

- Landing pages:
  - `content/docs/deploy/security.mdx` — new `## CORS (Cross-Origin Resource Sharing)` section (~67 lines) before "Production best practices"
  - `content/docs/deploy/run-server.mdx` — adds `--server-cors-allow-origin` row to the CLI flags table
- Source PR: https://github.com/resonatehq/resonate/pull/42
- API surface documented: `--server-cors-allow-origin` CLI flag (repeatable); `[server.cors] allow_origins` TOML; `RESONATE_SERVER__CORS__ALLOW_ORIGINS` env var
- Verified against v0.9.5 source:
  - `src/cli.rs:46-49` — flag definition
  - `src/config.rs:64-95` — `[server.cors]` / `CorsConfig`
  - `src/main.rs:439-463` — `build_cors_layer()` behaviour (empty = no headers, `*` = permissive with credentials, list = origin-reflection)

## Asset-creation iteration
Part of the iter-55 asset-creation batch (CORS / MySQL persistence / TS SDK non-retryable errors). Sibling PRs:
- https://github.com/resonatehq/docs.resonatehq.io/pull/190 (MySQL persistence)
- https://github.com/resonatehq/docs.resonatehq.io/pull/191 (TS SDK non-retryable errors)

## Test plan
- [ ] Site builds clean (`npm run build` from repo root) — verified locally; `/deploy/security` builds. The pre-existing `/get-started/examples/schedule` prerender error is present on `main` and unrelated.
- [ ] CLI flag and TOML key match v0.9.5 source (cited above)
- [ ] Eval-set candidates drafted for next maintenance iteration

Generated with Claude Code (https://claude.com/claude-code)
