### PR TITLE
nav: align brand-mark suffix + search button to canonical

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -50,7 +50,7 @@ export default function Navigation() {
             </a>
             <Link
               href="/"
-              className="font-display text-xl font-semibold tracking-tight text-bright-gray-500 dark:text-muted hover:text-bright-gray-900 dark:hover:text-primary transition focus-visible:outline-2 focus-visible:outline-secondary"
+              className="font-display text-sm font-medium tracking-tight text-bright-gray-500 dark:text-muted hover:text-bright-gray-900 dark:hover:text-primary transition focus-visible:outline-2 focus-visible:outline-secondary"
             >
               Docs
             </Link>

--- a/components/SearchDialog.tsx
+++ b/components/SearchDialog.tsx
@@ -39,7 +39,7 @@ export default function SearchDialog() {
     return (
       <button
         onClick={() => setOpen(true)}
-        className="hidden md:flex items-center gap-2 px-3 py-1.5 text-sm text-muted border border-primary/10 hover:border-primary/30 transition focus-visible:outline-2 focus-visible:outline-secondary"
+        className="hidden md:flex items-center gap-2 px-4 py-2 text-sm text-muted border border-primary/10 hover:border-primary/30 transition focus-visible:outline-2 focus-visible:outline-secondary"
         aria-label="Quick navigation"
       >
         <Search size={14} />


### PR DESCRIPTION
## Summary

Companion to the brand-mark alignment work landing on marketing, echo, and journal. The audit found two divergences on docs:

- Site-name suffix \`Docs\` was rendering at \`text-xl/600\` — same size/weight as 'Resonate' — so it read as a sibling word rather than a dimmed section label. Drops to \`text-sm/500\`.
- \`SearchDialog\` 'Jump to...' trigger had \`px-3 py-1.5\` (height 30px) while adjacent nav items used the canonical \`px-4 py-2\` (height 36px). Visible 4px height mismatch side-by-side.

Companion PRs:
- resonatehq/resonatehq.io#74 (marketing nav + footer)
- resonatehq/echo#56 (echo header + Sansation + Lora + width)
- resonatehq/journal.resonatehq.io#1 (Phase 1 build + alignment)

## Test plan

- [ ] Vercel preview loads
- [ ] Click between marketing → docs → echo → journal: brand mark sits at same offset and the suffix label is visibly dimmed/smaller than 'Resonate'
- [ ] Search button height matches adjacent nav items
- [ ] Mobile breakpoint still readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)