### PR TITLE
docs(kafka): fix message-id sample + sharpen plugin warning

### DIFF
--- a/content/docs/deploy/kafka.mdx
+++ b/content/docs/deploy/kafka.mdx
@@ -15,7 +15,7 @@ Resonate does not ship a native Kafka transport in the current server. The suppo
 
 ## The Kafka worker pattern
 
-Use a regular Kafka consumer (`kafkajs`, `confluent-kafka-python`, `rdkafka`, etc.) and call `beginRun` on each message. The Kafka message ID becomes the Resonate promise ID, so the dispatch is idempotent — duplicate deliveries reconnect to the in-flight execution rather than starting over.
+Use a regular Kafka consumer (`kafkajs`, `confluent-kafka-python`, `rdkafka`, etc.) and call `beginRun` on each message. A stable per-message identifier becomes the Resonate promise ID, so the dispatch is idempotent — duplicate deliveries reconnect to the in-flight execution rather than starting over.
 
 ```ts title="src/consumer.ts"
 import { Kafka } from "kafkajs";
@@ -28,12 +28,15 @@ await consumer.connect();
 await consumer.subscribe({ topic: "records_to_process", fromBeginning: true });
 
 await consumer.run({
-  eachMessage: async ({ message }) => {
-    const messageId = message.key!.toString("utf-8");
+  eachMessage: async ({ topic, partition, message }) => {
+    // topic-partition-offset uniquely identifies the message even when no key is set
+    const messageId = `${topic}-${partition}-${message.offset}`;
     await resonate.beginRun(messageId, "workflow", messageId, message.offset);
   },
 });
 ```
+
+If your producer sets a stable message key (or your payload carries a domain ID like a record UUID), that's also a valid promise ID — the only requirement is that the same logical message always resolves to the same string.
 
 Full TypeScript / Python / Rust walkthroughs and runnable repos are on the [Kafka worker example page](/get-started/examples/kafka-worker). Source repos:
 
