### PR TITLE
fix(footer): correct X and LinkedIn links to the canonical resonatehqio accounts

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -13,8 +13,8 @@ const footerLinks = {
     { label: "GitHub", href: "https://github.com/resonatehq" },
     { label: "Journal", href: "https://journal.resonatehq.io" },
     { label: "RSVP", href: "https://resonatehq.io/rsvp" },
-    { label: "X / Twitter", href: "https://x.com/resonaborated" },
-    { label: "LinkedIn", href: "https://www.linkedin.com/company/resonatehq" },
+    { label: "X / Twitter", href: "https://x.com/resonatehqio" },
+    { label: "LinkedIn", href: "https://www.linkedin.com/company/resonatehqio" },
   ],
   company: [
     { label: "Home", href: "https://www.resonatehq.io" },


### PR DESCRIPTION
The docs site footer linked two wrong social accounts in the `community` array:

- `x.com/resonaborated` — not Resonate's account
- `linkedin.com/company/resonatehq` — resolves to an unrelated company

Both now point at the canonical `resonatehqio` accounts (verified against the marketing site `resonatehq.io`, the source of truth: `twitter.com/resonatehqio` and `linkedin.com/company/resonatehqio`).

Two-line change in `components/Footer.tsx`; nothing else references the old handles. `npm run build` passes; link check reports 0 internal broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)