### PR TITLE
Add cross-SDK defaults reference page + inline blocks

### DIFF
--- a/content/docs/deploy/run-server.mdx
+++ b/content/docs/deploy/run-server.mdx
@@ -58,7 +58,7 @@ docker run --rm -p 8001:8001 -p 9090:9090 resonatehqio/resonate:v0.9.5
 ```shell title="Use Postgres storage"
 docker run --rm -p 8001:8001 -p 9090:9090 \
   -e RESONATE_STORAGE__TYPE=postgres \
-  -e RESONATE_STORAGE__POSTGRES__URL="postgres://user:pass@host:5432/resonate" \
+  -e RESONATE_STORAGE__POSTGRES__URL="postgres://<USER>:<PASSWORD>@host:5432/resonate" \
   resonatehqio/resonate:v0.9.5
 ```
 
@@ -102,7 +102,7 @@ For Postgres, swap the `[storage]` section:
 type = "postgres"
 
 [storage.postgres]
-url = "postgres://user:pass@host:5432/resonate"
+url = "postgres://<USER>:<PASSWORD>@host:5432/resonate"
 pool_size = 20
 ```
 
@@ -132,7 +132,7 @@ Every config field is also reachable as an environment variable. The convention 
 RESONATE_LEVEL=info
 RESONATE_SERVER__PORT=8001
 RESONATE_STORAGE__TYPE=postgres
-RESONATE_STORAGE__POSTGRES__URL=postgres://user:pass@host:5432/resonate
+RESONATE_STORAGE__POSTGRES__URL=postgres://<USER>:<PASSWORD>@host:5432/resonate
 RESONATE_AUTH__PUBLICKEY=/etc/resonate/auth/public.pem
 ```
 
@@ -145,7 +145,7 @@ Most settings can also be passed as CLI flags — useful for ad-hoc overrides:
 ```shell
 resonate serve \
   --storage-type postgres \
-  --storage-postgres-url "postgres://user:pass@localhost:5432/resonate" \
+  --storage-postgres-url "postgres://<USER>:<PASSWORD>@localhost:5432/resonate" \
   --storage-postgres-pool-size 20
 ```
 
@@ -208,7 +208,7 @@ With a `resonate.toml` (recommended):
 type = "postgres"
 
 [storage.postgres]
-url = "postgres://user:pass@localhost:5432/resonate"
+url = "postgres://<USER>:<PASSWORD>@localhost:5432/resonate"
 pool_size = 20
 ```
 
@@ -217,7 +217,7 @@ Or with CLI flags:
 ```shell
 resonate serve \
   --storage-type postgres \
-  --storage-postgres-url "postgres://user:pass@localhost:5432/resonate" \
+  --storage-postgres-url "postgres://<USER>:<PASSWORD>@localhost:5432/resonate" \
   --storage-postgres-pool-size 20
 ```
 
@@ -418,6 +418,23 @@ cd resonate
 cargo build --release
 ./target/release/resonate serve
 ```
+
+## Defaults
+
+The most commonly referenced server defaults:
+
+- **HTTP API port** — `8001` (`--server-port`)
+- **Bind address** — `0.0.0.0` (`--server-bind`); host advertised as `localhost`
+- **Storage backend** — `sqlite` at `resonate.db`
+- **`--tasks-lease-timeout`** — `15_000 ms`
+- **`--tasks-retry-timeout`** — `30_000 ms` (lower to `500 ms` for chained / recursive workflows)
+- **Prometheus metrics port** — `9090` (`0` disables)
+- **Log level** — `info`
+- **Postgres / MySQL pool size** — `10`
+- **`--transports-http-push-enabled` / `--transports-http-poll-enabled`** — `true`
+- **`--transports-gcps-enabled` / `--transports-bash-exec-enabled`** — `false`
+
+These mirror the operator surface above; the canonical cross-component reference (including SDK init, `ctx.run`, retry policy, and env-var defaults) is the [Defaults reference](/reference/defaults).
 
 ## Ports
 

--- a/content/docs/deploy/run-server.mdx
+++ b/content/docs/deploy/run-server.mdx
@@ -113,7 +113,7 @@ For MySQL, the equivalent block is:
 type = "mysql"
 
 [storage.mysql]
-url = "mysql://user:pass@host:3306/resonate"
+url = "mysql://<USER>:<PASSWORD>@host:3306/resonate"
 pool_size = 20
 ```
 
@@ -236,7 +236,7 @@ With a `resonate.toml` (recommended):
 type = "mysql"
 
 [storage.mysql]
-url = "mysql://user:pass@localhost:3306/resonate"
+url = "mysql://<USER>:<PASSWORD>@localhost:3306/resonate"
 pool_size = 20
 ```
 
@@ -245,7 +245,7 @@ Or with CLI flags:
 ```shell
 resonate serve \
   --storage-type mysql \
-  --storage-mysql-url "mysql://user:pass@localhost:3306/resonate" \
+  --storage-mysql-url "mysql://<USER>:<PASSWORD>@localhost:3306/resonate" \
   --storage-mysql-pool-size 20
 ```
 
