### PR TITLE
nav: suffix 'Docs' back to text-xl/600

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -50,7 +50,7 @@ export default function Navigation() {
             </a>
             <Link
               href="/"
-              className="font-display text-sm font-medium tracking-tight text-bright-gray-500 dark:text-muted hover:text-bright-gray-900 dark:hover:text-primary transition focus-visible:outline-2 focus-visible:outline-secondary"
+              className="font-display text-xl font-semibold tracking-tight text-bright-gray-500 dark:text-muted hover:text-bright-gray-900 dark:hover:text-primary transition focus-visible:outline-2 focus-visible:outline-secondary"
             >
               Docs
             </Link>


### PR DESCRIPTION
Revert the suffix dimming-via-size pass. Keeps the same font style as 'Resonate', differentiates only via color. Companion changes landing on journal + echo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)