@@ -43,7 +46,7 @@ Full TypeScript / Python / Rust walkthroughs and runnable repos are on the [Kafk
 
 ## Idempotent dispatch
 
-Every Kafka message carries a stable identifier — usually the message key, optionally combined with topic and partition. Pass that identifier as the Resonate promise ID:
+Every Kafka message has a stable identifier you can derive from its coordinates: `${topic}-${partition}-${offset}` is unique by construction, and a producer-supplied key (or a domain ID inside the payload) works equally well when present. Pass that identifier as the Resonate promise ID:
 
 ```ts
 await resonate.beginRun(messageId, "workflow", ...args);

--- a/content/docs/deploy/message-transports.mdx
+++ b/content/docs/deploy/message-transports.mdx
@@ -130,6 +130,10 @@ The transports below are specified in the [Message Passing Protocol](/spec/execu
 
 ### Kafka
 
+<Callout type="caution" title="Heads up: @resonatehq/kafka NPM plugin is legacy">
+The published `@resonatehq/kafka` NPM plugin (v0.1.x) targets the **legacy Go-based** Resonate Server. It does **not** work with the current Rust server (v0.9.x). Use the [Kafka worker pattern](/deploy/kafka) today; native `kafka://` transport is on the roadmap below.
+</Callout>
+
 **Not available in the current server.** Native `kafka://` transport is on the roadmap.
 
 For Kafka integration today, use a normal Kafka consumer to dispatch a Resonate workflow per message — see the [Kafka integration guide](/deploy/kafka) and the [Kafka worker example](/get-started/examples/kafka-worker).

--- a/content/docs/develop/typescript.mdx
+++ b/content/docs/develop/typescript.mdx
@@ -164,7 +164,9 @@ See [Message transports](/deploy/message-transports) for the transports the curr
 
 ### Consuming Kafka with Resonate
 
-There is no native Kafka transport in the current server. The supported pattern is a normal Kafka consumer that dispatches a Resonate workflow per message — the message ID becomes the durable promise ID, so duplicate deliveries reconnect to the in-flight execution rather than starting over.
+**Example: Kafka worker.** Kafka is the most common message-broker integration ask, so we ship a complete reference implementation. The pattern below works for any message broker — substitute your client library, keep the `resonate.beginRun(messageId, "workflow", ...)` shape.
+
+There is no native Kafka transport in the current server. The supported pattern is a normal Kafka consumer that dispatches a Resonate workflow per message — a stable per-message identifier becomes the durable promise ID, so duplicate deliveries reconnect to the in-flight execution rather than starting over.
 
 ```ts title="src/consumer.ts"
 import { Kafka } from "kafkajs";
@@ -177,15 +179,20 @@ await consumer.connect();
 await consumer.subscribe({ topic: "records_to_process", fromBeginning: true });
 
 await consumer.run({
-  eachMessage: async ({ message }) => {
-    const messageId = message.key!.toString("utf-8");
+  eachMessage: async ({ topic, partition, message }) => {
+    // topic-partition-offset uniquely identifies the message even when no key is set
+    const messageId = `${topic}-${partition}-${message.offset}`;
     // messageId is the durable promise id — duplicate invocations dedupe.
     await resonate.beginRun(messageId, "workflow", messageId, message.offset);
   },
 });
 ```
 
-The full example, with the workflow definition and a runnable Redpanda compose file, lives at [resonatehq-examples/example-kafka-worker-ts](https://github.com/resonatehq-examples/example-kafka-worker-ts) — see also the [Kafka worker example page](/get-started/examples/kafka-worker) for a side-by-side TypeScript / Python / Rust walkthrough and the [Kafka integration guide](/deploy/kafka).
+If your producer sets a stable message key (or your payload carries a domain ID), that's an equally valid promise ID — pick whichever uniquely identifies the logical message.
+
+The full example, with the workflow definition and a runnable Redpanda compose file, lives at [resonatehq-examples/example-kafka-worker-ts](https://github.com/resonatehq-examples/example-kafka-worker-ts) — see also the [Kafka worker example page](/get-started/examples/kafka-worker) for a side-by-side TypeScript / Python / Rust walkthrough.
+
+→ Full guide: [Kafka integration](/deploy/kafka)
 
 <Callout type="info" title="Roadmap">
 Native `kafka://` transport is specified in the [Message Passing Protocol](/spec/execution-model/message-passing#address-schemes) and on the roadmap. This page will gain a transport-plugin section once it ships.


### PR DESCRIPTION
Two reviewers (accuracy + helpfulness) audited the Kafka docs work in #194. This PR addresses one P1 (broken code sample) and two P2 nits.

## Fix 1 (P1) — message-id sample matches the example repo

`content/docs/develop/typescript.mdx:181` and `content/docs/deploy/kafka.mdx:32` both used `message.key!.toString("utf-8")`. The reference example's producer (`example-kafka-worker-ts/src/producer.ts:26`) sends `{ value: JSON.stringify(id) }` with **no key field**, so a developer copying the docs against the example repo gets `TypeError: Cannot read properties of null`.

The example repo's actual `consumer.ts` parses the UUID out of `JSON.parse(message.value)` — awkward to explain in a snippet. So both docs files now use `${topic}-${partition}-${offset}`, a canonical Kafka message identifier that works regardless of whether messages have keys, with a one-line code comment and a prose note that a producer-set key or domain ID is also valid.

The example repo uses a JSON-encoded UUID as the promise ID; the docs sample now uses topic-partition-offset, which is provably-unique by construction and degrades gracefully against any producer (including the example's keyless one).

## Fix 2 (P2) — frame why Kafka gets a code example

`content/docs/develop/typescript.mdx` Kafka subsection now opens with a one-paragraph framing intro ("Kafka is the most common message-broker integration ask, so we ship a complete reference implementation. The pattern below works for any message broker — substitute your client library, keep the `resonate.beginRun(messageId, "workflow", ...)` shape.") and ends with a "Full guide → [Kafka integration](/deploy/kafka)" link, answering a skimming reader's "why does Kafka get a code example when SQS/RabbitMQ/NATS don't?"

## Fix 3 (P2) — legacy-plugin warning gets a callout

`content/docs/deploy/message-transports.mdx` Planned/Kafka subsection now leads with a `<Callout type="caution">` flagging the `@resonatehq/kafka` v0.1.x → legacy-Go-server mismatch, so users who Google the plugin name and land on this page see the warning before reading the rest. The detailed prose paragraph is preserved below.

## Test plan

- [x] `npm run build` clean — 70 static pages generated, 0 internal broken links across 450 checked
- [x] All affected internal links resolve: `/deploy/kafka`, `/deploy/message-transports#planned`, `/get-started/examples/kafka-worker`, `/spec/execution-model/message-passing#address-schemes`
- [x] `example-kafka-worker-ts` GitHub link still resolves
- [x] No other Kafka mentions in the docs corpus contradict the new framing
- [x] `public/llms-full.txt` and `public/llms.txt` deliberately not committed (postbuild regenerates them; previous PR flagged a gitleaks issue with that regenerated file)