### PR TITLE
docs(sdk-ts): document non-retryable errors (v0.10.1)

### DIFF
--- a/content/docs/develop/typescript.mdx
+++ b/content/docs/develop/typescript.mdx
@@ -399,6 +399,22 @@ await resonate.run(
 );
 ```
 
+Local calls (`.run()` / `.beginRun()`) also accept `nonRetryableErrors`, an array of error class constructors that should not be retried by Resonate's retry policy.
+When the invoked function throws an instance of any listed class (or a subclass), Resonate skips the retry policy and rejects the call with the thrown error.
+
+```ts
+class ValidationError extends Error {}
+
+await resonate.run(
+  "invocation-id",
+  foo,
+  ...args,
+  resonate.options({
+    nonRetryableErrors: [ValidationError],
+  })
+);
+```
+
 ### `.get()`
 
 Resonate's `.get()` method allows you to subscribe to a function invocation.
@@ -633,6 +649,30 @@ resonate.register("foo", function* (ctx: Context, ...args: any[]) {
     })
   );
 });
+```
+
+Local calls (`.run()` / `.beginRun()`) also accept `nonRetryableErrors`, an array of error class constructors that should not be retried by Resonate's retry policy.
+When the invoked function throws an instance of any listed class (or a subclass), Resonate skips the retry policy and rejects the call with the thrown error.
+This pairs well with `retryPolicy`: errors that match `nonRetryableErrors` short-circuit retries, while all other errors still follow the configured policy.
+
+```ts
+class ValidationError extends Error {}
+
+resonate.register("foo", function* (ctx: Context, input: unknown) {
+  yield* ctx.run(
+    validate,
+    input,
+    ctx.options({
+      nonRetryableErrors: [ValidationError],
+    })
+  );
+});
+
+function validate(ctx: Context, input: unknown) {
+  if (!isValid(input)) {
+    throw new ValidationError("input failed validation");
+  }
+}
 ```
 
 ### `.promise()`


### PR DESCRIPTION
## Summary
Documents non-retryable errors for `@resonatehq/sdk` v0.10.1 (introduced PR resonatehq/resonate-sdk-ts#501).

- Landing page: `content/docs/develop/typescript.mdx`
- Source PR: https://github.com/resonatehq/resonate-sdk-ts/pull/501
- API surface documented: `nonRetryableErrors` option on `.options()` (array of error class constructors), available on local calls (`.run()` / `.beginRun()`) for both the Client and Context APIs.
- Verified against: `src/options.ts:43` (`nonRetryableErrors: Array<new (...args: any[]) => Error>`), `src/context.ts:587` (option exposed on `.options()` builder), `src/util.ts:141` (`instanceof` check that short-circuits the retry policy), and the v0.10.1 test cases at `tests/resonate.test.ts:1386` and `tests/util.test.ts:170`.

## Asset-creation iteration
Part of the iter-55 asset-creation batch (CORS / MySQL persistence / TS SDK non-retryable errors). Sibling PRs:
- https://github.com/resonatehq/docs.resonatehq.io/pull/189 (CORS support)
- https://github.com/resonatehq/docs.resonatehq.io/pull/190 (MySQL persistence)

## Test plan
- [ ] Site builds clean (`npm run build`)
- [ ] API surface matches v0.10.1 source
- [ ] Worked example typechecks against `@resonatehq/sdk@0.10.1`
- [ ] Eval-set candidates drafted for next maintenance iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
