### PR TITLE
docs(quickstart): add Go SDK tabs to the cross-language quickstart

### DIFF
--- a/content/docs/get-started/quickstart.mdx
+++ b/content/docs/get-started/quickstart.mdx
@@ -72,6 +72,7 @@ serde = { version = "1", features = ["derive"] }
 Requires **Go 1.22** or later.
 
 ```shell
+go mod init countdown
 go get github.com/resonatehq/resonate-sdk-go@latest
 ```
 
@@ -389,7 +390,7 @@ Inspect the execution with `resonate tree` — it renders the call graph as dura
 resonate tree countdown.1
 ```
 
-Now kill the worker mid-countdown and restart. **The countdown resumes where it stopped.**
+Now kill the worker mid-countdown and restart it with the same start command (keep `resonate dev` running). Because the invocation `countdown.1` already exists, **the countdown resumes where it stopped** instead of starting over. Use a delay long enough to interrupt it mid-countdown — for example `--arg 5 --arg 60`.
 
 ## Next steps
 

--- a/content/docs/get-started/quickstart.mdx
+++ b/content/docs/get-started/quickstart.mdx
@@ -25,6 +25,7 @@ brew install resonatehq/tap/resonate
   { label: "TypeScript", value: "typescript" },
   { label: "Python", value: "python" },
   { label: "Rust", value: "rust" },
+  { label: "Go", value: "go" },
 ]}>
 
 <TabItem value="typescript">
@@ -66,6 +67,18 @@ serde = { version = "1", features = ["derive"] }
 
 </TabItem>
 
+<TabItem value="go">
+
+Requires **Go 1.22** or later.
+
+```shell
+go get github.com/resonatehq/resonate-sdk-go@latest
+```
+
+No semver tag is published yet — `@latest` resolves to the latest `main` commit. See the [Go SDK guide](/develop/go) for details.
+
+</TabItem>
+
 </Tabs>
 
 ## Write a function
@@ -76,6 +89,7 @@ A countdown loop that survives restarts — minutes, hours, or days.
   { label: "TypeScript", value: "typescript" },
   { label: "Python", value: "python" },
   { label: "Rust", value: "rust" },
+  { label: "Go", value: "go" },
 ]}>
 
 <TabItem value="typescript">
@@ -172,6 +186,73 @@ async fn main() {
 
 </TabItem>
 
+<TabItem value="go">
+
+```go title="main.go"
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	resonate "github.com/resonatehq/resonate-sdk-go"
+)
+
+// CLI args arrive as a slice: `--arg 5 --arg 60` becomes args[0]=5, args[1]=60.
+func countdown(ctx *resonate.Context, args []int) (struct{}, error) {
+	count, delay := args[0], args[1]
+	for i := count; i > 0; i-- {
+		// Run a function, persist its result
+		f, err := ctx.Run(notify, i)
+		if err != nil {
+			return struct{}{}, err
+		}
+		if err := f.Await(nil); err != nil {
+			return struct{}{}, err
+		}
+		// Sleep
+		s, err := ctx.Sleep(time.Duration(delay) * time.Second)
+		if err != nil {
+			return struct{}{}, err
+		}
+		if err := s.Await(nil); err != nil {
+			return struct{}{}, err
+		}
+	}
+	fmt.Println("Done!")
+	return struct{}{}, nil
+}
+
+func notify(i int) (struct{}, error) {
+	fmt.Printf("Countdown: %d\n", i)
+	return struct{}{}, nil
+}
+
+func main() {
+	// Instantiate Resonate
+	r, err := resonate.New(resonate.Config{URL: "http://localhost:8001"})
+	if err != nil {
+		log.Fatalf("resonate.New: %v", err)
+	}
+	// Register the function
+	if _, err := resonate.Register(r, "countdown", countdown); err != nil {
+		log.Fatalf("Register: %v", err)
+	}
+	// Keep the worker alive to receive work
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	<-sig
+}
+```
+
+[Working example](https://github.com/resonatehq-examples/example-quickstart-go)
+
+</TabItem>
+
 </Tabs>
 
 ## Start the server
@@ -186,6 +267,7 @@ resonate dev
   { label: "TypeScript", value: "typescript" },
   { label: "Python", value: "python" },
   { label: "Rust", value: "rust" },
+  { label: "Go", value: "go" },
 ]}>
 
 <TabItem value="typescript">
@@ -208,6 +290,14 @@ python countdown.py
 
 ```shell
 cargo run