@@ -253,7 +253,7 @@ Or with environment variables:
 
 ```shell
 RESONATE_STORAGE__TYPE=mysql
-RESONATE_STORAGE__MYSQL__URL=mysql://user:pass@localhost:3306/resonate
+RESONATE_STORAGE__MYSQL__URL=mysql://<USER>:<PASSWORD>@localhost:3306/resonate
 RESONATE_STORAGE__MYSQL__POOL_SIZE=20
 ```
 

--- a/content/docs/develop/constraints.mdx
+++ b/content/docs/develop/constraints.mdx
@@ -296,6 +296,18 @@ This means if you use Resonate's APIs correctly, **you don't have to manually ch
 When you call operations through `ctx.run()` or `ctx.rpc()`, Resonate generates promise IDs that are the same across retries. This gives you automatic idempotency without manual deduplication logic.
 </Callout>
 
+### What `ctx.run` retries by default
+
+When you call `ctx.run(fn)` without supplying a `retryPolicy`, the SDK applies:
+
+- **TypeScript** — `Exponential()` for regular `async` functions, `Never()` for generator functions. `Exponential()` defaults: `delay = 1000 ms`, `factor = 2`, `maxDelay = 30 000 ms`, `maxRetries = Number.MAX_SAFE_INTEGER`.
+- **Python** — `Exponential()` for regular functions, `Never()` for generator functions. `Exponential()` defaults: `delay = 1 s`, `factor = 2`, `max_delay = 30 s`, `max_retries = sys.maxsize`.
+- **Rust** — no per-invocation retry policy yet; retries are governed by the server's `--tasks-retry-timeout` flag.
+
+This means a `ctx.run(fn)` call that keeps failing will keep retrying with exponential backoff, capped at 30 seconds between attempts, effectively forever — until the surrounding invocation's `timeout` fires.
+
+See the [Defaults reference](/reference/defaults) for the full per-SDK table.
+
 ---
 
 ## Activations cannot outlive the process

--- a/content/docs/develop/python.mdx
+++ b/content/docs/develop/python.mdx
@@ -568,3 +568,21 @@ def foo(ctx, arg):
 ### `.options()`
 
 Many of Context's methods support options on the call you are making.
+
+## Defaults
+
+The Python SDK ships with these key defaults. Times are in **seconds**.
+
+- **`Resonate()`** — `group = "default"`, `ttl = 10 s`, `log_level = logging.INFO`. URL falls back to `RESONATE_URL`, then `RESONATE_HOST`/`RESONATE_PORT`; otherwise local mode.
+- **`workers`** — defaults to `min(32, workers or (os.cpu_count() or 1))` execution threads.
+- **`ctx.run` / `Options`** — `durable = True`, `timeout = 31_536_000 s (1 year)`, `target = "default"`, `version = 0`, `tags = {}`, `non_retryable_exceptions = ()`, `idempotency_key = lambda id: id`.
+- **`retry_policy`** for `ctx.run` — resolves to `Exponential()` for regular functions, `Never()` for generator functions.
+- **`Exponential()` defaults** — `delay = 1`, `factor = 2`, `max_delay = 30`, `max_retries = sys.maxsize` (all times in seconds).
+- **`Constant()` / `Linear()` defaults** — `delay = 1`, `max_retries = sys.maxsize`.
+
+<Callout type="caution" title="Python times are seconds, TypeScript times are milliseconds">
+The Python SDK uses seconds for `ttl`, `timeout`, and retry-policy delays. The TypeScript SDK uses milliseconds. The numbers do not transfer directly between the two.
+</Callout>
+
+For the full table, per-SDK comparison, and source citations, see the [Defaults reference](/reference/defaults).
+

--- a/content/docs/develop/rust.mdx
+++ b/content/docs/develop/rust.mdx
@@ -438,3 +438,18 @@ async fn my_workflow(ctx: &Context) -> Result<()> {
     Ok(())
 }
 ```
+
+## Defaults
+
+The Rust SDK ships with these key defaults:
+
+- **`Resonate::local()`** — `pid = "default"`, `group = "default"`, `ttl = u64::MAX` (no expiry, local mode).
+- **`Resonate::new(ResonateConfig::default())`** — `ttl = 60_000 ms` (remote mode). URL falls back to `RESONATE_URL`, then `RESONATE_HOST` + `RESONATE_SCHEME` ("http") + `RESONATE_PORT` ("8001").
+- **`Options::default()`** — `target = "default"`, `timeout = Duration::from_secs(86_400)` (24 h), `version = 0`, `tags = HashMap::new()`.
+
+<Callout type="caution" title="Rust SDK has no per-call retry policy yet">
+The Rust `Options` struct does **not** carry a `retry_policy` field. Retry behaviour for Rust workers is governed server-side by the `--tasks-retry-timeout` flag (default `30_000 ms`). This is a known asymmetry with the TypeScript and Python SDKs, both of which support per-`ctx.run` retry policies.
+</Callout>
+
+For the full table, per-SDK comparison, and source citations, see the [Defaults reference](/reference/defaults).
+

--- a/content/docs/develop/typescript.mdx
+++ b/content/docs/develop/typescript.mdx
@@ -853,3 +853,17 @@ resonate.register("foo", function* (ctx: Context) {
   // Code after this call will be executed as normal
 });
 ```
