### PR TITLE
fix(mdx): label code blocks properly; tidy migration comparisons

### DIFF
--- a/components/mdx/CodeBlock.tsx
+++ b/components/mdx/CodeBlock.tsx
@@ -7,6 +7,19 @@ interface PreProps extends HTMLAttributes<HTMLPreElement> {
   children?: ReactNode;
   title?: string;
   "data-title"?: string;
+  "data-language"?: string;
+}
+
+// A migration guide titles its code blocks `System — path/to/file` (e.g.
+// `Resonate — example-hello-world-py/main.py`). Split that into a system
+// label and a filename so the header can badge the system and show the file
+// cleanly, instead of cramming both onto a bold line above an unlabeled block.
+const TITLE_SEPARATOR = " — ";
+
+function parseTitle(title: string): { system: string | null; file: string } {
+  const i = title.indexOf(TITLE_SEPARATOR);
+  if (i === -1) return { system: null, file: title };
+  return { system: title.slice(0, i), file: title.slice(i + TITLE_SEPARATOR.length) };
 }
 
 const LANGUAGE_LABELS: Record<string, string> = {
@@ -44,20 +57,32 @@ const LANGUAGE_LABELS: Record<string, string> = {
   yml: "yaml",
 };
 
-// Shiki tags the inner <code> with `language-X`. Pull X out so the chrome can
-// label even blocks that don't pass an explicit `title=`.
-function extractLanguage(children: ReactNode): string | null {
+// Shiki bakes the language into inline styles and drops the `language-X`
+// class, so prefer the `data-language` stamped on the <pre> by our rehype
+// transformer; fall back to the legacy class on the inner <code> just in case.
+function extractLanguage(children: ReactNode, dataLanguage?: string): string | null {
+  if (dataLanguage) return dataLanguage;
   if (!isValidElement(children)) return null;
   const className = (children.props as { className?: string })?.className ?? "";
   const match = className.match(/language-([a-zA-Z0-9_+-]+)/);
   return match ? match[1] : null;
 }
 
-export function Pre({ children, title, "data-title": dataTitle, ...props }: PreProps) {
+export function Pre({
+  children,
+  title,
+  "data-title": dataTitle,
+  "data-language": dataLanguage,
+  ...props
+}: PreProps) {
   const ref = useRef<HTMLDivElement>(null);
   const displayTitle = title || dataTitle;
-  const lang = extractLanguage(children);
+  const lang = extractLanguage(children, dataLanguage);
   const langLabel = lang ? (LANGUAGE_LABELS[lang.toLowerCase()] ?? lang.toLowerCase()) : null;
+  const { system, file } = displayTitle
+    ? parseTitle(displayTitle)
+    : { system: null, file: null };
+  const isResonate = system?.toLowerCase() === "resonate";
 
   return (
     <div className="group relative [&:not(:first-child)]:mt-4 last:mb-0">
@@ -65,13 +90,20 @@ export function Pre({ children, title, "data-title": dataTitle, ...props }: PreP
         <div className="flex items-center gap-2 min-w-0">
           {displayTitle ? (
             <>
-              <span className="truncate text-bright-gray-900 dark:text-primary">{displayTitle}</span>
-              {langLabel && (
-                <span className="shrink-0 text-fg-muted/60">·</span>
+              {system && (
+                <span
+                  className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                    isResonate
+                      ? "bg-secondary/15 text-accent-teal-700 dark:text-secondary"
+                      : "bg-bright-gray-200/80 text-bright-gray-600 dark:bg-primary/10 dark:text-fg-muted"
+                  }`}
+                >
+                  {system}
+                </span>
               )}
-              {langLabel && (
-                <span className="shrink-0 text-fg-muted">{langLabel}</span>
-              )}
+              <span className="truncate text-bright-gray-900 dark:text-primary">{file}</span>
+              {langLabel && <span className="shrink-0 text-fg-muted/60">·</span>}
+              {langLabel && <span className="shrink-0 text-fg-muted">{langLabel}</span>}
             </>
           ) : (
             <span className="text-fg-muted">{langLabel ?? "code"}</span>

--- a/content/docs/evaluate/coming-from/dbos.mdx
+++ b/content/docs/evaluate/coming-from/dbos.mdx
@@ -50,9 +50,7 @@ Here is the most basic migration — a workflow that runs a few steps, and the e
 
 <TabItem value="python">
 
-**DBOS** — `dbos-demo-apps/python/dbos-app-starter/app/main.py`:
-
-```python
+```python title="DBOS — dbos-demo-apps/python/dbos-app-starter/app/main.py"
 @DBOS.step()
 def step_one():
     time.sleep(5)
@@ -64,9 +62,7 @@ def workflow():
     # ... step_two(), step_three() ...
 ```
 
-**Resonate** — `example-hello-world-py/main.py`:
-
-```python
+```python title="Resonate — example-hello-world-py/main.py"
 def bar(_: Context, greetee: str) -> str:
     return f"Hello {greetee} from bar!"
 
@@ -88,9 +84,7 @@ def foo(ctx: Context, greetee: str) -> Generator[Any, Any, str]:
 
 <TabItem value="typescript">
 
-**DBOS** — `dbos-demo-apps/typescript/dbos-node-starter/src/main.ts`:
-
-```typescript
+```typescript title="DBOS — dbos-demo-apps/typescript/dbos-node-starter/src/main.ts"
 async function stepOne() {
   await sleep(5000);
   console.log("Completed step 1!");
@@ -104,9 +98,7 @@ async function exampleWorkflow() {
 const registeredWorkflow = DBOS.registerWorkflow(exampleWorkflow);
 ```
 
-**Resonate** — `example-hello-world-ts/index.ts`:
-
-```typescript
+```typescript title="Resonate — example-hello-world-ts/index.ts"
 async function bar(_: Context, greetee: string): Promise<string> {
   return `Hello ${greetee} from bar!`;
 }
@@ -136,9 +128,7 @@ const fooR = resonate.register("foo", foo);
 DBOS ships SDKs for TypeScript, Python, Go, and Java. There is no DBOS Rust SDK, so there is no DBOS code to place beside Resonate here. The Resonate Rust equivalent:
 </Callout>
 
-**Resonate** — `example-hello-world-rs/src/main.rs`:
-
-```rust
+```rust title="Resonate — example-hello-world-rs/src/main.rs"
 #[resonate::function]
 async fn greet(ctx: &Context, name: String) -> Result<String> {
     let greeting = ctx.run(format_greeting, name).await?;
@@ -157,9 +147,7 @@ async fn format_greeting(name: String) -> Result<String> {
 
 <TabItem value="go">
 
-**DBOS** — `dbos-demo-apps/golang/dbos-go-starter/main.go`:
-
-```go
+```go title="DBOS — dbos-demo-apps/golang/dbos-go-starter/main.go"
 func ExampleWorkflow(ctx dbos.DBOSContext, _ string) (string, error) {
     _, err := dbos.RunAsStep(ctx, func(stepCtx context.Context) (string, error) {
         return stepOne(stepCtx)
@@ -180,9 +168,7 @@ func stepOne(ctx context.Context) (string, error) {
 
 In `main()`, register it with `dbos.RegisterWorkflow(dbosCtx, ExampleWorkflow)`.
 
-**Resonate** — `example-hello-world-go/main.go`:
-
-```go
+```go title="Resonate — example-hello-world-go/main.go"
 func greet(_ *resonate.Context, args GreetArgs) (string, error) {
     return fmt.Sprintf("hello, %s!", args.Name), nil
 }
@@ -507,9 +493,7 @@ def process_tasks(tasks):
     return [handle.get_result() for handle in task_handles]
 ```
 
-**Resonate** — `example-fan-out-fan-in-py/workflow.py`:
-
-```python
+```python title="Resonate — example-fan-out-fan-in-py/workflow.py"
 # fan-out: rfi() returns a handle immediately
 email_p = yield ctx.rfi(send_email, event).options(id=f"{ctx.id}.email")
 sms_p   = yield ctx.rfi(send_sms, event).options(id=f"{ctx.id}.sms")
@@ -539,9 +523,7 @@ async function queueFunction() {
 }
 ```
 
-**Resonate** — `example-fan-out-fan-in-ts/src/workflow.ts`:
-
-```typescript
+```typescript title="Resonate — example-fan-out-fan-in-ts/src/workflow.ts"
 // fan-out: beginRun returns a future immediately
 const emailFuture = yield* ctx.beginRun(sendEmail, event);
 const smsFuture   = yield* ctx.beginRun(sendSms, event);
@@ -559,9 +541,7 @@ const results = [yield* emailFuture, yield* smsFuture];
 The Resonate Rust equivalent fans out with `.spawn()`:
 </Callout>
 
-**Resonate** — `example-fan-out-fan-in-rs/src/main.rs`:
-
-```rust
+```rust title="Resonate — example-fan-out-fan-in-rs/src/main.rs"
 // fan-out: .spawn() returns a handle immediately
 let h1 = ctx.run(process_item, items[0].clone()).spawn().await?;
 let h2 = ctx.run(process_item, items[1].clone()).spawn().await?;
@@ -601,9 +581,7 @@ for i, handle := range handles {                         // fan-in
 }
 ```
 
-**Resonate** — `example-fan-out-fan-in-go/main.go`:
-
-```go
+```go title="Resonate — example-fan-out-fan-in-go/main.go"
 futures := make([]*resonate.Future, 0, len(args.Channels))
 for _, ch := range args.Channels {                       // fan-out
     f, err := ctx.RPC("send", SendArgs{Channel: ch, Message: args.Message})
@@ -649,9 +627,7 @@ Both systems vary the unit by SDK. DBOS: TypeScript `DBOS.sleep` takes **millise
 
 <TabItem value="python">
 
-**DBOS** — `dbos-demo-apps/python/widget-store/widget_store/main.py`:
-
-```python
+```python title="DBOS — dbos-demo-apps/python/widget-store/widget_store/main.py"
 @DBOS.workflow()
 def dispatch_order_workflow(order_id):
     for _ in range(10):
@@ -659,9 +635,7 @@ def dispatch_order_workflow(order_id):
         update_order_progress(order_id)
 ```
 
-**Resonate** — `example-durable-sleep-py/worker.py`:
-
-```python
+```python title="Resonate — example-durable-sleep-py/worker.py"
 @resonate.register
 def sleeping_workflow(ctx: Context, wf_id: str, secs: float):
     print(f"Workflow {wf_id} starting, will sleep for {secs} seconds.")
@@ -675,9 +649,7 @@ def sleeping_workflow(ctx: Context, wf_id: str, secs: float):
 
 <TabItem value="typescript">
 
-**DBOS** — `dbos-demo-apps/typescript/widget-store/src/shop.ts`:
-
-```typescript
+```typescript title="DBOS — dbos-demo-apps/typescript/widget-store/src/shop.ts"
 export const dispatchOrder = DBOS.registerWorkflow(
   async (order_id: number) => {
     for (let i = 0; i < 10; i++) {
@@ -689,9 +661,7 @@ export const dispatchOrder = DBOS.registerWorkflow(
 );
 ```
 
-**Resonate** — `example-durable-sleep-ts/worker.ts`:
-
-```typescript
+```typescript title="Resonate — example-durable-sleep-ts/worker.ts"
 function* sleepingWorkflow(ctx: Context, ms: number) {
   yield* ctx.run((ctx: Context) => console.log(`Sleeping for ${ms / 1000} seconds...`));
   yield* ctx.sleep(ms);                        // milliseconds
@@ -709,9 +679,7 @@ function* sleepingWorkflow(ctx: Context, ms: number) {
 The Resonate Rust equivalent sleeps on a native `Duration`:
 </Callout>
 
-**Resonate** — `example-durable-sleep-rs/src/bin/worker.rs`:
-
-```rust
+```rust title="Resonate — example-durable-sleep-rs/src/bin/worker.rs"
 #[resonate::function]
 async fn sleeping_workflow(ctx: &Context, secs: u64) -> Result<String> {
     ctx.sleep(Duration::from_secs(secs)).await?;   // std::time::Duration
@@ -725,9 +693,7 @@ async fn sleeping_workflow(ctx: &Context, secs: u64) -> Result<String> {
 
 <TabItem value="go">
 
-**DBOS** — `dbos-demo-apps/golang/widget-store/workflows.go`:
-
-```go
+```go title="DBOS — dbos-demo-apps/golang/widget-store/workflows.go"
 func dispatchOrderWorkflow(ctx dbos.DBOSContext, orderID int) (string, error) {
     for range 10 {
         _, err := dbos.Sleep(ctx, time.Second)     // time.Duration
@@ -740,9 +706,7 @@ func dispatchOrderWorkflow(ctx dbos.DBOSContext, orderID int) (string, error) {
 }
 ```
 
-**Resonate** — `example-durable-sleep-go/main.go`:
-
-```go
+```go title="Resonate — example-durable-sleep-go/main.go"
 func sleepingWorkflow(ctx *resonate.Context, args SleepArgs) (string, error) {
     d := time.Duration(args.Secs) * time.Second
     f, err := ctx.Sleep(d)                       // time.Duration
@@ -781,9 +745,7 @@ DBOS uses a **6-field** cron with a leading seconds component — `* * * * * *` 
 
 <TabItem value="python">
 
-**DBOS** — `dbos-transact-py/tests/test_scheduler_decorator.py`:
-
-```python
+```python title="DBOS — dbos-transact-py/tests/test_scheduler_decorator.py"
 @DBOS.scheduled("* * * * * *")
 @DBOS.workflow()
 def test_workflow(scheduled: datetime, actual: datetime) -> None:
@@ -808,9 +770,7 @@ resonate.schedules.create(
 
 <TabItem value="typescript">
 
-**DBOS** — `dbos-transact-ts/tests/scheduler_decorator.test.ts`:
-
-```typescript
+```typescript title="DBOS — dbos-transact-ts/tests/scheduler_decorator.test.ts"
 @DBOS.scheduled({ crontab: '* * * * * *', mode: SchedulerMode.ExactlyOncePerIntervalWhenActive })
 @DBOS.workflow()
 static async scheduledDefault(schedTime: Date, startTime: Date) {
@@ -818,9 +778,7 @@ static async scheduledDefault(schedTime: Date, startTime: Date) {
 }
 ```
 
-**Resonate** — `example-schedule-ts/src/schedule.ts`:
-
-```typescript
+```typescript title="Resonate — example-schedule-ts/src/schedule.ts"
 await resonate.schedule("my-schedule", "* * * * *", myFunction /* , ...args */);
 ```
 
@@ -834,9 +792,7 @@ await resonate.schedule("my-schedule", "* * * * *", myFunction /* , ...args */);
 The Resonate Rust equivalent registers the schedule with the server:
 </Callout>
 
-**Resonate** — `example-schedule-rs/src/bin/schedule.rs`:
-
-```rust
+```rust title="Resonate — example-schedule-rs/src/bin/schedule.rs"
 let result = resonate
     .schedule(
         "daily_report",    // schedule ID
@@ -888,9 +844,7 @@ With Resonate, you achieve the same effect by creating a Durable Promise that is
 
 <TabItem value="python">
 
-**DBOS** — `dbos-demo-apps/python/widget-store/widget_store/main.py`:
-
-```python
+```python title="DBOS — dbos-demo-apps/python/widget-store/widget_store/main.py"
 @DBOS.workflow()
 def checkout_workflow():
     # ...
@@ -902,9 +856,7 @@ def checkout_workflow():
 DBOS.send(payment_id, payment_status, PAYMENT_STATUS)
 ```
 
-**Resonate** — `example-human-in-the-loop-py`:
-
-```python
+```python title="Resonate — example-human-in-the-loop-py"
 # worker.py
 @resonate.register()
 def foo(ctx, workflow_id):
@@ -927,9 +879,7 @@ resonate.promises.resolve(id=promise_id, ikey=promise_id)
 
 <TabItem value="typescript">
 
-**DBOS** — `dbos-demo-apps/typescript/widget-store/src/main.ts`:
-
-```typescript
+```typescript title="DBOS — dbos-demo-apps/typescript/widget-store/src/main.ts"
 export const checkoutWorkflow = DBOS.registerWorkflow(
   async () => {
     // ...
@@ -944,9 +894,7 @@ export const checkoutWorkflow = DBOS.registerWorkflow(
 await DBOS.send(key, status, PAYMENT_TOPIC);
 ```
 
-**Resonate** — `example-human-in-the-loop-ts`:
-
-```typescript
+```typescript title="Resonate — example-human-in-the-loop-ts"
 function* fooWorkflow(ctx: Context, workflowId: string) {
   const blockingPromise = yield* ctx.promise({});
   yield* ctx.run(sendEmail, blockingPromise.id);
@@ -1004,9 +952,7 @@ resonate
 
 <TabItem value="go">
 
-**DBOS** — `dbos-demo-apps/golang/widget-store/workflows.go`:
-
-```go
+```go title="DBOS — dbos-demo-apps/golang/widget-store/workflows.go"
 func checkoutWorkflow(ctx dbos.DBOSContext, _ string) (string, error) {
     // ...
     err = dbos.SetEvent(ctx, PAYMENT_ID, workflowID)                       // publish status
@@ -1015,9 +961,7 @@ func checkoutWorkflow(ctx dbos.DBOSContext, _ string) (string, error) {
 }
 ```
 
-**Resonate** — `example-human-in-the-loop-go`:
-
-```go
+```go title="Resonate — example-human-in-the-loop-go"
 func foo(ctx *resonate.Context, _ struct{}) (string, error) {
 	// Latent durable promise — no function backing it. Resolved externally.
 	f, err := ctx.Promise()
@@ -1068,9 +1012,7 @@ A saga runs a sequence of steps and, on failure, runs **compensations** to undo 
 
 <TabItem value="python">
 
-**DBOS** — `dbos-demo-apps/python/widget-store/widget_store/main.py`:
-
-```python
+```python title="DBOS — dbos-demo-apps/python/widget-store/widget_store/main.py"
 @DBOS.workflow()
 def checkout_workflow():
     order_id = create_order()
@@ -1089,9 +1031,7 @@ def checkout_workflow():
         update_order_status(order_id=order_id, status=OrderStatus.CANCELLED.value)
 ```
 
-**Resonate** — `example-money-transfer-py/main.py`:
-
-```python
+```python title="Resonate — example-money-transfer-py/main.py"
 def transfer_money(ctx, transfer_id, source, target, amount, *, simulate_credit_failure=False):
     yield ctx.run(apply_entry, f"{transfer_id}-debit", source, -amount, "debit")
     try:
@@ -1112,9 +1052,7 @@ def transfer_money(ctx, transfer_id, source, target, amount, *, simulate_credit_
 
 <TabItem value="typescript">
 
-**DBOS** — `dbos-demo-apps/typescript/widget-store/src/main.ts`:
-
-```typescript
+```typescript title="DBOS — dbos-demo-apps/typescript/widget-store/src/main.ts"
 export const checkoutWorkflow = DBOS.registerWorkflow(
   async () => {
     try {
@@ -1137,9 +1075,7 @@ export const checkoutWorkflow = DBOS.registerWorkflow(
 );
 ```
 
-**Resonate** — `example-saga-booking-ts/src/workflow.ts`:
-
-```typescript
+```typescript title="Resonate — example-saga-booking-ts/src/workflow.ts"
 let flightId: string | undefined;
 let hotelId: string | undefined;
 try {
@@ -1165,9 +1101,7 @@ try {
 The Resonate Rust equivalent compensates inline in the error branch:
 </Callout>
 
-**Resonate** — `example-money-transfer-rs/src/main.rs`:
-
-```rust
+```rust title="Resonate — example-money-transfer-rs/src/main.rs"
 #[resonate::function]
 async fn transfer_money(ctx: &Context, args: TransferArgs) -> Result<TransferResult> {
     let debit_id = format!("{}-debit", args.transfer_id);
@@ -1205,9 +1139,7 @@ async fn transfer_money(ctx: &Context, args: TransferArgs) -> Result<TransferRes
 
 <TabItem value="go">
 
-**DBOS** — `dbos-demo-apps/golang/widget-store/workflows.go`:
-
-```go
+```go title="DBOS — dbos-demo-apps/golang/widget-store/workflows.go"
 func checkoutWorkflow(ctx dbos.DBOSContext, _ string) (string, error) {
     // ... reserve inventory, await payment ...
     payment_status, err := dbos.Recv[string](ctx, PAYMENT_STATUS, 60*time.Second)

--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -56,9 +56,7 @@ Here is the most basic migration — a Workflow that calls one Activity, and the
 
 <TabItem value="python">
 
-**Temporal** — `samples-python/hello/hello_activity.py`:
-
-```python
+```python title="Temporal — samples-python/hello/hello_activity.py"
 @activity.defn
 def compose_greeting(input: ComposeGreetingInput) -> str:
     return f"{input.greeting}, {input.name}!"
@@ -74,9 +72,7 @@ class GreetingWorkflow:
         )
 ```
 
-**Resonate** — `example-hello-world-py/main.py`:
-
-```python
+```python title="Resonate — example-hello-world-py/main.py"
 def bar(_: Context, greetee: str) -> str:
     return f"Hello {greetee} from bar!"
 
@@ -92,9 +88,7 @@ def foo(ctx: Context, greetee: str) -> Generator[Any, Any, str]:
 
 <TabItem value="typescript">
 
-**Temporal** — `samples-typescript/hello-world/src/workflows.ts` + `activities.ts`:
-
-```typescript
+```typescript title="Temporal — samples-typescript/hello-world/src/workflows.ts + activities.ts"
 // activities.ts
 export async function greet(name: string): Promise<string> {
   return `Hello, ${name}!`;
@@ -110,9 +104,7 @@ export async function example(name: string): Promise<string> {
 }
 ```
 
-**Resonate** — `example-hello-world-ts/index.ts`:
-
-```typescript
+```typescript title="Resonate — example-hello-world-ts/index.ts"
 async function bar(_: Context, greetee: string): Promise<string> {
   return `Hello ${greetee} from bar!`;
 }
@@ -131,9 +123,7 @@ const fooR = resonate.register("foo", foo);
 
 <TabItem value="rust">
 
-**Temporal** — `sdk-rust/crates/sdk/examples/hello_world/workflows.rs`:
-
-```rust
+```rust title="Temporal — sdk-rust/crates/sdk/examples/hello_world/workflows.rs"
 #[workflow]
 pub struct HelloWorldWorkflow;
 
@@ -157,9 +147,7 @@ impl GreetingActivities {
 }
 ```
 
-**Resonate** — `example-hello-world-rs/src/main.rs`:
-
-```rust
+```rust title="Resonate — example-hello-world-rs/src/main.rs"
 #[resonate::function]
 async fn greet(ctx: &Context, name: String) -> Result<String> {
     let greeting = ctx.run(format_greeting, name).await?;
@@ -178,9 +166,7 @@ async fn format_greeting(name: String) -> Result<String> {
 
 <TabItem value="go">
 
-**Temporal** — `samples-go/helloworld/helloworld.go`:
-
-```go
+```go title="Temporal — samples-go/helloworld/helloworld.go"
 func Workflow(ctx workflow.Context, name string) (string, error) {
     ao := workflow.ActivityOptions{StartToCloseTimeout: 10 * time.Second}
     ctx = workflow.WithActivityOptions(ctx, ao)
@@ -195,9 +181,7 @@ func Activity(ctx context.Context, name string) (string, error) {
 }
 ```
 
-**Resonate** — `example-hello-world-go/main.go`:
-
-```go
+```go title="Resonate — example-hello-world-go/main.go"
 func greet(_ *resonate.Context, args GreetArgs) (string, error) {
     return fmt.Sprintf("hello, %s!", args.Name), nil
 }
@@ -703,16 +687,12 @@ Temporal accepts human strings (`'30 days'`) or a `timedelta`. Resonate's units 
 
 <TabItem value="python">
 
-**Temporal** — `samples-python/sleep_for_days/workflows.py`:
-
-```python
+```python title="Temporal — samples-python/sleep_for_days/workflows.py"
 # raced against a completion signal inside asyncio.wait(...):
 await workflow.sleep(timedelta(days=30))   # timedelta
 ```
 
-**Resonate** — `example-durable-sleep-py/worker.py`:
-
-```python
+```python title="Resonate — example-durable-sleep-py/worker.py"
 @resonate.register
 def sleeping_workflow(ctx: Context, wf_id: str, secs: float):
     yield ctx.sleep(secs)                   # seconds (float)
@@ -725,15 +705,11 @@ def sleeping_workflow(ctx: Context, wf_id: str, secs: float):
 
 <TabItem value="typescript">
 
-**Temporal** — `samples-typescript/sleep-for-days/src/workflows.ts`:
-
-```typescript
+```typescript title="Temporal — samples-typescript/sleep-for-days/src/workflows.ts"
 await Promise.race([sleep('30 days'), condition(() => isComplete)]);
 ```
 
-**Resonate** — `example-durable-sleep-ts/worker.ts`:
-
-```typescript
+```typescript title="Resonate — example-durable-sleep-ts/worker.ts"
 function* sleepingWorkflow(ctx: Context, ms: number) {
   yield* ctx.sleep(ms);                     // milliseconds
   return `Slept for ${ms / 1000} seconds`;
@@ -746,9 +722,7 @@ function* sleepingWorkflow(ctx: Context, ms: number) {
 
 <TabItem value="rust">
 
-**Temporal** — `sdk-rust/crates/sdk/examples/timer_examples/workflows.rs`:
-
-```rust
+```rust title="Temporal — sdk-rust/crates/sdk/examples/timer_examples/workflows.rs"
 #[run]
 pub async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<String> {
     ctx.timer(Duration::from_secs(1)).await;   // durable timer
@@ -756,9 +730,7 @@ pub async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<String> {
 }
 ```
 
-**Resonate** — `example-durable-sleep-rs/src/bin/worker.rs`:
-
-```rust
+```rust title="Resonate — example-durable-sleep-rs/src/bin/worker.rs"
 #[resonate::function]
 async fn sleeping_workflow(ctx: &Context, secs: u64) -> Result<String> {
     ctx.sleep(Duration::from_secs(secs)).await?;   // std::time::Duration
@@ -772,18 +744,14 @@ async fn sleeping_workflow(ctx: &Context, secs: u64) -> Result<String> {
 
 <TabItem value="go">
 
-**Temporal** — `samples-go/sleep-for-days/sleepfordays_workflow.go`:
-
-```go
+```go title="Temporal — samples-go/sleep-for-days/sleepfordays_workflow.go"
 selector := workflow.NewSelector(ctx)
 selector.AddFuture(workflow.NewTimer(ctx, time.Hour*24*30), func(f workflow.Future) {})
 selector.AddReceive(sigChan, func(c workflow.ReceiveChannel, more bool) { isComplete = true })
 selector.Select(ctx)
 ```
 
-**Resonate** — `example-durable-sleep-go/main.go`:
-
-```go
+```go title="Resonate — example-durable-sleep-go/main.go"
 func sleepingWorkflow(ctx *resonate.Context, args SleepArgs) (string, error) {
     d := time.Duration(args.Secs) * time.Second
     f, err := ctx.Sleep(d)                   // time.Duration
@@ -824,9 +792,7 @@ The non-blocking spawn primitive's name — TS `ctx.beginRun`, Python `ctx.rfi`,
 
 <TabItem value="python">
 
-**Temporal** — `samples-python/hello/hello_parallel_activity.py`:
-
-```python
+```python title="Temporal — samples-python/hello/hello_parallel_activity.py"
 results = await asyncio.gather(
     workflow.execute_activity(say_hello_activity, "user1", start_to_close_timeout=timedelta(seconds=5)),
     workflow.execute_activity(say_hello_activity, "user2", start_to_close_timeout=timedelta(seconds=5)),
@@ -834,9 +800,7 @@ results = await asyncio.gather(
 )
 ```
 
-**Resonate** — `example-fan-out-fan-in-py/workflow.py`:
-
-```python
+```python title="Resonate — example-fan-out-fan-in-py/workflow.py"
 # fan-out: rfi() returns a handle immediately
 email_p = yield ctx.rfi(send_email, event).options(id=f"{ctx.id}.email")
 sms_p   = yield ctx.rfi(send_sms, event).options(id=f"{ctx.id}.sms")
@@ -851,17 +815,13 @@ sms   = yield sms_p
 
 <TabItem value="typescript">
 
-**Temporal** — `samples-typescript/child-workflows/src/workflows.ts`:
-
-```typescript
+```typescript title="Temporal — samples-typescript/child-workflows/src/workflows.ts"
 const responseArray = await Promise.all(
   names.map((name) => executeChild(childWorkflow, { args: [name] })),
 );
 ```
 
-**Resonate** — `example-fan-out-fan-in-ts/src/workflow.ts`:
-
-```typescript
+```typescript title="Resonate — example-fan-out-fan-in-ts/src/workflow.ts"
 // fan-out: beginRun returns a future immediately
 const emailFuture = yield* ctx.beginRun(sendEmail, event);
 const smsFuture   = yield* ctx.beginRun(sendSms, event);
@@ -877,9 +837,7 @@ const results = [yield* emailFuture, yield* smsFuture];
 
 **Temporal Rust has no dedicated fan-out sample** — its `child_workflows` example starts children sequentially. The Resonate Rust equivalent fans out with `.spawn()`:
 
-**Resonate** — `example-fan-out-fan-in-rs/src/main.rs`:
-
-```rust
+```rust title="Resonate — example-fan-out-fan-in-rs/src/main.rs"
 // fan-out: .spawn() returns a handle immediately
 let h1 = ctx.run(process_item, items[0].clone()).spawn().await?;
 let h2 = ctx.run(process_item, items[1].clone()).spawn().await?;
@@ -894,9 +852,7 @@ let r2 = h2.await?;
 
 <TabItem value="go">
 
-**Temporal** — `samples-go/splitmerge-future/splitmerge_workflow.go`:
-
-```go
+```go title="Temporal — samples-go/splitmerge-future/splitmerge_workflow.go"
 var results []workflow.Future
 for i := 0; i < processorCount; i++ {                    // fan-out
     results = append(results, workflow.ExecuteActivity(ctx, ChunkProcessingActivity, i+1))
@@ -907,9 +863,7 @@ for i := 0; i < processorCount; i++ {                    // fan-in
 }
 ```
 
-**Resonate** — `example-fan-out-fan-in-go/main.go`:
-
-```go
+```go title="Resonate — example-fan-out-fan-in-go/main.go"
 futures := make([]*resonate.Future, 0, len(args.Channels))
 for _, ch := range args.Channels {                       // fan-out
     f, _ := ctx.RPC("send", SendArgs{Channel: ch, Message: args.Message})
@@ -954,9 +908,7 @@ async def workflow_compensation(self):
     )
 ```
 
-**Resonate** — `example-money-transfer-py/main.py`:
-
-```python
+```python title="Resonate — example-money-transfer-py/main.py"
 def transfer_money(ctx, transfer_id, source, target, amount, *, simulate_credit_failure=False):
     yield ctx.run(apply_entry, f"{transfer_id}-debit", source, -amount, "debit")
     try:
@@ -977,9 +929,7 @@ def transfer_money(ctx, transfer_id, source, target, amount, *, simulate_credit_
 
 <TabItem value="typescript">
 
-**Temporal** — `samples-typescript/saga/src/workflows.ts`:
-
-```typescript
+```typescript title="Temporal — samples-typescript/saga/src/workflows.ts"
 const compensations: Compensation[] = [];
 try {
   await addAddress({ accountId, address });
@@ -994,9 +944,7 @@ try {
 }
 ```
 
-**Resonate** — `example-saga-booking-ts/src/workflow.ts`:
-
-```typescript
+```typescript title="Resonate — example-saga-booking-ts/src/workflow.ts"
 let flightId: string | undefined;
 let hotelId: string | undefined;
 try {
@@ -1020,9 +968,7 @@ Temporal pushes typed `Compensation` closures onto a stack and drains it in a se
 
 <TabItem value="rust">
 
-**Temporal** — `sdk-rust/crates/sdk/examples/saga/workflows.rs`:
-
-```rust
+```rust title="Temporal — sdk-rust/crates/sdk/examples/saga/workflows.rs"
 #[run]
 pub async fn run(ctx: &mut WorkflowContext<Self>, trip_id: String) -> WorkflowResult<Vec<String>> {
     let mut saga = Saga::new(ctx, activity_opts());
@@ -1034,9 +980,7 @@ pub async fn run(ctx: &mut WorkflowContext<Self>, trip_id: String) -> WorkflowRe
 // book_trip: saga.step(book_hotel, …, cancel_hotel).await? — one step + compensation per booking
 ```
 
-**Resonate** — `example-money-transfer-rs/src/main.rs`:
-
-```rust
+```rust title="Resonate — example-money-transfer-rs/src/main.rs"
 #[resonate::function]
 async fn transfer_money(ctx: &Context, args: TransferArgs) -> Result<TransferResult> {
     // Step 1 — debit the source (durable checkpoint).
@@ -1132,9 +1076,7 @@ For bounded loops, the Resonate example is a plain `while`/`for` — no `continu
 
 <TabItem value="typescript">
 
-**Temporal** — `samples-typescript/continue-as-new/src/workflows.ts`:
-
-```typescript
+```typescript title="Temporal — samples-typescript/continue-as-new/src/workflows.ts"
 export async function loopingWorkflow(iteration = 0): Promise<void> {
   if (iteration === 10) return;
   await sleep(1000);
@@ -1142,9 +1084,7 @@ export async function loopingWorkflow(iteration = 0): Promise<void> {
 }
 ```
 
-**Resonate** — `example-infinite-workflow-ts/src/workflow.ts`:
-
-```typescript
+```typescript title="Resonate — example-infinite-workflow-ts/src/workflow.ts"
 function* healthMonitor(ctx: Context, config: MonitorConfig): Generator<any, MonitorResult, any> {
   let iteration = 0;
   // No continueAsNew — Resonate has no history limit.
@@ -1172,9 +1112,7 @@ function* playGame(ctx: Context, n: number) {
 
 <TabItem value="go">
 
-**Temporal** — `samples-go/child-workflow-continue-as-new/child_workflow.go`:
-
-```go
+```go title="Temporal — samples-go/child-workflow-continue-as-new/child_workflow.go"
 func SampleChildWorkflow(ctx workflow.Context, totalCount, runCount int) (string, error) {
     if runCount <= 0 {
         return "", errors.New("invalid run count")
@@ -1188,9 +1126,7 @@ func SampleChildWorkflow(ctx workflow.Context, totalCount, runCount int) (string
 }
 ```
 
-**Resonate** — `example-infinite-workflow-go/main.go`:
-
-```go
+```go title="Resonate — example-infinite-workflow-go/main.go"
 func heartbeatWorkflow(ctx *resonate.Context, args WorkflowArgs) (WorkflowResult, error) {
     for i := 0; args.Iterations == 0 || i < args.Iterations; i++ {
         tickF, err := ctx.Run(heartbeatTick, TickArgs{Tick: i + 1})
@@ -1237,9 +1173,7 @@ Temporal's `mutex` sample is ~130 lines across two workflows: a lock-manager wor
 This pattern currently has a Resonate example in TypeScript only.
 </Callout>
 
-**Temporal** — `samples-typescript/mutex/src/workflows.ts` (excerpt):
-
-```typescript
+```typescript title="Temporal — samples-typescript/mutex/src/workflows.ts (excerpt)"
 export async function lockWorkflow(requests = Array<LockRequest>()): Promise<void> {
   setHandler(lockRequestSignal, (req) => { requests.push(req); });
   while (!workflowInfo().continueAsNewSuggested) {
@@ -1255,9 +1189,7 @@ export async function lockWorkflow(requests = Array<LockRequest>()): Promise<voi
 }
 ```
 
-**Resonate** — `example-distributed-mutex-ts/src/workflow.ts`:
-
-```typescript
+```typescript title="Resonate — example-distributed-mutex-ts/src/workflow.ts"
 function* exclusiveResourceAccess(ctx: Context, resource: string, workers: string[]): Generator<any, MutexResult, any> {
   const results: WorkResult[] = [];
   // The generator IS the lock: each yield* blocks until the previous completes,
@@ -1282,9 +1214,7 @@ Temporal encrypts payloads with a `PayloadCodec` (`encode`/`decode` over `Payloa
 This pattern currently has a Resonate example in TypeScript only.
 </Callout>
 
-**Temporal** — `samples-typescript/encryption/src/encryption-codec.ts` (excerpt):
-
-```typescript
+```typescript title="Temporal — samples-typescript/encryption/src/encryption-codec.ts (excerpt)"
 export class EncryptionCodec implements PayloadCodec {
   async encode(payloads: Payload[]): Promise<Payload[]> {
     return Promise.all(payloads.map(async (payload) => ({
@@ -1299,9 +1229,7 @@ export class EncryptionCodec implements PayloadCodec {
 }
 ```
 
-**Resonate** — `example-encryption-ts/src/encryptor.ts` + `index.ts`:
-
-```typescript
+```typescript title="Resonate — example-encryption-ts/src/encryptor.ts + index.ts"
 export class AesGcmEncryptor implements Encryptor {
   encrypt(plaintext: Value): Value {
     if (!plaintext.data) return plaintext;

--- a/source.config.ts
+++ b/source.config.ts
@@ -22,6 +22,21 @@ export default defineConfig({
         light: "github-light",
         dark: "github-dark",
       },
+      // Shiki bakes the language into inline styles and drops the
+      // `language-x` class, so the code-block chrome had no way to label an
+      // untitled block and fell back to a meaningless "code". Stamp the
+      // language onto the <pre> as `data-language` so CodeBlock can show it.
+      transformers: [
+        {
+          name: "stamp-language",
+          pre(node) {
+            const lang = this.options.lang;
+            if (lang && lang !== "plaintext") {
+              node.properties["data-language"] = lang;
+            }
+          },
+        },
+      ],
     },
   },
 });


### PR DESCRIPTION
## What

Two fixes to how code blocks are labelled in the docs.

### 1. Untitled code blocks showed a meaningless `code` label
Shiki bakes the language into inline styles and drops the `language-x` class, so the code-block chrome had nothing to label an untitled block with and fell back to a literal **"code"**. A small rehype transformer now stamps the language onto the `<pre>` as `data-language`, and `CodeBlock` reads it — so an untitled block shows its actual language (`python`, `go`, …) everywhere on the site.

### 2. The "Coming from" migration comparisons were cramped
The side-by-side examples used a bold `**Temporal** — \`file\`:` line stacked directly on top of an unlabelled code block — two competing labels fighting for the same space. The system + filename now live in the code block's own title. `CodeBlock` parses a `System — file` title into a **system badge** (Resonate accented, the "from" system neutral) + filename + language, so each example reads as a single, clearly-labelled before/after.

70 comparison blocks across the Temporal and DBOS guides were converted. The remaining labels are genuine prose annotations (e.g. "no database, no server", "DBOS docs, Python queue tutorial") and are intentionally left as prose — their blocks still pick up the language label from fix #1.

## Verification
- `next build` passes (all 75 pages), `tsc` + lint clean.
- Confirmed in the built HTML that the badge + filename + language render and no `code` fallback remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)