### PR TITLE
docs(evaluate): add Rust + Go SDK tabs to Temporal/DBOS comparisons; fix accuracy

### DIFF
--- a/content/docs/evaluate/coming-from/byode.mdx
+++ b/content/docs/evaluate/coming-from/byode.mdx
@@ -314,7 +314,7 @@ Your custom system is tied to your stack, your choices, your company.
 
 **Resonate implements Distributed Async Await** - a protocol with:
 - Formal semantics (TLA+ models, published specifications)
-- Language-agnostic design (TypeScript and Python SDKs today, more coming)
+- Language-agnostic design (TypeScript, Python, and Rust SDKs today, with a Go SDK in active development)
 - Open source implementation (server and SDKs)
 
 If you outgrow Resonate or want to embed the protocol elsewhere, the model is portable.

--- a/content/docs/evaluate/coming-from/dbos.mdx
+++ b/content/docs/evaluate/coming-from/dbos.mdx
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <Callout type="info" title="SDK version">
-This page reflects `@resonatehq/sdk` v0.10.2 (current on npm) and `resonate-sdk` v0.6.7 for Python.
+This page reflects `@resonatehq/sdk` v0.10.2 (TypeScript, current on npm), `resonate-sdk` v0.6.7 (Python), `resonate-sdk` v0.4.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
 </Callout>
 
 **Are you coming from DBOS?**
@@ -43,6 +43,8 @@ How might you implement it in DBOS?
     values={[
         {label: 'Python', value: 'python'},
         {label: 'TypeScript', value: 'typescript'},
+        {label: 'Rust', value: 'rust'},
+        {label: 'Go', value: 'go'},
     ]}
 >
 