+
+## Defaults
+
+The TypeScript SDK ships with these key defaults. All values are in **milliseconds** unless noted.
+
+- **`new Resonate()`** — `group = "default"`, `ttl = 60_000 ms`, `logLevel = "warn"`. URL falls back to `RESONATE_URL`; when both are unset, a local in-memory network is used.
+- **`HttpNetwork`** — request `timeout = 10_000 ms` (overridable via `RESONATE_TIMEOUT`), URL fallback `"http://localhost:8001"`.
+- **`ctx.run` / `Options`** — `timeout = 86_400_000 ms (24 h)`, `target = "default"`, `version = 0`, `tags = {}`, `nonRetryableErrors = []`.
+- **`retryPolicy`** for `ctx.run` — `Exponential()` for regular `async` functions, `Never()` for generator functions.
+- **`Exponential()` defaults** — `delay = 1_000 ms`, `factor = 2`, `maxDelay = 30_000 ms`, `maxRetries = Number.MAX_SAFE_INTEGER`.
+- **`Constant()` / `Linear()` defaults** — `delay = 1_000 ms`, `maxRetries = Number.MAX_SAFE_INTEGER`.
+
+For the full table, per-SDK comparison, and source citations, see the [Defaults reference](/reference/defaults).
+

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -7,6 +7,7 @@
     "develop",
     "debug",
     "deploy",
+    "reference",
     "spec"
   ]
 }