+```
+
+</TabItem>
+
+<TabItem value="go">
+
+```shell
+go run .
 ```
 
 </TabItem>
@@ -228,6 +318,7 @@ resonate invoke countdown.1 --func countdown --arg 5 --arg 60
   { label: "TypeScript", value: "typescript" },
   { label: "Python", value: "python" },
   { label: "Rust", value: "rust" },
+  { label: "Go", value: "go" },
 ]}>
 
 <TabItem value="typescript">
@@ -262,6 +353,20 @@ Done!
 
 ```shell
 cargo run
+Countdown: 5
+Countdown: 4
+Countdown: 3
+Countdown: 2
+Countdown: 1
+Done!
+```
+
+</TabItem>
+
+<TabItem value="go">
+
+```shell
+go run .
 Countdown: 5
 Countdown: 4
 Countdown: 3

--- a/content/docs/get-started/quickstart.mdx
+++ b/content/docs/get-started/quickstart.mdx
@@ -249,6 +249,8 @@ func main() {
 }
 ```
 
+Go's `Register` takes a single args type, so the CLI's `--arg 5 --arg 60` arrives as `[]int{5, 60}`. Most workflows use a named struct instead — see the [Go SDK guide](/develop/go).
+
 [Working example](https://github.com/resonatehq-examples/example-quickstart-go)
 
 </TabItem>

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -13942,6 +13942,18 @@ serde = { version = "1", features = ["derive"] }
 
 
 
+Requires **Go 1.22** or later.
+
+```shell
+go get github.com/resonatehq/resonate-sdk-go@latest
+```
+
+No semver tag is published yet — `@latest` resolves to the latest `main` commit. See the [Go SDK guide](/develop/go) for details.
+
+
+
+
+
 ## Write a function
 
 A countdown loop that survives restarts — minutes, hours, or days.
@@ -14042,6 +14054,73 @@ async fn main() {
 
 
 
+```go title="main.go"
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	resonate "github.com/resonatehq/resonate-sdk-go"
+)
+
+// CLI args arrive as a slice: `--arg 5 --arg 60` becomes args[0]=5, args[1]=60.
+func countdown(ctx *resonate.Context, args []int) (struct{}, error) {
+	count, delay := args[0], args[1]
+	for i := count; i > 0; i-- {
+		// Run a function, persist its result
+		f, err := ctx.Run(notify, i)
+		if err != nil {
+			return struct{}{}, err
+		}
+		if err := f.Await(nil); err != nil {
+			return struct{}{}, err
+		}
+		// Sleep
+		s, err := ctx.Sleep(time.Duration(delay) * time.Second)
+		if err != nil {
+			return struct{}{}, err
+		}
+		if err := s.Await(nil); err != nil {
+			return struct{}{}, err
+		}
+	}
+	fmt.Println("Done!")
+	return struct{}{}, nil
+}
+
+func notify(i int) (struct{}, error) {
+	fmt.Printf("Countdown: %d\n", i)
+	return struct{}{}, nil
+}
+
+func main() {
+	// Instantiate Resonate
+	r, err := resonate.New(resonate.Config{URL: "http://localhost:8001"})
+	if err != nil {
+		log.Fatalf("resonate.New: %v", err)
+	}
+	// Register the function
+	if _, err := resonate.Register(r, "countdown", countdown); err != nil {
+		log.Fatalf("Register: %v", err)
+	}
+	// Keep the worker alive to receive work
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	<-sig
+}
+```
+
+[Working example](https://github.com/resonatehq-examples/example-quickstart-go)
+
+
+
+
+
 ## Start the server
 
 ```shell
