### PR TITLE
docs: third pillar is "Cost-efficient by design", not "absurdly cheap"

### DIFF
--- a/content/docs/evaluate/why-resonate.mdx
+++ b/content/docs/evaluate/why-resonate.mdx
@@ -35,7 +35,7 @@ Resonate takes a different path. The ecosystem is built on **open-source, plugga
 
 This is not AI-generated slop. The underlying [Async RPC protocol](https://www.async-rpc.io) is a fully formal JSON Schema specification — a machine-verifiable contract that constrains what "correct" means. AI is used throughout our development and testing processes, guided by these specs and protocols, to produce highly optimized software. The protocol is the contract; the implementation is generated against it, verified by [Deterministic Simulation Testing](#quality-is-not-optional), and delivered as production-grade source code.
 
-### 3. Absurdly cheap
+### 3. Cost-efficient by design
 
 Generated components plus serverless-native deployment produces a cost story that is not incremental — it is categorical.
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Home
 pageTitle: Resonate documentation
-description: Resonate — agent-native durable execution. Generated, optimized, absurdly cheap.
+description: Resonate — agent-native durable execution. Generated, optimized, cost-efficient by design.
 ---
 
 <img src="/images/home-hero-dark.png" alt="Resonate" className="home-hero hidden dark:block" />
@@ -13,7 +13,7 @@ Resonate is built on three pillars:
 
 - **Agent-native** — The SDK, docs, tool definitions, and operational surface are designed for agent consumption, not just human developers. CLIs over dashboards. Skill files over screenshots. Agents are the new developers, and Resonate is the platform they reach for.
 - **Generated & optimized** — Open-source pluggable components plus stack-specific generated servers. AI constrained by formal specs and protocols — not slop, but highly optimized software. Exactly what your stack needs, nothing more.
-- **Absurdly cheap** — Serverless-native architecture means you pay only for active execution. Workloads that cost ~$80K/year on hosted alternatives can run for under $100/year on Resonate. Orders of magnitude, not percentages.
+- **Cost-efficient by design** — Serverless-native architecture means you pay only for active execution. Workloads that cost ~$80K/year on hosted alternatives can run for under $100/year on Resonate. Orders of magnitude, not percentages.
 
 Build agents, workflows, pipelines, and services without thinking about retries or recovery — in a few lines of code.
 


### PR DESCRIPTION
## Summary

- Replaces "absurdly cheap" with **"Cost-efficient by design"** in three places on the docs site so the third pillar matches the canonical phrasing on resonatehq.io (`components/PromisePillars.tsx`).
- Affected: home `description` meta, home pillar bullet, and the `### 3.` heading in `evaluate/why-resonate.mdx`. The marketing site frames the cost story architecturally — "meter loop," serverless-native, no per-execution pricing — rather than with an emotional adjective; the docs were drifting.
- Numeric framing is unchanged ($80K/yr → <$100/yr, 100–800x, "orders of magnitude, not percentages") — it does the load-bearing work.

`public/llms.txt` and `public/llms-full.txt` regenerate from these sources via `scripts/generate-llms-txt.mjs`.

## Test plan
- [ ] Render the home page and `/evaluate/why-resonate` — heading + bullet read "Cost-efficient by design"
- [ ] Confirm no remaining "absurd"/"cheap" in `content/`: `grep -rni 'absurd\|cheap' content/`
- [ ] Regenerate llms.txt: `node scripts/generate-llms-txt.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)