### PR TITLE
docs(develop,deploy): promise-count constraint + serverless ttl gotcha

### DIFF
--- a/content/docs/deploy/serverless-workers.mdx
+++ b/content/docs/deploy/serverless-workers.mdx
@@ -125,3 +125,49 @@ Ready to use example apps:
 
 - [Durable Counter with Supabase Edge Functions | TypeScript](https://github.com/resonatehq-examples/example-countdown-supabase-ts)
 - [Deep Research Agent with Supabase Edge Functions | TypeScript](https://github.com/resonatehq-examples/example-openai-deep-research-agent-supabase-ts)
+
+## Serverless-specific constraints
+
+Serverless workers run inside platform-imposed invocation timeouts. Resonate's acquired-task lease (`ttl`) interacts with that timeout: the lease is the window the server gives the worker to make progress on a task before it considers the task abandoned and reassigns it. Workflows that accumulate many promises in a single root will eventually fail to replay within the lease, even if individual steps are fast.
+
+### Platform timeouts
+
+| Platform | Max invocation timeout | Notes |
+|---|---|---|
+| AWS Lambda | 15 min | Check `@resonatehq/aws` for default `ttl` |
+| Google Cloud Functions Gen 2 | 9 min (540s) | `@resonatehq/gcp` defaults `ttl` to 5 min — bump to 10 min so the lease always exceeds the function timeout |
+| Google Cloud Run | 60 min | Check `@resonatehq/gcp` for default `ttl` |
+| Cloudflare Workers | varies (CPU-time vs wall-clock differ by plan) | See [Cloudflare Workers limits](https://developers.cloudflare.com/workers/platform/limits/) |
+| Supabase Edge Functions | varies | See [Supabase Edge Functions limits](https://supabase.com/docs/guides/functions/limits) |
+
+<Callout type="warning" title="Avoid forever loops in a single durable invocation">
+A workflow that loops forever inside one root promise — `while(true) { doWork() }` — accumulates child promises with every iteration. After thousands of iterations (10k+ in practice), replay duration exceeds the acquired-task lease, the server emits error code `1199 — Task is not acquired` and reassigns the task mid-execution, and cadence collapses. The longer the workflow runs, the worse it gets.
+</Callout>
+
+### The fix: recursive tail call with `ctx.detached`
+
+Have the per-iteration function play exactly *one* iteration, and as its **last yield**, spawn the next iteration as a brand-new root via `ctx.detached`. The current invocation returns; the next invocation starts with a fresh origin id and an empty history.
+
+```typescript
+function* playGame(ctx: Context, n: number) {
+  // ...play exactly one game (ctx.run, ctx.sleep, etc.)...
+  yield* ctx.detached(playGame, n + 1); // ✅ last yield, fresh root, bounded replay
+}
+```
+
+The split must happen *inside* the per-iteration function. A parent loop that calls `ctx.detached` repeatedly — `for (;;) yield* ctx.detached(work, n)` — still records each call in the parent's history, reproducing the bug on the parent. See [Bound the promise count of a single execution](/develop/constraints#bound-the-promise-count-of-a-single-execution) for the full explanation.
+
+### Configuring `ttl`
+
+The shim `Resonate` constructor accepts a `ttl` option (milliseconds):
+
+```typescript
+import { Resonate } from "@resonatehq/gcp";
+
+const resonate = new Resonate({ ttl: 10 * 60 * 1000 }); // 10 min
+```
+
+`ttl` should exceed the platform's max invocation timeout. The lease tells the server how long to wait before assuming the worker is dead. If `ttl` is shorter than the platform timeout, the server may reassign the task to a fresh invocation while the original is still legitimately running, leading to mid-execution task reassignment (error code 1199) and duplicate work.
+
+**See also:**
+- [Bound the promise count of a single execution](/develop/constraints#bound-the-promise-count-of-a-single-execution)

--- a/content/docs/deploy/serverless-workers.mdx
+++ b/content/docs/deploy/serverless-workers.mdx
@@ -140,7 +140,7 @@ Serverless workers run inside platform-imposed invocation timeouts. Resonate's a
 | Cloudflare Workers | varies (CPU-time vs wall-clock differ by plan) | See [Cloudflare Workers limits](https://developers.cloudflare.com/workers/platform/limits/) |
 | Supabase Edge Functions | varies | See [Supabase Edge Functions limits](https://supabase.com/docs/guides/functions/limits) |
 
-<Callout type="warning" title="Avoid forever loops in a single durable invocation">
+<Callout type="caution" title="Avoid forever loops in a single durable invocation">
 A workflow that loops forever inside one root promise — `while(true) { doWork() }` — accumulates child promises with every iteration. After thousands of iterations (10k+ in practice), replay duration exceeds the acquired-task lease, the server emits error code `1199 — Task is not acquired` and reassigns the task mid-execution, and cadence collapses. The longer the workflow runs, the worse it gets.
 </Callout>
 

--- a/content/docs/develop/constraints.mdx
+++ b/content/docs/develop/constraints.mdx
@@ -471,7 +471,7 @@ function* playGame(ctx: Context, n: number) {
 }
 ```
 
-<Callout type="warning" title="The split must happen *inside* the per-iteration function">
+<Callout type="caution" title="The split must happen *inside* the per-iteration function">
 A parent loop that calls `ctx.detached` repeatedly — `for (;;) yield* ctx.detached(work, n)` — still records each call in the parent's history, reproducing the same accumulation problem on the parent. The recursive-tail shape (per-iteration function spawns its own successor as the last yield, then returns) is what bounds replay scope.
 </Callout>
 

--- a/content/docs/develop/constraints.mdx
+++ b/content/docs/develop/constraints.mdx
@@ -9,13 +9,14 @@ keywords:
 
 Resonate enables you to write distributed applications that survive failures and restarts, but this power comes with a few important rules you need to follow. This page explains what those rules are and, more importantly, **why they exist**.
 
-## The three rules
+## The four rules
 
 When writing durable functions with Resonate, you must follow these constraints:
 
 1. **Functions must be deterministic** - Same inputs always produce the same outputs
 2. **Functions must be idempotent** - Safe to retry multiple times
 3. **Activations cannot outlive the process** - Long-running work needs Resonate primitives
+4. **Bound the promise count of a single execution** - Replay cost scales with accumulated child promises
 
 Let's explore each one.
 
@@ -431,6 +432,60 @@ For work that takes hours, days, or weeks, use `ctx.sleep()` or Durable Promises
 
 ---
 
+## Bound the promise count of a single execution
+
+### What does this mean?
+
+Replay duration grows with the count of executed promises in a single root invocation. On cold-start, every prior step is replayed before the next can proceed.
+
+Each `ctx.run()`, `ctx.rpc()`, `ctx.sleep()`, or other Context call inside a root invocation adds one promise to that root's history. When the worker restarts (deploy, scale-down, crash, task reassignment), Resonate replays the function from the beginning, walking every recorded promise to reconstruct state. The more promises accumulated under a single root, the longer replay takes.
+
+### When this becomes a problem
+
+Workflows that loop indefinitely or accumulate many child promises within a single root.
+
+On serverless platforms with fixed acquired-task leases (e.g., `@resonatehq/gcp` default `ttl` = 5 min), replay duration eventually exceeds the lease, the server reassigns the task mid-execution (error code `1199 — Task is not acquired`), and cadence collapses.
+
+❌ **Single root accumulates children forever**
+
+```typescript
+function* playGame(ctx: Context, n: number) {
+  while (true) {                                  // ⚠️ one durable invocation forever
+    // ...play one game (ctx.run, ctx.sleep, etc.)...
+    // every yield adds a child promise to this root's history;
+    // after thousands of iterations, replay > task lease
+  }
+}
+```
+
+### The solution: Recursive tail call with `ctx.detached`
+
+Have the per-iteration function play exactly *one* iteration, and as its **last yield**, spawn the next iteration as a brand-new root via `ctx.detached`. The current invocation returns; the next invocation starts with a fresh origin id and an empty history.
+
+✅ **Each invocation = one iteration, replay scope bounded**
+
+```typescript
+function* playGame(ctx: Context, n: number) {
+  // ...play exactly one game (ctx.run, ctx.sleep, etc.)...
+  yield* ctx.detached(playGame, n + 1); // ✅ last yield, fresh root, bounded replay
+}
+```
+
+<Callout type="warning" title="The split must happen *inside* the per-iteration function">
+A parent loop that calls `ctx.detached` repeatedly — `for (;;) yield* ctx.detached(work, n)` — still records each call in the parent's history, reproducing the same accumulation problem on the parent. The recursive-tail shape (per-iteration function spawns its own successor as the last yield, then returns) is what bounds replay scope.
+</Callout>
+
+The same pattern applies to any forever-running workflow: poll loops, monitoring agents, recurring jobs, demo loops. The per-iteration function plays one iteration, then `yield* ctx.detached(self, next)` as its final yield.
+
+<Callout type="tip" title="One iteration = one root">
+If a workflow loops indefinitely or accumulates many child promises, split iterations with `ctx.detached()`. Each iteration gets a fresh root and a bounded replay scope, regardless of how long the overall workflow runs.
+</Callout>
+
+**See also:**
+- [Serverless-specific constraints](/deploy/serverless-workers#serverless-specific-constraints)
+
+---
+
 ## Summary
 
 | Constraint | Why it exists | Solution |
@@ -438,6 +493,7 @@ For work that takes hours, days, or weeks, use `ctx.sleep()` or Durable Promises
 | **Deterministic** | Functions are replayed on restart - must produce same results | Use `ctx.math.random()`, `ctx.date.now()`, `ctx.run()` |
 | **Idempotent** | Functions are retried on failure - must be safe to repeat | Use idempotency keys, upserts, deduplication checks |
 | **Process lifetime** | Activations end when process ends - can't outlive it | Use `ctx.sleep()`, Durable Promises for long-running work |
+| **Bounded promise count** | Replay walks all prior promises - cost scales linearly | Use `ctx.detached()` for forever-loop iterations |
 
 Following these rules ensures your distributed application survives process crashes and restarts, retries safely without duplicating work, and handles long-running workflows spanning hours or days.
 


### PR DESCRIPTION
## Summary
- Adds a fourth durable-function constraint: **Bound the promise count of a single execution** to `develop/constraints.mdx` (replay duration scales with accumulated promises; on serverless this hits the acquired-task lease and collapses cadence)
- Adds a **Serverless-specific constraints** section to `deploy/serverless-workers.mdx` with platform timeout table, the `while(true)` warning, the recursive-tail fix, and `ttl` configuration
- Both pages teach the canonical recursive-tail pattern with `ctx.detached` and explicitly call out the parent-loop variant as an anti-pattern that reproduces the bug

## Why
Motivated by the chess-hero-server slow-burn collapse on 2026-05-05. After 8 days of `while(true) { playGame() }` inside a single durable invocation, ~10k accumulated child promises caused cold-start replay to exceed the `@resonatehq/gcp` default 5-min `ttl` on Cloud Functions. Server reassigned tasks mid-execution (error code 1199); cadence collapsed from 4.5s/move to 13–22 min/move.

The fix: https://github.com/resonatehq/chess-hero-server/commit/68eddff — refactor `playGame` to play one game, `yield* ctx.detached(playGame, n + 1)` as last yield. Each game is its own root, replay scope bounded.

Currently no doc surface teaches this pattern. The `ctx.detached` reference frames it as fire-and-forget; nothing names replay cost as a function of promise count; serverless guidance has no gotchas at all.

## Test plan
- [ ] Cross-links resolve: `/develop/constraints#bound-the-promise-count-of-a-single-execution` ↔ `/deploy/serverless-workers#serverless-specific-constraints`
- [ ] Tone matches existing constraints page (❌/✅, Callouts, See also blocks)
- [ ] Platform table is honest about what's verified vs needs checking
- [ ] Code examples use the recursive-tail shape (not parent-loop)

Companion PR on SDK: resonatehq/resonate-sdk-ts#521 (JSDoc on `Context#detached`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)