--- a/content/docs/reference/defaults.mdx
+++ b/content/docs/reference/defaults.mdx
@@ -98,6 +98,8 @@ The SDK init defaults are the values you get from calling `new Resonate()` (Type
 
 There is no `workers` / `concurrency` parameter in the TypeScript SDK — task execution runs on the Node/Bun event loop with no SDK-side cap.
 
+See [TypeScript SDK Defaults](/develop/typescript#defaults) for surface-scoped framing.
+
 ### Python
 
 | Option | Default | Source |
@@ -115,6 +117,8 @@ There is no `workers` / `concurrency` parameter in the TypeScript SDK — task e
 Python `ttl=10` is **10 seconds**. TypeScript `ttl=60000` is **60 seconds**. They are not identical defaults in either value or unit.
 </Callout>
 
+See [Python SDK Defaults](/develop/python#defaults) for surface-scoped framing.
+
 ### Rust
 
 | Option | Default | Source |
@@ -128,6 +132,8 @@ Python `ttl=10` is **10 seconds**. TypeScript `ttl=60000` is **60 seconds**. The
 | `prefix` | resolved from `RESONATE_PREFIX`, else empty | `resonate-sdk-rs/resonate/src/resonate.rs:154-156` |
 
 The Rust SDK has no `workers` parameter — function execution runs on the user-supplied Tokio runtime.
+
+See [Rust SDK Defaults](/develop/rust#defaults) for surface-scoped framing.
 
 ---
 
@@ -151,6 +157,8 @@ The TypeScript `Options` class sets the following defaults in its constructor:
 
 So the practical answer to "what is the default retry behaviour of `ctx.run` in the TypeScript SDK?" is: **`Exponential()` with its own defaults** (see below) for regular `async` functions, and **`Never()`** for generator functions.
 
+See [TypeScript SDK Defaults](/develop/typescript#defaults) for surface-scoped framing.
+
 ### Python
 
 The Python `Options` dataclass:
@@ -168,6 +176,8 @@ The Python `Options` dataclass:
 | `timeout` | `31_536_000` = **1 year, in seconds** | `resonate-sdk-py/resonate/options.py:26` |
 | `version` | `0` | `resonate-sdk-py/resonate/options.py:27` |
 
+See [Python SDK Defaults](/develop/python#defaults) for surface-scoped framing.
+
 ### Rust
 
 The Rust `Options` struct currently exposes only structural fields:
@@ -182,6 +192,8 @@ The Rust `Options` struct currently exposes only structural fields:
 <Callout type="caution" title="Rust SDK has no per-call retry policy yet">
 The Rust SDK `Options` struct does **not** carry a `retry_policy` field — retry behaviour is governed by the server's task-retry contract, not by a per-invocation policy. This is a known asymmetry with the TypeScript and Python SDKs and is tracked separately.
 </Callout>
+
+See [Rust SDK Defaults](/develop/rust#defaults) for surface-scoped framing.
 
 ---
 

--- a/content/docs/reference/defaults.mdx
+++ b/content/docs/reference/defaults.mdx
@@ -1,0 +1,276 @@
+---
+title: Defaults reference
+description: Canonical reference for default values across the Resonate server and SDKs (TypeScript, Python, Rust).
+keywords:
+  - reference
+  - defaults
+  - retries
+  - configuration
+  - timeout
+  - retry policy
+---
+
+This page is the **single source of truth** for default values across the Resonate server and SDKs. Every value below is sourced from a specific file and line in the canonical source repositories; if a default changes in source, this page is wrong until it is updated.
+
+If you only want to know "what does `ctx.run` retry by default?" — see [ctx.run / per-call options](#ctxrun--per-call-options) and [Retry policies](#retry-policies).
+
+---
+
+## Server defaults
+
+The Resonate server is a Rust binary. Its source lives at [`resonatehq/resonate`](https://github.com/resonatehq/resonate); every default below is sourced from `src/config.rs`. The CLI flag name is the kebab-case path through the config struct (e.g. `tasks.lease_timeout` → `--tasks-lease-timeout`); the equivalent environment variable uses double-underscore nesting (e.g. `RESONATE_TASKS__LEASE_TIMEOUT`). Loading order: built-in defaults → optional `resonate.toml` → env vars.
+
+### HTTP server
+
+| Setting | Default | Source |
+|---|---|---|
+| `--server-host` | `"localhost"` | `resonate/src/config.rs:99` |
+| `--server-port` | `8001` | `resonate/src/config.rs:102` |
+| `--server-bind` | `"0.0.0.0"` | `resonate/src/config.rs:105` |
+| `--server-shutdown-timeout` | `10000` ms | `resonate/src/config.rs:108` |
+| `--server-url` | unset (falls back to `http://{host}:{port}` in response headers) | `resonate/src/config.rs:91` |
+| `--server-cors-allow-origins` | empty (CORS disabled) | `resonate/src/config.rs:67` |
+| `--level` | `"info"` | `resonate/src/config.rs:60` |
+
+### Storage
+
+| Setting | Default | Source |
+|---|---|---|
+| `--storage-type` | `"sqlite"` | `resonate/src/config.rs:148` |
+| `--storage-sqlite-path` | `"resonate.db"` | `resonate/src/config.rs:159` |
+| `--storage-postgres-url` | unset | `resonate/src/config.rs:174` |
+| `--storage-postgres-pool-size` | `10` | `resonate/src/config.rs:182` |
+| `--storage-mysql-url` | unset | `resonate/src/config.rs:197` |
+| `--storage-mysql-pool-size` | `10` | `resonate/src/config.rs:182` (shared `default_pool_size`) |
+
+### Tasks + background scans
+
+| Setting | Default | Source |
+|---|---|---|
+| `--tasks-lease-timeout` | `15000` ms | `resonate/src/config.rs:250` |
+| `--tasks-retry-timeout` | `30000` ms | `resonate/src/config.rs:253` — most deployments should lower this to `500` ms; see the [tip on Run a server](/deploy/run-server#configuration) |
+| `--timeouts-poll-interval` | `1000` ms | `resonate/src/config.rs:273` |
+| `--messages-poll-interval` | `100` ms | `resonate/src/config.rs:296` |
+| `--messages-batch-size` | `100` | `resonate/src/config.rs:299` |
+
+### Transports
+
+| Setting | Default | Source |
+|---|---|---|
+| `--transports-http-push-enabled` | `true` | `resonate/src/config.rs:399` |
+| `--transports-http-push-concurrency` | `16` | `resonate/src/config.rs:387` |
+| `--transports-http-push-connect-timeout` | `10000` ms | `resonate/src/config.rs:390` |
+| `--transports-http-push-request-timeout` | `180000` ms | `resonate/src/config.rs:393` |
+| `--transports-http-push-auth-mode` | `"none"` | `resonate/src/config.rs:462` (`HttpPushAuthMode::None`) |
+| `--transports-http-push-auth-header` | `"Authorization"` | `resonate/src/config.rs:442` |
+| `--transports-http-poll-enabled` | `true` | `resonate/src/config.rs:494` |
+| `--transports-http-poll-max-connections` | `1000` | `resonate/src/config.rs:485` |
+| `--transports-http-poll-buffer-size` | `100` | `resonate/src/config.rs:488` |
+| `--transports-gcps-enabled` | `false` | `resonate/src/config.rs:351` |
+| `--transports-bash-exec-enabled` | `false` | `resonate/src/config.rs:342` |
+
+### Observability
+
+| Setting | Default | Source |
+|---|---|---|
+| `--observability-metrics-port` | `9090` (set to `0` to disable) | `resonate/src/config.rs:513` |
+| `--observability-otlp-endpoint` | `"localhost:4317"` | `resonate/src/config.rs:516` |
+
+---
+
+## SDK init defaults
+
+The SDK init defaults are the values you get from calling `new Resonate()` (TypeScript), `Resonate()` (Python), or `Resonate::local()` / `Resonate::new(ResonateConfig::default())` (Rust) with no arguments.
+
+### TypeScript
+
+| Option | Default | Source |
+|---|---|---|
+| `url` | resolved from `RESONATE_URL` env, otherwise local in-memory network | `resonate-sdk-ts/src/resonate.ts:147` |
+| `group` | `"default"` | `resonate-sdk-ts/src/resonate.ts:103` |
+| `pid` | random UUID | `resonate-sdk-ts/src/resonate.ts:149` |
+| `ttl` | `1 * util.MIN` = **60,000 ms** | `resonate-sdk-ts/src/resonate.ts:105` (constant at `src/util.ts:25`) |
+| `verbose` | `false` | `resonate-sdk-ts/src/resonate.ts:108` |
+| `logLevel` | `"warn"` (fallback when `verbose=false`) | `resonate-sdk-ts/src/resonate.ts:137` |
+| `prefix` | resolved from `RESONATE_PREFIX`, else empty | `resonate-sdk-ts/src/resonate.ts:132` |
+| HTTP request timeout (`HttpNetwork`) | `RESONATE_TIMEOUT` env var if set, else `10 * util.SEC` = **10,000 ms** | `resonate-sdk-ts/src/network/http.ts:60-62` |
+| HTTP URL fallback | `"http://localhost:8001"` | `resonate-sdk-ts/src/network/http.ts:58` |
+
+There is no `workers` / `concurrency` parameter in the TypeScript SDK — task execution runs on the Node/Bun event loop with no SDK-side cap.
+
+### Python
+
+| Option | Default | Source |
+|---|---|---|
+| `url` | resolved from `RESONATE_URL`, else `RESONATE_HOST` + `RESONATE_PORT`, else local | `resonate-sdk-py/resonate/resonate.py:173-181` |
+| `group` | `"default"` | `resonate-sdk-py/resonate/resonate.py:99` |
+| `pid` | `uuid.uuid4().hex` | `resonate-sdk-py/resonate/resonate.py:161` |
+| `ttl` | `10` (seconds) | `resonate-sdk-py/resonate/resonate.py:101` |
+| `log_level` | `logging.INFO` | `resonate-sdk-py/resonate/resonate.py:102` |
+| `workers` | `min(32, workers or (os.cpu_count() or 1))` | `resonate-sdk-py/resonate/processor.py:16` |
+| `RESONATE_SCHEME` fallback | `"http"` | `resonate-sdk-py/resonate/resonate.py:179` |
+| `RESONATE_PORT` fallback | `"8001"` | `resonate-sdk-py/resonate/resonate.py:180` |
+
+<Callout type="caution" title="Python ttl is in seconds; TypeScript ttl is in milliseconds">
+Python `ttl=10` is **10 seconds**. TypeScript `ttl=60000` is **60 seconds**. They are not identical defaults in either value or unit.
+</Callout>
+
+### Rust
+
+| Option | Default | Source |
+|---|---|---|
+| `url` | resolved from `RESONATE_URL`, else `RESONATE_HOST`/`RESONATE_SCHEME`/`RESONATE_PORT` | `resonate-sdk-rs/resonate/src/resonate.rs:164-171` |
+| `RESONATE_SCHEME` fallback | `"http"` | `resonate-sdk-rs/resonate/src/resonate.rs:168` |
+| `RESONATE_PORT` fallback | `"8001"` | `resonate-sdk-rs/resonate/src/resonate.rs:169` |
+| `group` | `"default"` (in `local_with`) | `resonate-sdk-rs/resonate/src/resonate.rs:121` |
+| `pid` | `"default"` (in `local_with`); from network in remote mode | `resonate-sdk-rs/resonate/src/resonate.rs:120,191` |
+| `ttl` | `60_000` ms (remote) / `u64::MAX` (local) | `resonate-sdk-rs/resonate/src/resonate.rs:151,127` |
+| `prefix` | resolved from `RESONATE_PREFIX`, else empty | `resonate-sdk-rs/resonate/src/resonate.rs:154-156` |
+
+The Rust SDK has no `workers` parameter — function execution runs on the user-supplied Tokio runtime.
+
+---
+
+## ctx.run / per-call options
+
+These are the defaults applied to a single `ctx.run(...)`, `ctx.rpc(...)`, or top-level `resonate.run(...)` call when no per-call options are passed.
+
+### TypeScript
+
+The TypeScript `Options` class sets the following defaults in its constructor:
+
+| Field | Default | Source |
+|---|---|---|
+| `id` | `undefined` (auto-generated by the runtime) | `resonate-sdk-ts/src/options.ts:48` |
+| `retryPolicy` | `undefined` at the options layer; **resolved to `new Exponential()` for regular functions, `new Never()` for generator functions** when `ctx.run` / `ctx.rpc` executes | `resonate-sdk-ts/src/options.ts:49`, resolution at `resonate-sdk-ts/src/context.ts:397,432` |
+| `tags` | `{}` | `resonate-sdk-ts/src/options.ts:50` |
+| `target` | `"default"` | `resonate-sdk-ts/src/options.ts:51` |
+| `timeout` | `24 * util.HOUR` = **86,400,000 ms (24 h)** | `resonate-sdk-ts/src/options.ts:52` (constants at `src/util.ts:24-26`) |
+| `version` | `0` | `resonate-sdk-ts/src/options.ts:53` |
+| `nonRetryableErrors` | `[]` | `resonate-sdk-ts/src/options.ts:54` |
+
+So the practical answer to "what is the default retry behaviour of `ctx.run` in the TypeScript SDK?" is: **`Exponential()` with its own defaults** (see below) for regular `async` functions, and **`Never()`** for generator functions.
+
+### Python
+
+The Python `Options` dataclass:
+
+| Field | Default | Source |
+|---|---|---|
+| `durable` | `True` | `resonate-sdk-py/resonate/options.py:18` |
+| `encoder` | `None` | `resonate-sdk-py/resonate/options.py:19` |
+| `id` | `None` (auto-generated) | `resonate-sdk-py/resonate/options.py:20` |
+| `idempotency_key` | `lambda id: id` (identity) | `resonate-sdk-py/resonate/options.py:21` |
+| `non_retryable_exceptions` | `()` | `resonate-sdk-py/resonate/options.py:22` |
+| `retry_policy` | `lambda f: Never() if isgeneratorfunction(f) else Exponential()` | `resonate-sdk-py/resonate/options.py:23` |
+| `target` | `"default"` | `resonate-sdk-py/resonate/options.py:24` |
+| `tags` | `{}` | `resonate-sdk-py/resonate/options.py:25` |
+| `timeout` | `31_536_000` = **1 year, in seconds** | `resonate-sdk-py/resonate/options.py:26` |
+| `version` | `0` | `resonate-sdk-py/resonate/options.py:27` |
+
+### Rust
+
+The Rust `Options` struct currently exposes only structural fields:
+
+| Field | Default | Source |
+|---|---|---|
+| `tags` | `HashMap::new()` (empty) | `resonate-sdk-rs/resonate/src/options.rs:20` |
+| `target` | `"default"` | `resonate-sdk-rs/resonate/src/options.rs:21` |
+| `timeout` | `Duration::from_secs(86_400)` = **24 h** | `resonate-sdk-rs/resonate/src/options.rs:22` |
+| `version` | `0` | `resonate-sdk-rs/resonate/src/options.rs:23` |
+
+<Callout type="caution" title="Rust SDK has no per-call retry policy yet">
+The Rust SDK `Options` struct does **not** carry a `retry_policy` field — retry behaviour is governed by the server's task-retry contract, not by a per-invocation policy. This is a known asymmetry with the TypeScript and Python SDKs and is tracked separately.
+</Callout>
+
+---
+
+## Retry policies
+
+Retry policies are constructible by users and supplied via the per-call options. The four built-in policies share the same shape across TypeScript and Python with one important difference: **TypeScript times are in milliseconds, Python times are in seconds.**
+
+### Exponential
+
+| Parameter | TypeScript default | Python default |
+|---|---|---|
+| `delay` | `1000` (ms) — `resonate-sdk-ts/src/retries.ts:53` | `1` (sec) — `resonate-sdk-py/resonate/retry_policies/exponential.py:11` |
+| `factor` | `2` — `resonate-sdk-ts/src/retries.ts:54` | `2` — `resonate-sdk-py/resonate/retry_policies/exponential.py:13` |
+| `maxRetries` / `max_retries` | `Number.MAX_SAFE_INTEGER` — `resonate-sdk-ts/src/retries.ts:55` | `sys.maxsize` — `resonate-sdk-py/resonate/retry_policies/exponential.py:12` |
+| `maxDelay` / `max_delay` | `30000` (ms) — `resonate-sdk-ts/src/retries.ts:56` | `30` (sec) — `resonate-sdk-py/resonate/retry_policies/exponential.py:14` |
+
+Both SDKs use the formula `min(delay * factor^attempt, maxDelay)` for the n-th retry, with attempt 0 returning 0.
+
+### Constant
+
+| Parameter | TypeScript default | Python default |
+|---|---|---|
+| `delay` | `1000` (ms) — `resonate-sdk-ts/src/retries.ts:16` | `1` (sec) — `resonate-sdk-py/resonate/retry_policies/constant.py:11` |
+| `maxRetries` / `max_retries` | `Number.MAX_SAFE_INTEGER` — `resonate-sdk-ts/src/retries.ts:16` | `sys.maxsize` — `resonate-sdk-py/resonate/retry_policies/constant.py:12` |
+
+### Linear
+
+| Parameter | TypeScript default | Python default |
+|---|---|---|
+| `delay` | `1000` (ms) — `resonate-sdk-ts/src/retries.ts:93` | `1` (sec) — `resonate-sdk-py/resonate/retry_policies/linear.py:11` |
+| `maxRetries` / `max_retries` | `Number.MAX_SAFE_INTEGER` — `resonate-sdk-ts/src/retries.ts:93` | `sys.maxsize` — `resonate-sdk-py/resonate/retry_policies/linear.py:12` |
+
+The n-th retry delay is `delay * attempt` in both SDKs.
+
+### Never
+
+`Never` takes no parameters in either SDK. It returns `0` on attempt 0 and `null` / `None` for all later attempts.
+
+- TypeScript — `resonate-sdk-ts/src/retries.ts:118-135`
+- Python — `resonate-sdk-py/resonate/retry_policies/never.py`
+
+### Rust
+
+The Rust SDK does not yet ship `Exponential` / `Constant` / `Linear` / `Never` retry-policy types — there is no per-invocation retry policy on the Rust `Options` struct (see the callout above). Retry behaviour for Rust workers is determined server-side via `--tasks-retry-timeout`.
+
+---
+
+## Cross-SDK parity
+
+| Concept | TypeScript | Python | Rust |
+|---|---|---|---|
+| Init `group` | `"default"` | `"default"` | `"default"` |
+| Init `ttl` | `60_000` ms | `10` sec | `60_000` ms (remote) / `u64::MAX` (local) |
+| Init time unit | milliseconds | seconds | milliseconds (ttl) / `Duration` (timeout) |
+| Per-call `timeout` | 24 h | 1 year | 24 h |
+| Per-call `target` | `"default"` | `"default"` | `"default"` |
+| Per-call `tags` | `{}` | `{}` | empty `HashMap` |
+| Per-call `version` | `0` | `0` | `0` |
+| Default retry policy (regular fn) | `Exponential()` | `Exponential()` | not configurable per-call |
+| Default retry policy (generator fn) | `Never()` | `Never()` | n/a |
+| Retry-policy time unit | milliseconds | seconds | n/a |
+| `Exponential` `maxDelay` | `30_000` ms | `30` sec | n/a |
+| Concurrency cap | none | `min(32, workers or os.cpu_count() or 1)` | none (Tokio runtime) |
+
+**Asymmetries to call out:**
+
+- **Per-call `timeout`.** TypeScript and Rust default to **24 h**; Python defaults to **1 year**. Same field, very different envelope.
+- **`ttl`.** TypeScript and Rust use **milliseconds**; Python uses **seconds**. Same name, different unit.
+- **Retry-policy time units.** TypeScript retry policies are configured in **milliseconds**; Python retry policies are configured in **seconds**. The behaviour curve is identical; the numbers are not.
+- **Per-call retry policy.** Available in TypeScript and Python; **not yet on the Rust `Options` struct**. Rust retries are governed by the server's `--tasks-retry-timeout` flag.
+- **Worker concurrency cap.** Only Python imposes one (`min(32, ...)`). TypeScript and Rust lean on the host event-loop / runtime.
+
+---
+
+## Environment variables
+
+The SDKs share a common set of `RESONATE_*` environment variables. Defaults below are the fallbacks applied when both the constructor argument and the env var are unset.
+
+| Env var | Default | Sources |
+|---|---|---|
+| `RESONATE_URL` | unset → local in-memory mode | TS: `resonate-sdk-ts/src/resonate.ts:147`; Py: `resonate-sdk-py/resonate/resonate.py:175`; Rs: `resonate-sdk-rs/resonate/src/resonate.rs:165` |
+| `RESONATE_HOST` | unset | TS: not consumed; Py: `resonate-sdk-py/resonate/resonate.py:177`; Rs: `resonate-sdk-rs/resonate/src/resonate.rs:167` |
+| `RESONATE_SCHEME` | `"http"` | Py: `resonate-sdk-py/resonate/resonate.py:179`; Rs: `resonate-sdk-rs/resonate/src/resonate.rs:168` |
+| `RESONATE_PORT` | `"8001"` | Py: `resonate-sdk-py/resonate/resonate.py:180`; Rs: `resonate-sdk-rs/resonate/src/resonate.rs:169` |
+| `RESONATE_TOKEN` | unset | TS: `resonate-sdk-ts/src/network/http.ts:67`; Py: `resonate-sdk-py/resonate/resonate.py:184`; Rs: `resonate-sdk-rs/resonate/src/resonate.rs:175` |
+| `RESONATE_USERNAME` | unset (Python only) | Py: `resonate-sdk-py/resonate/resonate.py:187` |
+| `RESONATE_PASSWORD` | `""` (Python only) | Py: `resonate-sdk-py/resonate/resonate.py:189` |
+| `RESONATE_PREFIX` | unset → empty prefix | TS: `resonate-sdk-ts/src/resonate.ts:132`; Rs: `resonate-sdk-rs/resonate/src/resonate.rs:155` |
+| `RESONATE_TIMEOUT` | `10000` ms (TS HTTP only) | TS: `resonate-sdk-ts/src/network/http.ts:60-62` |
+| `RESONATE_URL` HTTP fallback | `"http://localhost:8001"` (TS `HttpNetwork` constructor) | `resonate-sdk-ts/src/network/http.ts:58` |
+
+Server-side `RESONATE_*` environment variables (storage, auth, transports) follow the `RESONATE_<SECTION>__<FIELD>` convention. See [Run a server › Environment variables](/deploy/run-server#environment-variables) for the complete list — those defaults track the server flag table above.

--- a/content/docs/reference/meta.json
+++ b/content/docs/reference/meta.json
@@ -1,0 +1,3 @@
+{
+  "title": "Reference"
+}


### PR DESCRIPTION
## Summary

Adds a canonical cross-SDK defaults reference page at `/reference/defaults` plus inline `## Defaults` blocks on five per-SDK and deploy pages. Motivated by a real failure: Echo deflected on _"what are the retry defaults for a ctx.run in the typescript sdk?"_ with "check the SDK source" because defaults lived only in SDK source code, not in authored docs. With this PR's content in the corpus, Echo now returns the actual values (Exponential, 1000 ms, factor 2, 30 000 ms maxDelay, MAX_SAFE_INTEGER maxRetries, with Never() for generators).

**Every numeric default is cited file:line** back to:
- `resonate-sdk-ts/src/{retries,options,context,resonate,network/http}.ts`
- `resonate-sdk-py/resonate/{options,resonate,processor}.py` + `retry_policies/exponential.py`
- `resonate-sdk-rs/resonate/src/{options,resonate}.rs`
- `resonatehq/resonate`'s `src/config.rs`

## What's in the PR

**Canonical reference (new):**
- `content/docs/reference/defaults.mdx` — full cross-SDK table, asymmetries called out
- `content/docs/reference/meta.json` — section title

**Nav:**
- `content/docs/meta.json` — registers `"reference"` between `"deploy"` and `"spec"`

**Inline `## Defaults` blocks (per-surface, short, link to canonical):**
- `content/docs/develop/constraints.mdx` — `ctx.run` retry default subsection in idempotency
- `content/docs/develop/typescript.mdx` — init / HTTP / Options / retry policies
- `content/docs/develop/python.mdx` — same, seconds-based units called out
- `content/docs/develop/rust.mdx` — same, with the Rust no-per-call-retry asymmetry
- `content/docs/deploy/run-server.mdx` — server flag summary linking to canonical

**Pre-existing edit (unrelated to defaults work but bundled here):**
- `content/docs/deploy/run-server.mdx` — six `postgres://user:pass@host` placeholder URLs changed to `postgres://<USER>:<PASSWORD>@host`. Same documentation intent; the new shape can't be mistaken for a credential.

## Cross-SDK asymmetries explicitly called out

- **Time units differ.** TS = milliseconds. Python = seconds. Rust = mixed (`Duration` for timeout, ms for ttl).
- **`Options.timeout` envelope.** TS and Rust default to 24 hours. Python defaults to **1 year** (`31_536_000` seconds).
- **`ttl` unit and value.** TS and Rust = `60_000` ms. Python = `10` sec.
- **Rust has no per-call `retry_policy`** — retry cadence comes from the server's `--tasks-retry-timeout` flag.
- **Worker concurrency cap.** Only Python has one (`min(32, workers or os.cpu_count() or 1)`).

## Test plan

- [ ] Confirm the page renders cleanly on Vercel preview (Fumadocs build)
- [ ] Confirm the `/reference/defaults` URL is reachable and the new section appears in the sidebar
- [ ] Confirm none of the 5 inline blocks duplicate the canonical table content (each lists only its own surface's defaults)
- [ ] Confirm no broken cross-page links from inline blocks → canonical page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note on inline-block heading style

Four of the five inline blocks use `## Defaults` as a peer section. `constraints.mdx` instead nests the block under `### What ctx.run retries by default` inside its idempotency section — this is intentional: the block is wedged into existing narrative rather than appended as a new top-level section. Reviewer expectation should be "5 inline default-defaults insertions" not "5 `## Defaults` headings".

## Review followups (commit 22c00f6)

Landed after the original PR review (verdict: pass) flagged four items:

- **mysql URL placeholders.** `mysql://user:pass@...` → `mysql://<USER>:<PASSWORD>@...` on four lines of `deploy/run-server.mdx` (116, 239, 248, 256), matching the postgres fix pattern so the gitleaks regex `[A-Za-z0-9._%+-]+:[…]@` can't trip on a future docs PR.
- **Canonical → per-SDK back-refs.** Each per-SDK subsection on the canonical defaults page (TypeScript / Python / Rust under both *SDK init defaults* and *ctx.run / per-call options*) now ends with a one-line link back to `/develop/<sdk>#defaults`. Round-trip navigation; the reverse direction was already in place.
- **`#ctxrun--per-call-options` anchor verified.** Resolved the slug locally against `github-slugger@2.0.0` (the slugifier Fumadocs `15.7.13` uses by default) — `"ctx.run / per-call options"` → `"ctxrun--per-call-options"`, matching the intra-page link. No change required.
- **Inline-block heading-style note** — see the section above.