@@ -14072,6 +14151,14 @@ python countdown.py
 
 ```shell
 cargo run
+```
+
+
+
+
+
+```shell
+go run .
 ```
 
 
@@ -14122,6 +14209,20 @@ Done!
 
 ```shell
 cargo run
+Countdown: 5
+Countdown: 4
+Countdown: 3
+Countdown: 2
+Countdown: 1
+Done!
+```
+
+
+
+
+
+```shell
+go run .
 Countdown: 5
 Countdown: 4
 Countdown: 3

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -14115,6 +14115,8 @@ func main() {
 }
 ```
 
+Go's `Register` takes a single args type, so the CLI's `--arg 5 --arg 60` arrives as `[]int{5, 60}`. Most workflows use a named struct instead — see the [Go SDK guide](/develop/go).
+
 [Working example](https://github.com/resonatehq-examples/example-quickstart-go)
 
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -13945,6 +13945,7 @@ serde = { version = "1", features = ["derive"] }
 Requires **Go 1.22** or later.
 
 ```shell
+go mod init countdown
 go get github.com/resonatehq/resonate-sdk-go@latest
 ```
 
@@ -14245,7 +14246,7 @@ Inspect the execution with `resonate tree` — it renders the call graph as dura
 resonate tree countdown.1
 ```
 
-Now kill the worker mid-countdown and restart. **The countdown resumes where it stopped.**
+Now kill the worker mid-countdown and restart it with the same start command (keep `resonate dev` running). Because the invocation `countdown.1` already exists, **the countdown resumes where it stopped** instead of starting over. Use a delay long enough to interrupt it mid-countdown — for example `--arg 5 --arg 60`.
 
 ## Next steps
 


### PR DESCRIPTION
Adds a **Go** tab to each of the 4 `<Tabs groupId="language">` groups on `get-started/quickstart.mdx` (Install the SDK / Write a function / Start the worker / Result), bringing Go to parity with TypeScript, Python, and Rust on the highest-traffic cross-language comparison page.

### Stacking & merge order
- **Stacked on #206** (`develop/go.mdx`). Base is `flossy/iter72-go-docs`; GitHub will retarget to `main` once #206 merges. The Go install tab links to `/develop/go`, which #206 introduces — merge **#206 first**.
- **Paired with** [example-quickstart-go#2](https://github.com/resonatehq-examples/example-quickstart-go/pull/2), which converts that repo from the `greet` demo into the same durable countdown. The "Write a function" Go code block is **byte-identical** to that repo's `main.go`. Merge the example PR so the docs↔repo code stays in sync.

### The `[]int` arg (why Go differs subtly from the struct-first style)
`resonate invoke` wraps each `--arg` into a JSON array, and a registered Go function takes a single arg, so the workflow takes `args []int` (`args[0]=count, args[1]=delay`). This is what lets the **same** shared `resonate invoke countdown.1 --func countdown --arg 5 --arg 60` step work for Go as for TS/Py — no per-language invoke command needed. A named struct can't absorb the CLI's array form (it errors with `cannot unmarshal array into Go value`).

### Verification
- Go code compile-verified (`go build` + `go vet`) against SDK main `22076134651f` **and** the example-repo pin `290b211` — both clean.
- Run end-to-end against `resonate dev` (server v0.9.7): worker printed `Countdown: 5…1` then `Done!`; promise `resolved`.
- `npm run build` clean; `check-links` **0 internal broken** (6 external warns are pre-existing localhost metrics/tracing URLs). `llms-full.txt` regenerated (additive).
- Two independent fresh-context reviews (technical APPROVE; editorial APPROVE-WITH-FIXES — the one parity fix, trimming the Go snippet's doc-comments to match the other tabs, is applied here and in the example repo).