### PR TITLE
docs: replace idiomatic "cheap" with low-cost wording

### DIFF
--- a/content/docs/deploy/index.mdx
+++ b/content/docs/deploy/index.mdx
@@ -188,7 +188,7 @@ services:
       replicas: 5
 ```
 
-**Why:** Simple, cheap, easy to manage. Perfect for small teams.
+**Why:** Simple, low-cost, easy to manage. Perfect for small teams.
 
 ### Medium production (10-100 workers)
 

--- a/content/docs/deploy/scaling.mdx
+++ b/content/docs/deploy/scaling.mdx
@@ -293,7 +293,7 @@ gcloud run deploy resonate-worker \
 ```
 
 <Callout type="tip" title="Start with containers, scale to serverless later">
-Containerized workers are easier to debug and cheaper at low scale. Move to serverless when you need auto-scaling or have highly variable load.
+Containerized workers are easier to debug and lower-cost at low scale. Move to serverless when you need auto-scaling or have highly variable load.
 </Callout>
 
 ## Server scaling limitations

--- a/content/docs/get-started/examples/async-http-api-endpoints.mdx
+++ b/content/docs/get-started/examples/async-http-api-endpoints.mdx
@@ -369,7 +369,7 @@ You'll see `pending` until the worker completes, then `resolved` with the result
 
 ## Try the dedup story
 
-Call `/begin` twice with the same `id`. Resonate doesn't run the work twice — the second call reconnects to the in-flight execution and the polling endpoint returns the same eventual result. This is the same idempotency primitive that makes safe retries cheap.
+Call `/begin` twice with the same `id`. Resonate doesn't run the work twice — the second call reconnects to the in-flight execution and the polling endpoint returns the same eventual result. This is the same idempotency primitive that makes safe retries inexpensive.
 
 ## Related
 


### PR DESCRIPTION
Echo-corpus vocabulary scrub: "cheap" reworded to "low-cost"/"lower-cost"/"inexpensive" in deploy/index, deploy/scaling, async-http-api-endpoints. Cost-of-operation uses; no meaning change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)