@@ -90,13 +92,80 @@ async function main() {
 
     </TabItem>
 
+    <TabItem value="rust">
+
+See it in action: [example-recursive-factorial-rs](https://github.com/resonatehq-examples/example-recursive-factorial-rs)
+
+```rust
+#[resonate::function]
+async fn factorial(ctx: &Context, n: u64) -> Result<u64> {
+    if n <= 1 {
+        return Ok(1);
+    }
+    let result = ctx.run(factorial, n - 1).await?;
+
+    Ok(n * result)
+}
+
+#[tokio::main]
+async fn main() {
+    let resonate = Resonate::local();
+    resonate.register(factorial).unwrap();
+
+    let result: u64 = resonate.run("factorial-5", factorial, 5).await.unwrap();
+    println!("{result}");
+
+    resonate.stop().await.unwrap();
+}
+```
+
+    </TabItem>
+
+    <TabItem value="go">
+
+See it in action: [example-recursive-factorial-go](https://github.com/resonatehq-examples/example-recursive-factorial-go)
+
+```go
+type Args struct {
+	N int `json:"n"`
+}
+
+func factorial(ctx *resonate.Context, args Args) (int, error) {
+	if args.N <= 1 {
+		return 1, nil
+	}
+	f, err := ctx.Run(factorial, Args{N: args.N - 1})
+	if err != nil {
+		return 0, err
+	}
+	var result int
+	if err := f.Await(&result); err != nil {
+		return 0, err
+	}
+	return args.N * result, nil
+}
+
+func main() {
+	r, _ := resonate.New(resonate.Config{URL: "http://localhost:8001"})
+	defer func() { _ = r.Stop() }()
+
+	factorialFn, _ := resonate.Register(r, "factorial", factorial)
+
+	h, _ := factorialFn.Run(context.Background(), "factorial-5", Args{N: 5})
+	result, _ := h.Result(context.Background())
+	fmt.Println(result)
+}
+```
+
+    </TabItem>
+
 </Tabs>
 
 ## Zero-dependency development
 
-With DBOS, your Worker or application must always connect to a Postgres database, whether it’s a local development or a production instance.
+With DBOS, your application always runs against a database. Recent versions default to an embedded SQLite database for local development and use Postgres in production, so there is always a database in the loop.
 
-Resonate offers a zero-dependency development experience, where a Worker (single node application) can run without connecting to a Resonate Server.
+Resonate offers a zero-dependency development experience: a Worker (single node application) runs entirely in-memory, with no database and no Resonate Server, until you choose to connect one.
 
 <Tabs
     groupId="preferred-language"
@@ -104,6 +173,8 @@ Resonate offers a zero-dependency development experience, where a Worker (single
     values={[
         {label: 'Python', value: 'python'},
         {label: 'TypeScript', value: 'typescript'},
+        {label: 'Rust', value: 'rust'},
+        {label: 'Go', value: 'go'},
     ]}
 >
 
@@ -132,6 +203,39 @@ const resonate = new Resonate();
 
     </TabItem>
 
+    <TabItem value="rust">
+
+```rust
+use resonate::prelude::*;
+
+let resonate = Resonate::local();
+
+// ...
+```
+
+    </TabItem>
+
+    <TabItem value="go">
+
+```go
+import (
+	resonate "github.com/resonatehq/resonate-sdk-go"
+	"github.com/resonatehq/resonate-sdk-go/localnet"
+)
+
+// Local development mode runs the server state machine in-process,
+// using in-memory storage for promises and tasks.
+pid := "dev-worker"
+r, _ := resonate.New(resonate.Config{
+	Network:   localnet.NewLocal("default", &pid),
+	Heartbeat: resonate.NoopHeartbeat{}, // localnet has no lease endpoint to heartbeat against
+})
+
+// ...
+```
+
+    </TabItem>
+
 </Tabs>
 
 ## Human-in-the-loop
@@ -147,6 +251,8 @@ Then, you can resolve it from anywhere, optionally sending data into the functio
     values={[
         {label: 'Python', value: 'python'},
         {label: 'TypeScript', value: 'typescript'},
+        {label: 'Rust', value: 'rust'},
+        {label: 'Go', value: 'go'},
     ]}
 >
 
@@ -198,15 +304,78 @@ await resonate.promises.resolve(promiseId, { data: JSON.stringify(data) });
 
     </TabItem>
 
+    <TabItem value="rust">
+
+See it in action: [example-human-in-the-loop-rs](https://github.com/resonatehq-examples/example-human-in-the-loop-rs)
+
+```rust
+// worker.rs
+#[resonate::function]
+async fn foo(ctx: &Context) -> Result<()> {
+    // Latent durable promise — no function backing it. Resolved externally.
+    let blocking_promise = ctx.promise::<bool>();
+    let _promise_id = blocking_promise.id().await?;
+    // ...
+    // suspend until the promise is resolved (survives crashes)
+    let _data = blocking_promise.await?;
+    // ...
+    Ok(())
+}
+```
+
+```rust
+use resonate::types::Value;
+
+// resolve from anywhere
+resonate
+    .promises
+    .resolve(&promise_id, Value::from_serializable(data)?)
+    .await?;
+```
+
+    </TabItem>
+
+    <TabItem value="go">
+
+See it in action: [example-human-in-the-loop-go](https://github.com/resonatehq-examples/example-human-in-the-loop-go)
+
+```go
+func foo(ctx *resonate.Context, _ struct{}) (string, error) {
+	// Latent durable promise — no function backing it. Resolved externally.
+	f, err := ctx.Promise()
+	if err != nil {
+		return "", err
+	}
+	promiseID := f.ID() // hand this ID to whoever resolves it
+	_ = promiseID
+	// ...
+	// Await suspends the workflow until the promise settles (survives crashes).
+	var data string
+	if err := f.Await(&data); err != nil {
+		return "", err
+	}
+	// ...
+	return data, nil
+}
+```
+
+```shell
+# The Go SDK has no high-level promises sub-client yet (pre-release), so
+# resolve the latent promise from outside via the Resonate CLI or server API:
+resonate promises resolve <promise-id> --value '{"data": "approved"}'
+```
+
+    </TabItem>
+
 </Tabs>
 
 ## Distributed execution
 
-A major difference between Resonate and DBOS is that Resonate can orchestrate executions across multiple Workers while DBOS cannot.
 With Resonate, you can run multiple Workers in a group, and Resonate will automatically load-balance invocations across them.
+DBOS can also distribute work across multiple processes, using durable queues that those processes poll.
+The meaningful difference is in crash recovery, which we cover below.
 
 Consider the following Resonate example.
-How would you accomplish this using DBOS?
 
 <Tabs
     groupId="preferred-language"
@@ -214,6 +383,8 @@ How would you accomplish this using DBOS?
     values={[
         {label: 'Python', value: 'python'},
         {label: 'TypeScript', value: 'typescript'},
+        {label: 'Rust', value: 'rust'},
+        {label: 'Go', value: 'go'},
     ]}
 >
 
@@ -275,11 +446,66 @@ async function main() {
 
     </TabItem>
 
+    <TabItem value="rust">
+
+See it in action: [example-load-balancing-rs](https://github.com/resonatehq-examples/example-load-balancing-rs)
+
+```rust
+// worker.rs
+let resonate = Resonate::new(ResonateConfig {
+    url: Some("http://localhost:8001".into()),
+    group: Some("workers".into()),
+    ..Default::default()
+});
+```
+
+```rust
+// client.rs
+let resonate = Resonate::new(ResonateConfig {
+    url: Some("http://localhost:8001".into()),
+    group: Some("client".into()),
+    ..Default::default()
+});
+
+let result: u64 = resonate
+    .rpc(&promise_id, "function_name", params)
+    .target("poll://any@workers")
+    .await?;
+```
+
+    </TabItem>
+
+    <TabItem value="go">
+
+See it in action: [example-load-balancing-go](https://github.com/resonatehq-examples/example-load-balancing-go)
+
+```go
+// worker
+r, _ := resonate.New(resonate.Config{
+	Network: httpnet.NewHTTP("http://localhost:8001", httpnet.HTTPOptions{
+		Group: "workers",
+	}),
+})
+```
+
+```go
+// client
+r, _ := resonate.New(resonate.Config{
+	Network: httpnet.NewHTTP("http://localhost:8001", httpnet.HTTPOptions{
+		Group: "client",
+	}),
+})
+
+h, _ := r.RPC(context.Background(), promiseID, "function_name", params,
+	resonate.RPCOptions{Target: "poll://any@workers"})
+```
+
+    </TabItem>
+
 </Tabs>
 
-DBOS is designed to ensure durability for a single instance of an application.
-When a DBOS application process crashes, an operator must restart the application for any in-progress functions/workflows to recover and resume.
+The meaningful difference is in crash recovery.
+Resonate automatically recovers and resumes in-progress functions/workflows in another Worker, as part of its open-source core.
 
-Resonate will automatically recover and resume in-progress functions/workflows in another Worker.
-
-In essence, DBOS focuses on single-instance durability without addressing scalability, while Resonate holistically addresses the needs of modern distributed systems.
+With DBOS, automatic recovery of in-progress workflows across instances relies on DBOS Conductor (a separate service, with its full feature set on a paid tier).
+Without Conductor, recovery in a distributed deployment is coordinated manually, and a single-node deployment recovers its own workflows when that process restarts.

--- a/content/docs/evaluate/coming-from/dbos.mdx
+++ b/content/docs/evaluate/coming-from/dbos.mdx
@@ -362,7 +362,7 @@ func foo(ctx *resonate.Context, _ struct{}) (string, error) {
 ```shell
 # The Go SDK has no high-level promises sub-client yet (pre-release), so
 # resolve the latent promise from outside via the Resonate CLI or server API:
-resonate promises resolve <promise-id> --value '{"data": "approved"}'
+resonate promises resolve <promise-id> --value '{"headers": {}, "data": "approved"}'
 ```
 
     </TabItem>
@@ -507,5 +507,5 @@ h, _ := r.RPC(context.Background(), promiseID, "function_name", params,
 The meaningful difference is in crash recovery.
 Resonate automatically recovers and resumes in-progress functions/workflows in another Worker, as part of its open-source core.
 
-With DBOS, automatic recovery of in-progress workflows across instances relies on DBOS Conductor (a separate service, with its full feature set on a paid tier).
+With DBOS, automatic recovery of in-progress workflows across instances relies on DBOS Conductor, a separate service with tiered plans.
 Without Conductor, recovery in a distributed deployment is coordinated manually, and a single-node deployment recovers its own workflows when that process restarts.

--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -362,7 +362,7 @@ func foo(ctx *resonate.Context, _ struct{}) (string, error) {
 ```shell
 # The Go SDK has no high-level promises sub-client yet (pre-release), so
 # resolve the latent promise from outside via the Resonate CLI or server API:
-resonate promises resolve <promise-id> --value '{"data": "approved"}'
+resonate promises resolve <promise-id> --value '{"headers": {}, "data": "approved"}'
 ```
 
     </TabItem>

--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <Callout type="info" title="SDK version">
-This page reflects `@resonatehq/sdk` v0.10.2 (current on npm) and `resonate-sdk` v0.6.7 for Python.
+This page reflects `@resonatehq/sdk` v0.10.2 (TypeScript, current on npm), `resonate-sdk` v0.6.7 (Python), `resonate-sdk` v0.4.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
 </Callout>
 
 **Are you coming from Temporal?**
@@ -43,6 +43,8 @@ How might you implement it in Temporal?
     values={[
         {label: 'Python', value: 'python'},
         {label: 'TypeScript', value: 'typescript'},
+        {label: 'Rust', value: 'rust'},
+        {label: 'Go', value: 'go'},
     ]}
 >
 
@@ -91,6 +93,73 @@ async function main() {
 
     </TabItem>
 
+    <TabItem value="rust">
+
+See it in action: [example-recursive-factorial-rs](https://github.com/resonatehq-examples/example-recursive-factorial-rs)
+
+```rust
+#[resonate::function]
+async fn factorial(ctx: &Context, n: u64) -> Result<u64> {
+    if n <= 1 {
+        return Ok(1);
+    }
+    let result = ctx.run(factorial, n - 1).await?;
+
+    Ok(n * result)
+}
+
+#[tokio::main]
+async fn main() {
+    let resonate = Resonate::local();
+    resonate.register(factorial).unwrap();
+
+    let result: u64 = resonate.run("factorial-5", factorial, 5).await.unwrap();
+    println!("{result}");
+
+    resonate.stop().await.unwrap();
+}
+```
+
+    </TabItem>
+
+    <TabItem value="go">
+
+See it in action: [example-recursive-factorial-go](https://github.com/resonatehq-examples/example-recursive-factorial-go)
+
+```go
+type Args struct {
+	N int `json:"n"`
+}
+
+func factorial(ctx *resonate.Context, args Args) (int, error) {
+	if args.N <= 1 {
+		return 1, nil
+	}
+	f, err := ctx.Run(factorial, Args{N: args.N - 1})
+	if err != nil {
+		return 0, err
+	}
+	var result int
+	if err := f.Await(&result); err != nil {
+		return 0, err
+	}
+	return args.N * result, nil
+}
+
+func main() {
+	r, _ := resonate.New(resonate.Config{URL: "http://localhost:8001"})
+	defer func() { _ = r.Stop() }()
+
+	factorialFn, _ := resonate.Register(r, "factorial", factorial)
+
+	h, _ := factorialFn.Run(context.Background(), "factorial-5", Args{N: 5})
+	result, _ := h.Result(context.Background())
+	fmt.Println(result)
+}
+```
+
+    </TabItem>
+
 </Tabs>
 
 ## Zero-dependency development
@@ -105,6 +174,8 @@ Resonate offers a zero-dependency development experience, where a Worker (single
     values={[
         {label: 'Python', value: 'python'},
         {label: 'TypeScript', value: 'typescript'},
+        {label: 'Rust', value: 'rust'},
+        {label: 'Go', value: 'go'},
     ]}
 >
 
@@ -132,6 +203,39 @@ const resonate = new Resonate();
 
     </TabItem>
 
+    <TabItem value="rust">
+
+```rust
+use resonate::prelude::*;
+
+let resonate = Resonate::local();
+
+// ...
+```
+
+    </TabItem>
+
+    <TabItem value="go">
+
+```go
+import (
+	resonate "github.com/resonatehq/resonate-sdk-go"
+	"github.com/resonatehq/resonate-sdk-go/localnet"
+)
+
+// Local development mode runs the server state machine in-process,
+// using in-memory storage for promises and tasks.
+pid := "dev-worker"
+r, _ := resonate.New(resonate.Config{
+	Network:   localnet.NewLocal("default", &pid),
+	Heartbeat: resonate.NoopHeartbeat{}, // localnet has no lease endpoint to heartbeat against
+})
+
+// ...
+```
+
+    </TabItem>
+
 </Tabs>
 
 ## Human-in-the-loop
@@ -147,6 +251,8 @@ Then, you can resolve it from anywhere, optionally sending data into the functio
     values={[
         {label: 'Python', value: 'python'},
         {label: 'TypeScript', value: 'typescript'},
+        {label: 'Rust', value: 'rust'},
+        {label: 'Go', value: 'go'},
     ]}
 >
 
@@ -198,6 +304,69 @@ await resonate.promises.resolve(promiseId, { data: JSON.stringify(data) });
 
     </TabItem>
 
+    <TabItem value="rust">
+
+See it in action: [example-human-in-the-loop-rs](https://github.com/resonatehq-examples/example-human-in-the-loop-rs)
+
+```rust
+// worker.rs
+#[resonate::function]
+async fn foo(ctx: &Context) -> Result<()> {
+    // Latent durable promise — no function backing it. Resolved externally.
+    let blocking_promise = ctx.promise::<bool>();
+    let _promise_id = blocking_promise.id().await?;
+    // ...
+    // suspend until the promise is resolved (survives crashes)
+    let _data = blocking_promise.await?;
+    // ...
+    Ok(())
+}
+```
+
+```rust
+use resonate::types::Value;
+
+// resolve from anywhere
+resonate
+    .promises
+    .resolve(&promise_id, Value::from_serializable(data)?)
+    .await?;
+```
+
+    </TabItem>
+
+    <TabItem value="go">
+
+See it in action: [example-human-in-the-loop-go](https://github.com/resonatehq-examples/example-human-in-the-loop-go)
+
+```go
+func foo(ctx *resonate.Context, _ struct{}) (string, error) {
+	// Latent durable promise — no function backing it. Resolved externally.
+	f, err := ctx.Promise()
+	if err != nil {
+		return "", err
+	}
+	promiseID := f.ID() // hand this ID to whoever resolves it
+	_ = promiseID
+	// ...
+	// Await suspends the workflow until the promise settles (survives crashes).
+	var data string
+	if err := f.Await(&data); err != nil {
+		return "", err
+	}
+	// ...
+	return data, nil
+}
+```
+
+```shell
+# The Go SDK has no high-level promises sub-client yet (pre-release), so
+# resolve the latent promise from outside via the Resonate CLI or server API:
+resonate promises resolve <promise-id> --value '{"data": "approved"}'
+```
+
+    </TabItem>
+
 </Tabs>
 
 ## Distributed execution
@@ -214,6 +383,8 @@ Resonate will automatically load balance the invocations across the Workers in t
     values={[
         {label: 'Python', value: 'python'},
         {label: 'TypeScript', value: 'typescript'},
+        {label: 'Rust', value: 'rust'},
+        {label: 'Go', value: 'go'},
     ]}
 >
 
@@ -271,6 +442,62 @@ async function main() {
     })
   );
 }
+```
+
+    </TabItem>
+
+    <TabItem value="rust">
+
+See it in action: [example-load-balancing-rs](https://github.com/resonatehq-examples/example-load-balancing-rs)
+
+```rust
+// worker.rs
+let resonate = Resonate::new(ResonateConfig {
+    url: Some("http://localhost:8001".into()),
+    group: Some("workers".into()),
+    ..Default::default()
+});
+```
+
+```rust
+// client.rs
+let resonate = Resonate::new(ResonateConfig {
+    url: Some("http://localhost:8001".into()),
+    group: Some("client".into()),
+    ..Default::default()
+});
+
+let result: u64 = resonate
+    .rpc(&promise_id, "function_name", params)
+    .target("poll://any@workers")
+    .await?;
+```
+
+    </TabItem>
+
+    <TabItem value="go">
+
+See it in action: [example-load-balancing-go](https://github.com/resonatehq-examples/example-load-balancing-go)
+
+```go
+// worker
+r, _ := resonate.New(resonate.Config{
+	Network: httpnet.NewHTTP("http://localhost:8001", httpnet.HTTPOptions{
+		Group: "workers",
+	}),
+})
+```
+
+```go
+// client
+r, _ := resonate.New(resonate.Config{
+	Network: httpnet.NewHTTP("http://localhost:8001", httpnet.HTTPOptions{
+		Group: "client",
+	}),
+})
+
+h, _ := r.RPC(context.Background(), promiseID, "function_name", params,
+	resonate.RPCOptions{Target: "poll://any@workers"})
 ```
 
     </TabItem>

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -8021,7 +8021,7 @@ Your custom system is tied to your stack, your choices, your company.
 
 **Resonate implements Distributed Async Await** - a protocol with:
 - Formal semantics (TLA+ models, published specifications)
-- Language-agnostic design (TypeScript and Python SDKs today, more coming)
+- Language-agnostic design (TypeScript, Python, and Rust SDKs today, with a Go SDK in active development)
 - Open source implementation (server and SDKs)
 
 If you outgrow Resonate or want to embed the protocol elsewhere, the model is portable.
@@ -8079,7 +8079,7 @@ url: /evaluate/coming-from/dbos
 title: Coming from DBOS
 ---
 
-This page reflects `@resonatehq/sdk` v0.10.2 (current on npm) and `resonate-sdk` v0.6.7 for Python.
+This page reflects `@resonatehq/sdk` v0.10.2 (TypeScript, current on npm), `resonate-sdk` v0.6.7 (Python), `resonate-sdk` v0.4.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
 
 
 **Are you coming from DBOS?**
@@ -8155,13 +8155,80 @@ async function main() {
 
     
 
+    
+
+See it in action: [example-recursive-factorial-rs](https://github.com/resonatehq-examples/example-recursive-factorial-rs)
+
+```rust
+#[resonate::function]
+async fn factorial(ctx: &Context, n: u64) -> Result<u64> {
+    if n <= 1 {
+        return Ok(1);
+    }
+    let result = ctx.run(factorial, n - 1).await?;
+
+    Ok(n * result)
+}
+
+#[tokio::main]
+async fn main() {
+    let resonate = Resonate::local();
+    resonate.register(factorial).unwrap();
+
+    let result: u64 = resonate.run("factorial-5", factorial, 5).await.unwrap();
+    println!("{result}");
+
+    resonate.stop().await.unwrap();
+}
+```
+
+    
+
+    
+
+See it in action: [example-recursive-factorial-go](https://github.com/resonatehq-examples/example-recursive-factorial-go)
+
+```go
+type Args struct {
+	N int `json:"n"`
+}
+
+func factorial(ctx *resonate.Context, args Args) (int, error) {
+	if args.N <= 1 {
+		return 1, nil
+	}
+	f, err := ctx.Run(factorial, Args{N: args.N - 1})
+	if err != nil {
+		return 0, err
+	}
+	var result int
+	if err := f.Await(&result); err != nil {
+		return 0, err
+	}
+	return args.N * result, nil
+}
+
+func main() {
+	r, _ := resonate.New(resonate.Config{URL: "http://localhost:8001"})
+	defer func() { _ = r.Stop() }()
+
+	factorialFn, _ := resonate.Register(r, "factorial", factorial)
+
+	h, _ := factorialFn.Run(context.Background(), "factorial-5", Args{N: 5})
+	result, _ := h.Result(context.Background())
+	fmt.Println(result)
+}
+```
+
+    
+
 
 
 ## Zero-dependency development
 
-With DBOS, your Worker or application must always connect to a Postgres database, whether it’s a local development or a production instance.
+With DBOS, your application always runs against a database. Recent versions default to an embedded SQLite database for local development and use Postgres in production, so there is always a database in the loop.
 
-Resonate offers a zero-dependency development experience, where a Worker (single node application) can run without connecting to a Resonate Server.
+Resonate offers a zero-dependency development experience: a Worker (single node application) runs entirely in-memory, with no database and no Resonate Server, until you choose to connect one.
 
 
 
@@ -8182,6 +8249,39 @@ resonate = Resonate.local()
 
 ```typescript
 const resonate = new Resonate();
+
+// ...
+```
+
+    
+
+    
+
+```rust
+use resonate::prelude::*;
+
+let resonate = Resonate::local();
+
+// ...
+```
+
+    
+
+    
+
+```go
+import (
+	resonate "github.com/resonatehq/resonate-sdk-go"
+	"github.com/resonatehq/resonate-sdk-go/localnet"
+)
+
+// Local development mode runs the server state machine in-process,
+// using in-memory storage for promises and tasks.
+pid := "dev-worker"
+r, _ := resonate.New(resonate.Config{
+	Network:   localnet.NewLocal("default", &pid),
+	Heartbeat: resonate.NoopHeartbeat{}, // localnet has no lease endpoint to heartbeat against
+})
 
 // ...
 ```
@@ -8247,15 +8347,78 @@ await resonate.promises.resolve(promiseId, { data: JSON.stringify(data) });
 
     
 
+    
+
+See it in action: [example-human-in-the-loop-rs](https://github.com/resonatehq-examples/example-human-in-the-loop-rs)
+
+```rust
+// worker.rs
+#[resonate::function]
+async fn foo(ctx: &Context) -> Result<()> {
+    // Latent durable promise — no function backing it. Resolved externally.
+    let blocking_promise = ctx.promise::<bool>();
+    let _promise_id = blocking_promise.id().await?;
+    // ...
+    // suspend until the promise is resolved (survives crashes)
+    let _data = blocking_promise.await?;
+    // ...
+    Ok(())
+}
+```
+
+```rust
+use resonate::types::Value;
+
+// resolve from anywhere
+resonate
+    .promises
+    .resolve(&promise_id, Value::from_serializable(data)?)
+    .await?;
+```
+
+    
+
+    
+
+See it in action: [example-human-in-the-loop-go](https://github.com/resonatehq-examples/example-human-in-the-loop-go)
+
+```go
+func foo(ctx *resonate.Context, _ struct{}) (string, error) {
+	// Latent durable promise — no function backing it. Resolved externally.
+	f, err := ctx.Promise()
+	if err != nil {
+		return "", err
+	}
+	promiseID := f.ID() // hand this ID to whoever resolves it
+	_ = promiseID
+	// ...
+	// Await suspends the workflow until the promise settles (survives crashes).
+	var data string
+	if err := f.Await(&data); err != nil {
+		return "", err
+	}
+	// ...
+	return data, nil
+}
+```
+
+```shell
+# The Go SDK has no high-level promises sub-client yet (pre-release), so
+# resolve the latent promise from outside via the Resonate CLI or server API:
+resonate promises resolve <promise-id> --value '{"data": "approved"}'
+```
+
+    
+
 
 
 ## Distributed execution
 
-A major difference between Resonate and DBOS is that Resonate can orchestrate executions across multiple Workers while DBOS cannot.
 With Resonate, you can run multiple Workers in a group, and Resonate will automatically load-balance invocations across them.
+DBOS can also distribute work across multiple processes, using durable queues that those processes poll.
+The meaningful difference is in crash recovery, which we cover below.
 
 Consider the following Resonate example.
-How would you accomplish this using DBOS?
 
 
 
@@ -8317,14 +8480,69 @@ async function main() {
 
     
 
+    
+
+See it in action: [example-load-balancing-rs](https://github.com/resonatehq-examples/example-load-balancing-rs)
+
+```rust
+// worker.rs
+let resonate = Resonate::new(ResonateConfig {
+    url: Some("http://localhost:8001".into()),
+    group: Some("workers".into()),
+    ..Default::default()
+});
+```
+
+```rust
+// client.rs
+let resonate = Resonate::new(ResonateConfig {
+    url: Some("http://localhost:8001".into()),
+    group: Some("client".into()),
+    ..Default::default()
+});
+
+let result: u64 = resonate
+    .rpc(&promise_id, "function_name", params)
+    .target("poll://any@workers")
+    .await?;
+```
+
+    
+
+    
+
+See it in action: [example-load-balancing-go](https://github.com/resonatehq-examples/example-load-balancing-go)
+
+```go
+// worker
+r, _ := resonate.New(resonate.Config{
+	Network: httpnet.NewHTTP("http://localhost:8001", httpnet.HTTPOptions{
+		Group: "workers",
+	}),
+})
+```
+
+```go
+// client
+r, _ := resonate.New(resonate.Config{
+	Network: httpnet.NewHTTP("http://localhost:8001", httpnet.HTTPOptions{
+		Group: "client",
+	}),
+})
+
+h, _ := r.RPC(context.Background(), promiseID, "function_name", params,
+	resonate.RPCOptions{Target: "poll://any@workers"})
+```
+
+    
 
 
-DBOS is designed to ensure durability for a single instance of an application.
-When a DBOS application process crashes, an operator must restart the application for any in-progress functions/workflows to recover and resume.
 
-Resonate will automatically recover and resume in-progress functions/workflows in another Worker.
+The meaningful difference is in crash recovery.
+Resonate automatically recovers and resumes in-progress functions/workflows in another Worker, as part of its open-source core.
 
-In essence, DBOS focuses on single-instance durability without addressing scalability, while Resonate holistically addresses the needs of modern distributed systems.
+With DBOS, automatic recovery of in-progress workflows across instances relies on DBOS Conductor (a separate service, with its full feature set on a paid tier).
+Without Conductor, recovery in a distributed deployment is coordinated manually, and a single-node deployment recovers its own workflows when that process restarts.
 
 ---
 
@@ -8708,7 +8926,7 @@ url: /evaluate/coming-from/temporal
 title: Coming from Temporal
 ---
 
-This page reflects `@resonatehq/sdk` v0.10.2 (current on npm) and `resonate-sdk` v0.6.7 for Python.
+This page reflects `@resonatehq/sdk` v0.10.2 (TypeScript, current on npm), `resonate-sdk` v0.6.7 (Python), `resonate-sdk` v0.4.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
 
 
 **Are you coming from Temporal?**
@@ -8785,6 +9003,73 @@ async function main() {
 
     
 
+    
+
+See it in action: [example-recursive-factorial-rs](https://github.com/resonatehq-examples/example-recursive-factorial-rs)
+
+```rust
+#[resonate::function]
+async fn factorial(ctx: &Context, n: u64) -> Result<u64> {
+    if n <= 1 {
+        return Ok(1);
+    }
+    let result = ctx.run(factorial, n - 1).await?;
+
+    Ok(n * result)
+}
+
+#[tokio::main]
+async fn main() {
+    let resonate = Resonate::local();
+    resonate.register(factorial).unwrap();
+
+    let result: u64 = resonate.run("factorial-5", factorial, 5).await.unwrap();
+    println!("{result}");
+
+    resonate.stop().await.unwrap();
+}
+```
+
+    
+
+    
+
+See it in action: [example-recursive-factorial-go](https://github.com/resonatehq-examples/example-recursive-factorial-go)
+
+```go
+type Args struct {
+	N int `json:"n"`
+}
+
+func factorial(ctx *resonate.Context, args Args) (int, error) {
+	if args.N <= 1 {
+		return 1, nil
+	}
+	f, err := ctx.Run(factorial, Args{N: args.N - 1})
+	if err != nil {
+		return 0, err
+	}
+	var result int
+	if err := f.Await(&result); err != nil {
+		return 0, err
+	}
+	return args.N * result, nil
+}
+
+func main() {
+	r, _ := resonate.New(resonate.Config{URL: "http://localhost:8001"})
+	defer func() { _ = r.Stop() }()
+
+	factorialFn, _ := resonate.Register(r, "factorial", factorial)
+
+	h, _ := factorialFn.Run(context.Background(), "factorial-5", Args{N: 5})
+	result, _ := h.Result(context.Background())
+	fmt.Println(result)
+}
+```
+
+    
+
 
 
 ## Zero-dependency development
@@ -8811,6 +9096,39 @@ resonate = Resonate.local()
 
 ```typescript
 const resonate = new Resonate();
+
+// ...
+```
+
+    
+
+    
+
+```rust
+use resonate::prelude::*;
+
+let resonate = Resonate::local();
+
+// ...
+```
+
+    
+
+    
+
+```go
+import (
+	resonate "github.com/resonatehq/resonate-sdk-go"
+	"github.com/resonatehq/resonate-sdk-go/localnet"
+)
+
+// Local development mode runs the server state machine in-process,
+// using in-memory storage for promises and tasks.
+pid := "dev-worker"
+r, _ := resonate.New(resonate.Config{
+	Network:   localnet.NewLocal("default", &pid),
+	Heartbeat: resonate.NoopHeartbeat{}, // localnet has no lease endpoint to heartbeat against
+})
 
 // ...
 ```
@@ -8872,6 +9190,69 @@ function* foo(context: Context) {
 ```typescript
 // client.ts
 await resonate.promises.resolve(promiseId, { data: JSON.stringify(data) });
+```
+
+    
+
+    
+
+See it in action: [example-human-in-the-loop-rs](https://github.com/resonatehq-examples/example-human-in-the-loop-rs)
+
+```rust
+// worker.rs
+#[resonate::function]
+async fn foo(ctx: &Context) -> Result<()> {
+    // Latent durable promise — no function backing it. Resolved externally.
+    let blocking_promise = ctx.promise::<bool>();
+    let _promise_id = blocking_promise.id().await?;
+    // ...
+    // suspend until the promise is resolved (survives crashes)
+    let _data = blocking_promise.await?;
+    // ...
+    Ok(())
+}
+```
+
+```rust
+use resonate::types::Value;
+
+// resolve from anywhere
+resonate
+    .promises
+    .resolve(&promise_id, Value::from_serializable(data)?)
+    .await?;
+```
+
+    
+
+    
+
+See it in action: [example-human-in-the-loop-go](https://github.com/resonatehq-examples/example-human-in-the-loop-go)
+
+```go
+func foo(ctx *resonate.Context, _ struct{}) (string, error) {
+	// Latent durable promise — no function backing it. Resolved externally.
+	f, err := ctx.Promise()
+	if err != nil {
+		return "", err
+	}
+	promiseID := f.ID() // hand this ID to whoever resolves it
+	_ = promiseID
+	// ...
+	// Await suspends the workflow until the promise settles (survives crashes).
+	var data string
+	if err := f.Await(&data); err != nil {
+		return "", err
+	}
+	// ...
+	return data, nil
+}
+```
+
+```shell
+# The Go SDK has no high-level promises sub-client yet (pre-release), so
+# resolve the latent promise from outside via the Resonate CLI or server API:
+resonate promises resolve <promise-id> --value '{"data": "approved"}'
 ```
 
     
@@ -8942,6 +9323,62 @@ async function main() {
     })
   );
 }
+```
+
+    
+
+    
+
+See it in action: [example-load-balancing-rs](https://github.com/resonatehq-examples/example-load-balancing-rs)
+
+```rust
+// worker.rs
+let resonate = Resonate::new(ResonateConfig {
+    url: Some("http://localhost:8001".into()),
+    group: Some("workers".into()),
+    ..Default::default()
+});
+```
+
+```rust
+// client.rs
+let resonate = Resonate::new(ResonateConfig {
+    url: Some("http://localhost:8001".into()),
+    group: Some("client".into()),
+    ..Default::default()
+});
+
+let result: u64 = resonate
+    .rpc(&promise_id, "function_name", params)
+    .target("poll://any@workers")
+    .await?;
+```
+
+    
+
+    
+
+See it in action: [example-load-balancing-go](https://github.com/resonatehq-examples/example-load-balancing-go)
+
+```go
+// worker
+r, _ := resonate.New(resonate.Config{
+	Network: httpnet.NewHTTP("http://localhost:8001", httpnet.HTTPOptions{
+		Group: "workers",
+	}),
+})
+```
+
+```go
+// client
+r, _ := resonate.New(resonate.Config{
+	Network: httpnet.NewHTTP("http://localhost:8001", httpnet.HTTPOptions{
+		Group: "client",
+	}),
+})
+
+h, _ := r.RPC(context.Background(), promiseID, "function_name", params,
+	resonate.RPCOptions{Target: "poll://any@workers"})
 ```
 
     

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -8405,7 +8405,7 @@ func foo(ctx *resonate.Context, _ struct{}) (string, error) {
 ```shell
 # The Go SDK has no high-level promises sub-client yet (pre-release), so
 # resolve the latent promise from outside via the Resonate CLI or server API:
-resonate promises resolve <promise-id> --value '{"data": "approved"}'
+resonate promises resolve <promise-id> --value '{"headers": {}, "data": "approved"}'
 ```
 
     
@@ -8541,7 +8541,7 @@ h, _ := r.RPC(context.Background(), promiseID, "function_name", params,
 The meaningful difference is in crash recovery.
 Resonate automatically recovers and resumes in-progress functions/workflows in another Worker, as part of its open-source core.
 
-With DBOS, automatic recovery of in-progress workflows across instances relies on DBOS Conductor (a separate service, with its full feature set on a paid tier).
+With DBOS, automatic recovery of in-progress workflows across instances relies on DBOS Conductor, a separate service with tiered plans.
 Without Conductor, recovery in a distributed deployment is coordinated manually, and a single-node deployment recovers its own workflows when that process restarts.
 
 ---
@@ -9252,7 +9252,7 @@ func foo(ctx *resonate.Context, _ struct{}) (string, error) {
 ```shell
 # The Go SDK has no high-level promises sub-client yet (pre-release), so
 # resolve the latent promise from outside via the Resonate CLI or server API:
-resonate promises resolve <promise-id> --value '{"data": "approved"}'
+resonate promises resolve <promise-id> --value '{"headers": {}, "data": "approved"}'
 ```
 
     


### PR DESCRIPTION
## What

On the **Evaluate → Coming from** comparison pages:

- **Rust + Go SDK tabs** added to `temporal.mdx` and `dbos.mdx` everywhere those pages already had Python/TypeScript language tabs — the recursive-factorial, zero-dependency-development, human-in-the-loop, and distributed-execution sections.
- **SDK-version callouts** on both pages now list TypeScript `0.10.2`, Python `0.6.7`, Rust `0.4.0`, and the pre-release Go SDK.
- **BYODE page** SDK list now reads "TypeScript, Python, and Rust SDKs today, with a Go SDK in active development" (was "TypeScript and Python … more coming").
- **DBOS accuracy** corrected against DBOS 2.x (see review note below).

## Verification

- Every Rust snippet compiles against `resonate-sdk` **0.4.0** (crates.io); every Go snippet compiles against the current Go SDK `main`.
- The Go human-in-the-loop tab honestly notes the Go SDK has no high-level promises sub-client yet (pre-release) and shows the CLI resolve path.
- `npm run build` clean; link check **0 internal broken** (6 pre-existing external localhost warns).
- Restate page: code re-verified accurate against `@restatedev/restate-sdk` 1.14.x — no changes needed. Temporal claims re-verified accurate against current Temporal — no changes needed.

## Review note (DBOS competitive framing)

Two DBOS claims were factually out of date and have been rewritten:

1. **Zero-dependency:** "must always connect to a Postgres database … local development" → DBOS now defaults to an embedded SQLite database locally (Postgres in production). Resonate's differentiator (a fully in-memory local Worker, no database at all) is preserved.
2. **Distributed execution:** "Resonate can orchestrate across multiple Workers while DBOS cannot" / "DBOS focuses on single-instance durability without addressing scalability" → DBOS *does* distribute work across processes via durable queues. The honest, narrower difference is now stated: Resonate's cross-Worker recovery is in the open-source core, whereas DBOS's automatic cross-instance recovery relies on DBOS Conductor.

Please confirm the exact competitor wording before merge.