### PR TITLE
docs(develop): document `.stop()` across TS / Python / Rust

### DIFF
--- a/content/docs/develop/python.mdx
+++ b/content/docs/develop/python.mdx
@@ -330,16 +330,20 @@ resonate.promises.reject(
 
 ### `.start()` and `.stop()`
 
-The Python SDK uses background threads for the bridge, message source, and heartbeat. `.start()` boots them; `.stop()` joins them.
+The Python SDK uses background threads for the bridge, message source, and heartbeat. `.start()` boots them; `.stop()` signals them to exit.
 
 ```py
 resonate.start()  # explicit start (also auto-runs on first .run() / .rpc())
 resonate.stop()   # graceful shutdown
 ```
 
-`.stop()` is synchronous (no `await` — Python's SDK is thread-based, not async). It signals the background threads to exit and joins them.
+`.stop()` is synchronous (no `await` — Python's SDK is thread-based, not async). It signals the background threads to exit. The threads are daemon threads, so the interpreter will exit when only daemon threads remain.
 
-**When to call `.stop()`.** Call it from any process that should exit after its work finishes — demo scripts, one-shot jobs, examples, CI tasks. Without it, the daemon threads keep running and the interpreter may not exit cleanly when `main()` returns.
+<Callout type="info" title="Default poller blocks on `iter_lines`">
+The default `Poller` message source uses a blocking long-poll HTTP read. Its `stop()` sets a shutdown flag, but the underlying `iter_lines` call only checks that flag between messages — so `.stop()` may not return until the next message arrives or the connection's read timeout fires. Workers exit cleanly on `SIGINT`/`SIGTERM` because the threads are daemonized; the same is true on a script reaching end-of-`main`.
+</Callout>
+
+**When to call `.stop()`.** Call it from any process that should exit after its work finishes — demo scripts, one-shot jobs, examples, CI tasks. Without it, you rely on daemon-thread exit at interpreter shutdown, which is less graceful than a clean stop.
 
 ```py title="main.py"
 from resonate import Resonate
@@ -350,7 +354,7 @@ resonate.register(greet)
 result = resonate.run("greet-1", "greet", "world")
 print(result)
 
-# Required for clean shutdown.
+# Graceful shutdown.
 resonate.stop()
 ```
 
@@ -363,6 +367,8 @@ Calling `.stop()` on a worker (an RPC service, a Kafka consumer, an MCP server, 
 
 The process keeps running but silently stops processing work. Workers should stay up; let process termination (SIGINT / SIGTERM) end the lifecycle.
 </Callout>
+
+**Between debug runs, stop the previous client.** If you keep starting fresh workers in the same process group without stopping the previous one, the old workers keep heartbeating and still hold task leases — they will pick up new dispatches and produce surprising routing. Call `.stop()` in a shutdown hook so leases release cleanly.
 
 After calling `.stop()`, the client should not be used for further operations — construct a new `Resonate` instance instead.
 

--- a/content/docs/develop/python.mdx
+++ b/content/docs/develop/python.mdx
@@ -328,6 +328,44 @@ resonate.promises.reject(
 )
 ```
 
+### `.start()` and `.stop()`
+
+The Python SDK uses background threads for the bridge, message source, and heartbeat. `.start()` boots them; `.stop()` joins them.
+
+```py
+resonate.start()  # explicit start (also auto-runs on first .run() / .rpc())
+resonate.stop()   # graceful shutdown
+```
+
+`.stop()` is synchronous (no `await` — Python's SDK is thread-based, not async). It signals the background threads to exit and joins them.
+
+**When to call `.stop()`.** Call it from any process that should exit after its work finishes — demo scripts, one-shot jobs, examples, CI tasks. Without it, the daemon threads keep running and the interpreter may not exit cleanly when `main()` returns.
+
+```py title="main.py"
+from resonate import Resonate
+
+resonate = Resonate()
+resonate.register(greet)
+
+result = resonate.run("greet-1", "greet", "world")
+print(result)
+
+# Required for clean shutdown.
+resonate.stop()
+```
+
+<Callout type="caution" title="Don't call `.stop()` on a long-running worker">
+Calling `.stop()` on a worker (an RPC service, a Kafka consumer, an MCP server, or any other long-lived process) tears down the channels the worker uses to receive and hold work:
+
+- The message source (poller) stops — the worker stops receiving dispatched tasks.
+- The heartbeat thread stops — the server-side TTL on in-flight tasks expires, and the server reassigns them.
+- The bridge thread joins — in-flight commands are not processed.
+
+The process keeps running but silently stops processing work. Workers should stay up; let process termination (SIGINT / SIGTERM) end the lifecycle.
+</Callout>
+
+After calling `.stop()`, the client should not be used for further operations — construct a new `Resonate` instance instead.
+
 ## Context APIs
 
 **How to use the Resonate Context object in the Python SDK.**

--- a/content/docs/develop/rust.mdx
+++ b/content/docs/develop/rust.mdx
@@ -311,11 +311,40 @@ resonate.promises.cancel("promise-id", json!(null)).await?;
 
 ### `.stop()`
 
-Graceful shutdown. Stops background tasks (heartbeat, subscriptions).
+Gracefully shuts down a Resonate Client. Closes the connection to the Resonate Server, stops the heartbeat loop, and aborts the subscription refresh task.
 
 ```rust
 resonate.stop().await?;
 ```
+
+**When to call it.** Call `.stop()` from any process that should exit after its work finishes — demo binaries, one-shot jobs, examples, CI tasks. Without it, the background tasks keep the Tokio runtime alive and the process hangs after `main` returns.
+
+```rust title="src/main.rs"
+#[tokio::main]
+async fn main() -> Result<()> {
+    let resonate = Resonate::local();
+    resonate.register("greet", greet);
+
+    let result: String = resonate.run("greet-1", "greet", "world").await?;
+    println!("{result}");
+
+    // Required for the process to exit.
+    resonate.stop().await?;
+    Ok(())
+}
+```
+
+<Callout type="caution" title="Don't call `.stop()` on a long-running worker">
+Calling `.stop()` on a worker (an RPC service, a Kafka consumer, an MCP server, or any other long-lived process) tears down the channels the worker uses to receive and hold work:
+
+- The connection to the Resonate Server closes — the worker stops receiving dispatched tasks.
+- The heartbeat loop stops — the server-side TTL on in-flight tasks expires, and the server reassigns them.
+- The subscription refresh task is aborted — listeners on awaited promises are no longer re-registered.
+
+The worker keeps running but silently stops processing work. Workers should stay up; let process termination (SIGINT / SIGTERM) end the lifecycle.
+</Callout>
+
+After calling `.stop()`, the client should not be used for further operations — construct a new `Resonate` instance instead.
 
 ## Context APIs
 

--- a/content/docs/develop/rust.mdx
+++ b/content/docs/develop/rust.mdx
@@ -321,16 +321,15 @@ resonate.stop().await?;
 
 ```rust title="src/main.rs"
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() {
     let resonate = Resonate::local();
-    resonate.register("greet", greet);
+    resonate.register(greet).unwrap();
 
-    let result: String = resonate.run("greet-1", "greet", "world").await?;
+    let result: String = resonate.run("greet-1", greet, "world").await.unwrap();
     println!("{result}");
 
     // Required for the process to exit.
-    resonate.stop().await?;
-    Ok(())
+    resonate.stop().await.unwrap();
 }
 ```
 
@@ -343,6 +342,8 @@ Calling `.stop()` on a worker (an RPC service, a Kafka consumer, an MCP server, 
 
 The worker keeps running but silently stops processing work. Workers should stay up; let process termination (SIGINT / SIGTERM) end the lifecycle.
 </Callout>
+
+**Between debug runs, stop the previous client.** If you keep starting fresh workers in the same process group without stopping the previous one, the old workers keep heartbeating and still hold task leases — they will pick up new dispatches and produce surprising routing. Call `.stop()` in a shutdown hook so leases release cleanly.
 
 After calling `.stop()`, the client should not be used for further operations — construct a new `Resonate` instance instead.
 

--- a/content/docs/develop/typescript.mdx
+++ b/content/docs/develop/typescript.mdx
@@ -530,6 +530,51 @@ Example:
 await resonate.promises.cancel("promise-id");
 ```
 
+### `.stop()`
+
+Gracefully shuts down a Resonate Client. Closes the long-polling connection to the Resonate Server, stops the heartbeat loop, and clears the subscription refresh interval.
+
+```ts
+await resonate.stop();
+```
+
+`.stop()` returns a `Promise<void>` and **must be awaited**.
+
+**When to call it.** Call `.stop()` from any process that should exit after its work finishes — demo scripts, one-shot jobs, examples, CI tasks. Without it, the client keeps the Node.js event loop alive via the long-poll connection and the subscription refresh interval, and the process hangs after `main()` returns.
+
+```ts title="src/index.ts"
+import { Resonate } from "@resonatehq/sdk";
+
+async function main() {
+  const resonate = new Resonate();
+  resonate.register("greet", (ctx, name) => `Hello, ${name}!`);
+
+  const result = await resonate.run("greet-1", "greet", "world");
+  console.log(result);
+
+  // Required for the process to exit.
+  await resonate.stop();
+}
+
+main();
+```
+
+<Callout type="caution" title="Don't call `.stop()` on a long-running worker">
+Calling `.stop()` on a worker (an RPC service, a Kafka consumer, an MCP server, or any other long-lived process) tears down the very channels the worker uses to receive and hold work:
+
+- The long-polling connection to the Resonate Server closes — the worker stops receiving dispatched tasks.
+- The heartbeat loop stops — the server-side TTL on in-flight tasks expires, and the server reassigns them.
+- The subscription refresh interval stops — listeners on awaited promises are no longer re-registered.
+
+The worker keeps running but silently stops processing work. Workers should stay up; let process termination (SIGINT / SIGTERM) end the lifecycle.
+</Callout>
+
+**Common pitfalls.**
+
+- **Don't reuse the client after `.stop()`.** The transport is closed and the refresh interval is gone. Subsequent calls do not throw, but they will not behave correctly. Construct a new `Resonate` instance instead.
+- **Always `await` the call.** The unawaited form (`resonate.stop();`) happens to work in narrow cases because Node drains microtasks before exit, but it races any work that follows. Tests in the SDK uniformly use `await resonate.stop()` — match that.
+- **Between debug runs, stop the previous client.** If you keep starting fresh workers in the same process group without stopping the previous one, the old workers still hold task leases and will pick up new work, producing surprising routing.
+
 ## Context APIs
 
 **How to use the Resonate Context object in the TypeScript SDK.**

--- a/content/docs/develop/typescript.mdx
+++ b/content/docs/develop/typescript.mdx
@@ -572,7 +572,7 @@ The worker keeps running but silently stops processing work. Workers should stay
 **Common pitfalls.**
 
 - **Don't reuse the client after `.stop()`.** The transport is closed and the refresh interval is gone. Subsequent calls do not throw, but they will not behave correctly. Construct a new `Resonate` instance instead.
-- **Always `await` the call.** The unawaited form (`resonate.stop();`) happens to work in narrow cases because Node drains microtasks before exit, but it races any work that follows. Tests in the SDK uniformly use `await resonate.stop()` — match that.
+- **Always `await` the call.** The unawaited form (`resonate.stop();`) starts the shutdown and discards the returned promise. Node drains the microtasks before exit, so a script that has nothing after the stop call still exits, but any code that follows — another `await`, a second `resonate.run()`, a `process.exit(0)` — runs against an in-flight teardown. Tests in the SDK uniformly use `await resonate.stop()`; match that.
 - **Between debug runs, stop the previous client.** If you keep starting fresh workers in the same process group without stopping the previous one, the old workers still hold task leases and will pick up new work, producing surprising routing.
 
 ## Context APIs

--- a/content/docs/get-started/examples/durable-sleep.mdx
+++ b/content/docs/get-started/examples/durable-sleep.mdx
@@ -156,7 +156,7 @@ const result = await resonate.rpc(
   resonate.options({ target: "poll://any@workers" }),
 );
 console.log(result);
-resonate.stop();
+await resonate.stop();
 ```
 
 </TabItem>

--- a/content/docs/get-started/examples/hello-world.mdx
+++ b/content/docs/get-started/examples/hello-world.mdx
@@ -84,7 +84,7 @@ const fooR = resonate.register("foo", foo);
 
 const result = await fooR.run("greeting-workflow", "World");
 console.log(result);
-resonate.stop();
+await resonate.stop();
 ```
 
 </TabItem>

--- a/content/docs/get-started/examples/load-balancing.mdx
+++ b/content/docs/get-started/examples/load-balancing.mdx
@@ -174,7 +174,7 @@ await resonate.beginRpc(
   { id, computeCost },
   resonate.options({ target: "poll://any@workers" }),
 );
-resonate.stop();
+await resonate.stop();
 ```
 
 </TabItem>

--- a/content/docs/get-started/examples/recursive-factorial.mdx
+++ b/content/docs/get-started/examples/recursive-factorial.mdx
@@ -179,7 +179,7 @@ const result = await resonate.rpc(
   resonate.options({ target: "poll://any@factorial-workers" }),
 );
 console.log(`Factorial of ${n} is ${result}`);
-resonate.stop();
+await resonate.stop();
 ```
 
 </TabItem>

--- a/content/docs/get-started/examples/schedule.mdx
+++ b/content/docs/get-started/examples/schedule.mdx
@@ -76,7 +76,7 @@ await resonate.schedule(
   123,              // userId argument
 );
 console.log("Schedule created. Start the worker to process executions.");
-resonate.stop();
+await resonate.stop();
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary

The TypeScript develop page had no documentation for `resonate.stop()`, the Rust section was a one-liner, and the Python page didn't cover it at all. Users were left without guidance on the two failure modes:

- **Scripts hang on exit** if `.stop()` is missing (the long-poll connection, heartbeat, and subscription-refresh interval keep the Node.js / Tokio runtime alive).
- **Workers silently stop processing** if `.stop()` is called on them (the same teardown that lets scripts exit is what a worker needs to keep running).

This surfaced on 2026-05-20 when five TypeScript examples in [`resonatehq/examples-ci`](https://github.com/resonatehq/examples-ci) hung past the 30s CI timeout — each was a one-line fix to call `resonate.stop()` at end of `main()`. Closes Finding #14 in the bench propagation backlog.

## What's in this PR

- **TS develop page** (`content/docs/develop/typescript.mdx`) — new `### .stop()` section between `.promises.cancel()` and `## Context APIs`. Covers what it does, must-await semantics, when to call, the "don't call on workers" caution, reuse behavior, and the debug-run / zombie-dispatch pitfall.
- **Rust develop page** (`content/docs/develop/rust.mdx`) — expanded the existing one-line section to match: when-to-call, worker caution, no reuse.
- **Python develop page** (`content/docs/develop/python.mdx`) — new `### .start() and .stop()` section. Notes the sync shape (no `await`) and threaded teardown.
- **In-doc example pages** — five TS snippets used a bare `resonate.stop();`; all are in top-level-await contexts, so swapped to `await resonate.stop();` (`hello-world`, `recursive-factorial`, `load-balancing`, `schedule`, `durable-sleep`).

## Followups (out of scope here)

- The [Resonate SDK Specification](https://github.com/resonatehq/resonate-sdk-specification) has no `.stop()` coverage. The client lifecycle belongs in the cross-SDK contract.
- Several examples in the `resonatehq-examples` fleet ship bare `resonate.stop();` calls. They mostly work because Node drains microtasks before exit, but they're a latent bug — should adopt `await` to match the SDK tests.

## Test plan

- [x] `bun run build` succeeds locally
- [x] `postbuild` link-checker reports 0 internal broken links
- [x] `next start` + curl confirms anchors render: `/develop/typescript#stop`, `/develop/python#start-and-stop`, `/develop/rust#stop`
- [x] Caution callout component renders (not raw MDX)
- [ ] Reviewer spot-checks the rendered pages on Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)