### PR TITLE
ci: build + link-check + llms-sync workflow; fix corpus generator mangling code generics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs, but never cancel a push to main mid-commit.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: Build, link-check & llms sync
+    runs-on: ubuntu-latest
+    permissions:
+      # Write is used only by the auto-regen commit on push to main.
+      # Pull-request runs (including forks) get read-only and never push.
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # `npm run build` also runs `postbuild` (scripts/check-links.mjs), which
+      # boots `next start` and crawls every page. Internal broken links fail the
+      # build; unreachable external links (e.g. localhost metrics/tracing demos)
+      # are warn-only. It also regenerates public/llms.txt and llms-full.txt.
+      - name: Build, generate llms corpus, and check links
+        run: npm run build
+
+      # Pull requests: the build just regenerated the corpus. If it differs from
+      # what the PR committed, the author forgot to regenerate — fail with a fix.
+      - name: Verify llms corpus is in sync (pull requests)
+        if: github.event_name == 'pull_request'
+        run: |
+          if ! git diff --exit-code public/llms.txt public/llms-full.txt; then
+            echo "::error::public/llms.txt and/or public/llms-full.txt are stale. Run 'npm run build' locally and commit the regenerated llms files."
+            exit 1
+          fi
+          echo "llms corpus is in sync."
+
+      # Push to main: self-heal a merge that forgot to regenerate the corpus by
+      # committing the freshly built files back. [skip ci] prevents a loop.
+      - name: Regenerate llms corpus if drifted (push to main)
+        if: github.event_name == 'push'
+        run: |
+          if git diff --quiet public/llms.txt public/llms-full.txt; then
+            echo "llms corpus already in sync; nothing to commit."
+            exit 0
+          fi
+          git config user.name "resonate-docs-bot"
+          git config user.email "cullywakelin@gmail.com"
+          git add public/llms.txt public/llms-full.txt
+          git commit -m "chore(docs): regenerate llms corpus [skip ci]"
+          if ! git push; then
+            echo "::warning::Could not push regenerated llms corpus to main (branch protection may block Actions pushing to main). The pull-request sync check remains the enforcing gate."
+          fi
+
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Run gitleaks from its pinned image — no license key required, unlike the
+      # gitleaks GitHub Action under an organization. Scans the working tree
+      # (--no-git) against .gitleaks.toml, which allowlists doc placeholders.
+      - name: Run gitleaks
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/repo" \
+            -w /repo \
+            ghcr.io/gitleaks/gitleaks:v8.18.4 \
+            detect --no-git --config /repo/.gitleaks.toml --redact --no-banner --verbose

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,29 @@
+# gitleaks configuration for docs.resonatehq.io
+#
+# Extends the built-in ruleset and allowlists the placeholder connection
+# strings that recur throughout the documentation examples. These are not
+# real credentials — they use literal <USER>/<PASSWORD> placeholders — but
+# generic database-URL rules tend to flag them.
+title = "docs.resonatehq.io"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Documentation example placeholders, not real secrets"
+# Match against the whole line — a rule's extracted "secret" is usually only the
+# credential token, so a full connection-string regex must target the line.
+regexTarget = "line"
+regexes = [
+  # postgres://<USER>:<PASSWORD>@host:5432/resonate and friends
+  '''postgres(ql)?://<USER>:<PASSWORD>@''',
+  # any connection string whose credentials are angle-bracket placeholders
+  '''://<[A-Z_]+>:<[A-Z_]+>@''',
+]
+paths = [
+  # Build artifacts / dependencies — never part of the committed source.
+  # Next.js bakes preview-mode signing keys into .next/, which trip generic
+  # secret rules; these are not real, checked-in credentials.
+  '''^\.next/''',
+  '''^node_modules/''',
+]

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -319,7 +319,7 @@ pg_isready -h localhost -p 5432
 type = "postgres"
 
 [storage.postgres]
-url = "postgres://:@localhost:5432/resonate"
+url = "postgres://<USER>:<PASSWORD>@localhost:5432/resonate"
 ```
 
 Or set `RESONATE_STORAGE__POSTGRES__URL` in the environment. Check the host, port, database, user, and password all match what your Postgres instance expects.
@@ -351,7 +351,7 @@ Another process is using port 8001 (HTTP).
 lsof -i :8001
 
 # Kill the process if needed
-kill -9 
+kill -9 <PID>
 ```
 
 2. **Use a different port:**
@@ -655,7 +655,7 @@ time curl -s http://resonate-server:8001/health
 2. **Tune connection pool:**
 ```toml title="resonate.toml"
 [storage.postgres]
-url = "postgres://:@localhost:5432/resonate"
+url = "postgres://<USER>:<PASSWORD>@localhost:5432/resonate"
 pool_size = 50  # Increase pool size (default: 10)
 ```
 
@@ -773,7 +773,7 @@ Use PostgreSQL for any deployment with concurrent writers:
 type = "postgres"
 
 [storage.postgres]
-url = "postgres://:@localhost:5432/resonate"
+url = "postgres://<USER>:<PASSWORD>@localhost:5432/resonate"
 ```
 
 SQLite is best for development and single-tenant deployments where there is no concurrent write contention against the server.
@@ -861,14 +861,14 @@ For shared, multi-tenant deployments, PostgreSQL provides better concurrency and
 ```bash title="Start server with PostgreSQL"
 resonate serve \
   --storage-type postgres \
-  --storage-postgres-url "postgres://:@localhost:5432/resonate" \
+  --storage-postgres-url "postgres://<USER>:<PASSWORD>@localhost:5432/resonate" \
   --storage-postgres-pool-size 20
 ```
 
 For SSL connections, include `sslmode` in the connection string:
 
 ```bash
---storage-postgres-url "postgres://:@postgres.example.com:5432/resonate?sslmode=require"
+--storage-postgres-url "postgres://<USER>:<PASSWORD>@postgres.example.com:5432/resonate?sslmode=require"
 ```
 
 ## PostgreSQL high availability
@@ -1104,7 +1104,7 @@ services:
     environment:
       RESONATE_SERVER__BIND: "0.0.0.0"
       RESONATE_STORAGE__TYPE: postgres
-      RESONATE_STORAGE__POSTGRES__URL: postgres://:@postgres:5432/resonate
+      RESONATE_STORAGE__POSTGRES__URL: postgres://<USER>:<PASSWORD>@postgres:5432/resonate
     depends_on:
       postgres:
         condition: service_healthy
@@ -1309,6 +1309,8 @@ Cloud Run workers stay alive polling for tasks and scale automatically based on 
 Lambda workers can run as functions that poll for tasks or respond to events:
 
 ```typescript title="lambda-worker.ts"
+import { Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate({
   url: process.env.RESONATE_URL!,
   group: "lambda-workers",
@@ -1324,6 +1326,9 @@ export async function handler(event: any) {
 **Deployment (using AWS CDK):**
 
 ```typescript title="worker-stack.ts"
+import * as cdk from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+
 export class ResonateWorkerStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string) {
     super(scope, id);
@@ -1782,6 +1787,9 @@ Resonate does not ship a native Kafka transport in the current server. The suppo
 Use a regular Kafka consumer (`kafkajs`, `confluent-kafka-python`, `rdkafka`, etc.) and call `beginRun` on each message. A stable per-message identifier becomes the Resonate promise ID, so the dispatch is idempotent — duplicate deliveries reconnect to the in-flight execution rather than starting over.
 
 ```ts title="src/consumer.ts"
+import { Kafka } from "kafkajs";
+import { resonate } from "./workflow";
+
 const kafka = new Kafka({ brokers: ["localhost:9092"] });
 const consumer = kafka.consumer({ groupId: "workers" });
 
@@ -1934,6 +1942,8 @@ The Resonate SDKs also emit logs for observing application behavior.
 The TypeScript SDK uses console logging by default:
 
 ```typescript
+import { Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate({
   url: "http://localhost:8001",
   logLevel: "debug",  // debug | info | warn | error
@@ -2916,7 +2926,7 @@ docker run --rm -p 8001:8001 -p 9090:9090 resonatehqio/resonate:v0.9.8
 ```shell title="Use Postgres storage"
 docker run --rm -p 8001:8001 -p 9090:9090 \
   -e RESONATE_STORAGE__TYPE=postgres \
-  -e RESONATE_STORAGE__POSTGRES__URL="postgres://:@host:5432/resonate" \
+  -e RESONATE_STORAGE__POSTGRES__URL="postgres://<USER>:<PASSWORD>@host:5432/resonate" \
   resonatehqio/resonate:v0.9.8
 ```
 
@@ -2960,7 +2970,7 @@ For Postgres, swap the `[storage]` section:
 type = "postgres"
 
 [storage.postgres]
-url = "postgres://:@host:5432/resonate"
+url = "postgres://<USER>:<PASSWORD>@host:5432/resonate"
 pool_size = 20
 ```
 
@@ -2971,7 +2981,7 @@ For MySQL, the equivalent block is:
 type = "mysql"
 
 [storage.mysql]
-url = "mysql://:@host:3306/resonate"
+url = "mysql://<USER>:<PASSWORD>@host:3306/resonate"
 pool_size = 20
 ```
 
@@ -2984,13 +2994,13 @@ publickey = "/etc/resonate/auth/public.pem"
 
 ### Environment variables
 
-Every config field is also reachable as an environment variable. The convention is `RESONATE___`, with `__` separating nested keys:
+Every config field is also reachable as an environment variable. The convention is `RESONATE_<SECTION>__<FIELD>`, with `__` separating nested keys:
 
 ```shell
 RESONATE_LEVEL=info
 RESONATE_SERVER__PORT=8001
 RESONATE_STORAGE__TYPE=postgres
-RESONATE_STORAGE__POSTGRES__URL=postgres://:@host:5432/resonate
+RESONATE_STORAGE__POSTGRES__URL=postgres://<USER>:<PASSWORD>@host:5432/resonate
 RESONATE_AUTH__PUBLICKEY=/etc/resonate/auth/public.pem
 ```
 
@@ -3005,7 +3015,7 @@ Most settings can also be passed as CLI flags — useful for ad-hoc overrides:
 ```shell
 resonate serve \
   --storage-type postgres \
-  --storage-postgres-url "postgres://:@localhost:5432/resonate" \
+  --storage-postgres-url "postgres://<USER>:<PASSWORD>@localhost:5432/resonate" \
   --storage-postgres-pool-size 20
 ```
 
@@ -3068,7 +3078,7 @@ With a `resonate.toml` (recommended):
 type = "postgres"
 
 [storage.postgres]
-url = "postgres://:@localhost:5432/resonate"
+url = "postgres://<USER>:<PASSWORD>@localhost:5432/resonate"
 pool_size = 20
 ```
 
@@ -3077,7 +3087,7 @@ Or with CLI flags:
 ```shell
 resonate serve \
   --storage-type postgres \
-  --storage-postgres-url "postgres://:@localhost:5432/resonate" \
+  --storage-postgres-url "postgres://<USER>:<PASSWORD>@localhost:5432/resonate" \
   --storage-postgres-pool-size 20
 ```
 
@@ -3096,7 +3106,7 @@ With a `resonate.toml` (recommended):
 type = "mysql"
 
 [storage.mysql]
-url = "mysql://:@localhost:3306/resonate"
+url = "mysql://<USER>:<PASSWORD>@localhost:3306/resonate"
 pool_size = 20
 ```
 
@@ -3105,7 +3115,7 @@ Or with CLI flags:
 ```shell
 resonate serve \
   --storage-type mysql \
-  --storage-mysql-url "mysql://:@localhost:3306/resonate" \
+  --storage-mysql-url "mysql://<USER>:<PASSWORD>@localhost:3306/resonate" \
   --storage-mysql-pool-size 20
 ```
 
@@ -3113,7 +3123,7 @@ Or with environment variables:
 
 ```shell
 RESONATE_STORAGE__TYPE=mysql
-RESONATE_STORAGE__MYSQL__URL=mysql://:@localhost:3306/resonate
+RESONATE_STORAGE__MYSQL__URL=mysql://<USER>:<PASSWORD>@localhost:3306/resonate
 RESONATE_STORAGE__MYSQL__POOL_SIZE=20
 ```
 
@@ -3325,6 +3335,8 @@ Workers register with the Resonate server using a **group name**. All workers in
 ### Worker registration
 
 ```typescript title="TypeScript worker registration"
+import { Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate({
   url: "http://resonate-server:8001",
   group: "workers", // All workers in this group can handle the same tasks
@@ -3716,6 +3728,8 @@ When auth is enabled, all API requests must include a valid JWT token in the `Au
 ### TypeScript SDK
 
 ```typescript title="index.ts"
+import { Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate({
   url: "http://localhost:8001",
   token: process.env.RESONATE_TOKEN,
@@ -3727,6 +3741,8 @@ The SDK sends the token as a `Bearer` token in the `Authorization` header automa
 #### Example: Secure production setup
 
 ```typescript title="resonate-client.ts"
+import { Resonate } from "@resonatehq/sdk";
+
 const token = process.env.RESONATE_TOKEN;
 
 if (!token) {
@@ -3753,7 +3769,7 @@ let resonate = Resonate::new(ResonateConfig {
 });
 ```
 
-`ResonateConfig::token` is `Option`, so `std::env::var("RESONATE_TOKEN").ok()` is the idiomatic way to populate it from the environment. `Resonate::new` returns `Resonate` directly (not a `Result`).
+`ResonateConfig::token` is `Option<String>`, so `std::env::var("RESONATE_TOKEN").ok()` is the idiomatic way to populate it from the environment. `Resonate::new` returns `Resonate` directly (not a `Result`).
 
 ## CORS (Cross-Origin Resource Sharing)
 
@@ -4010,6 +4026,9 @@ npm install @resonatehq/aws
 Instead of importing Resonate from the SDK package, import it from the AWS shim package.
 
 ```ts title="index.ts"
+import { Resonate } from "@resonatehq/aws";
+import { countdown } from "./count";
+
 const resonate = new Resonate();
 
 resonate.register("countdown", countdown);
@@ -4030,6 +4049,9 @@ npm install @resonatehq/cloudflare
 Instead of importing Resonate from the SDK package, import it from the Cloudflare shim package.
 
 ```ts title="index.ts"
+import { Resonate } from "@resonatehq/cloudflare";
+import { countdown } from "./count";
+
 const resonate = new Resonate();
 
 resonate.register("countdown", countdown);
@@ -4055,6 +4077,9 @@ npm install @resonatehq/gcp
 Instead of importing Resonate from the SDK package, import it from the GCP shim package.
 
 ```ts title="index.ts"
+import { Resonate } from "@resonatehq/gcp";
+import { countdown } from "./count";
+
 const resonate = new Resonate();
 
 resonate.register("countdown", countdown);
@@ -4080,6 +4105,9 @@ npm install @resonatehq/supabase
 Instead of importing Resonate from the SDK package, import it from the Supabase shim package.
 
 ```ts title="index.ts"
+import { Resonate } from "@resonatehq/supabase";
+import { countdown } from "./count";
+
 const resonate = new Resonate();
 resonate.register("countdown", countdown);
 
@@ -4127,6 +4155,8 @@ The split must happen *inside* the per-iteration function. A parent loop that ca
 The shim `Resonate` constructor accepts a `ttl` option (milliseconds):
 
 ```typescript
+import { Resonate } from "@resonatehq/gcp";
+
 const resonate = new Resonate({ ttl: 10 * 60 * 1000 }); // 10 min
 ```
 
@@ -4178,6 +4208,9 @@ npm install @resonatehq/opentelemetry
 ### Configure OpenTelemetry
 
 ```typescript
+import { ResonateOpenTelemetry } from "@resonatehq/opentelemetry";
+import { Resonate } from "@resonatehq/sdk";
+
 // Initialize OpenTelemetry
 const otel = new ResonateOpenTelemetry({
   serviceName: "my-resonate-app",
@@ -4246,6 +4279,8 @@ services:
 Commercial solution with powerful features:
 
 ```typescript
+import { ResonateOpenTelemetry } from "@resonatehq/opentelemetry";
+
 const otel = new ResonateOpenTelemetry({
   serviceName: "my-resonate-app",
   exporterEndpoint: "http://localhost:8126/v0.4/traces",  // Datadog Agent
@@ -4259,6 +4294,8 @@ Traces appear in Datadog APM UI automatically.
 Cloud-native observability platform:
 
 ```typescript
+import { ResonateOpenTelemetry } from "@resonatehq/opentelemetry";
+
 const otel = new ResonateOpenTelemetry({
   serviceName: "my-resonate-app",
   exporterEndpoint: "https://api.honeycomb.io/v1/traces",
@@ -4273,6 +4310,9 @@ const otel = new ResonateOpenTelemetry({
 AWS-native tracing:
 
 ```typescript
+import { AWSXRayPropagator } from "@opentelemetry/propagator-aws-xray";
+import { AWSXRayIdGenerator } from "@opentelemetry/id-generator-aws-xray";
+
 const otel = new ResonateOpenTelemetry({
   serviceName: "my-resonate-app",
   exporterEndpoint: "http://localhost:2000",  // X-Ray daemon
@@ -4414,6 +4454,8 @@ Understand the complete execution path.
 High-volume systems generate too many traces. Use sampling to reduce overhead:
 
 ```typescript
+import { ParentBasedSampler, TraceIdRatioBasedSampler } from "@opentelemetry/sdk-trace-base";
+
 const otel = new ResonateOpenTelemetry({
   serviceName: "my-resonate-app",
   sampler: new ParentBasedSampler({
@@ -4434,6 +4476,8 @@ Most backends support tail-based sampling (sample after seeing full trace).
 **Trace ID in logs:**
 
 ```typescript
+import { trace } from "@opentelemetry/api";
+
 const span = trace.getActiveSpan();
 const traceId = span?.spanContext().traceId;
 
@@ -6534,27 +6578,27 @@ The SDK detects the function kind from the first parameter:
 | `&Info` | **Leaf with metadata** | Read-only access to execution metadata (ID, parent, tags) |
 | *(anything else)* | **Pure leaf** | Stateless computation — no special environment |
 
-All durable functions must return `Result` (where `Result` is `resonate::error::Result`).
+All durable functions must return `Result<T>` (where `Result` is `resonate::error::Result`).
 
 ```rust
 use resonate::prelude::*;
 
 // Workflow — orchestrates sub-tasks
 #[resonate::function]
-async fn my_workflow(ctx: &Context, input: String) -> Result {
+async fn my_workflow(ctx: &Context, input: String) -> Result<String> {
     let result = ctx.run(my_leaf, input).await?;
     Ok(result)
 }
 
 // Pure leaf — stateless computation
 #[resonate::function]
-async fn my_leaf(input: String) -> Result {
+async fn my_leaf(input: String) -> Result<String> {
     Ok(format!("Processed: {input}"))
 }
 
 // Leaf with metadata — access to execution info
 #[resonate::function]
-async fn my_info_leaf(info: &Info, input: String) -> Result {
+async fn my_info_leaf(info: &Info, input: String) -> Result<String> {
     Ok(format!("ID: {}, Input: {input}", info.id()))
 }
 ```
@@ -6639,7 +6683,7 @@ schedule.delete().await?;
 Get a handle to an existing execution by its promise ID.
 
 ```rust
-let mut handle = resonate.get::("invocation-id").await?;
+let mut handle = resonate.get::<String>("invocation-id").await?;
 let result = handle.result().await?;
 ```
 
@@ -6654,7 +6698,7 @@ use std::collections::HashMap;
 
 // Create a promise with a timeout, initial parameter, and tags
 // timeout_at is i64 milliseconds since the Unix epoch
-// param is a Value; tags are a HashMap
+// param is a Value; tags are a HashMap<String, String>
 resonate.promises.create("promise-id", timeout_at, Value::from_serializable(json!({}))?, HashMap::new()).await?;
 
 // Get a promise by ID
@@ -6722,7 +6766,7 @@ By default, `.await` executes sequentially — the calling function blocks until
 
 ```rust
 #[resonate::function]
-async fn my_workflow(ctx: &Context) -> Result {
+async fn my_workflow(ctx: &Context) -> Result<String> {
     let result = ctx.run(my_leaf, "input".into()).await?;
     Ok(result)
 }
@@ -6750,8 +6794,8 @@ The calling function blocks until the remote function returns.
 
 ```rust
 #[resonate::function]
-async fn my_workflow(ctx: &Context) -> Result {
-    let result = ctx.rpc::("remote-func", "input".into()).await?;
+async fn my_workflow(ctx: &Context) -> Result<String> {
+    let result = ctx.rpc::<String>("remote-func", "input".into()).await?;
     Ok(result)
 }
 ```
@@ -6761,8 +6805,8 @@ Use `.spawn()` for parallel remote invocations:
 ```rust
 #[resonate::function]
 async fn my_workflow(ctx: &Context) -> Result<()> {
-    let f1 = ctx.rpc::("worker-a", "data".into()).spawn().await?;
-    let f2 = ctx.rpc::("worker-b", "data".into()).spawn().await?;
+    let f1 = ctx.rpc::<String>("worker-a", "data".into()).spawn().await?;
+    let f2 = ctx.rpc::<String>("worker-b", "data".into()).spawn().await?;
 
     f1.await?;
     f2.await?;
@@ -6797,7 +6841,7 @@ All Context execution methods support builder options before `.await` or `.spawn
 use std::time::Duration;
 
 #[resonate::function]
-async fn my_workflow(ctx: &Context) -> Result {
+async fn my_workflow(ctx: &Context) -> Result<String> {
     let result = ctx.run(my_leaf, "input".into())
         .timeout(Duration::from_secs(30))
         .await?;
@@ -6810,7 +6854,7 @@ async fn my_workflow(ctx: &Context) -> Result {
 | `.timeout(Duration)` | Execution timeout |
 | `.target(&str)` | Target worker group — only valid on `ctx.rpc()` builders |
 
-)`. These are not available on Context builders.">
+
 
 
 
@@ -6912,6 +6956,8 @@ Once installed, you can import the Resonate SDK into your TypeScript files, and 
 Initializing a Resonate Client gives you the APIs needed to register, activate, and await on functions.
 
 ```ts title="index.ts"
+import { Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate();
 ```
 
@@ -6924,6 +6970,8 @@ Upon initialization, the Resonate Client will look for [environment variables](#
 For example, to specify a Resonate Server and process group, pass the url and group in the options.
 
 ```ts title="index.ts"
+import { Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate({
   // ...
   url: "https://localhost:8001", // Resonate Server URL
@@ -6944,6 +6992,8 @@ This is ideal for getting started quickly or for integrating Resonate into an ex
 Resonate will automatically operate in "local development mode" when no URL is provided via constructor options or [environment variables](#environment-variables).
 
 ```ts title="index.ts"
+import { Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate();
 ```
 
@@ -6960,6 +7010,8 @@ The TypeScript SDK supports both **token-based** and **basic** authentication wh
 Use JWT bearer tokens for production deployments:
 
 ```ts title="index.ts"
+import { Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate({
   url: "https://localhost:8001",
   token: process.env.RESONATE_TOKEN, // Load from environment
@@ -6996,6 +7048,9 @@ See [Message transports](/deploy/message-transports) for the transports the curr
 There is no native Kafka transport in the current server. The supported pattern is a normal Kafka consumer that dispatches a Resonate workflow per message — a stable per-message identifier becomes the durable promise ID, so duplicate deliveries reconnect to the in-flight execution rather than starting over.
 
 ```ts title="src/consumer.ts"
+import { Kafka } from "kafkajs";
+import { resonate } from "./workflow";
+
 const kafka = new Kafka({ brokers: ["localhost:9092"] });
 const consumer = kafka.consumer({ groupId: "workers" });
 
@@ -7055,6 +7110,8 @@ This is convenient for unit tests or quick experiments that do not require a Res
   ```
 
   ```ts
+  import { Resonate } from "@resonatehq/sdk";
+
   const resonate = new Resonate(); // picks up RESONATE_URL automatically
   ```
 
@@ -7365,6 +7422,8 @@ await resonate.stop();
 **When to call it.** Call `.stop()` from any process that should exit after its work finishes — demo scripts, one-shot jobs, examples, CI tasks. Without it, the client keeps the Node.js event loop alive via the long-poll connection and the subscription refresh interval, and the process hangs after `main()` returns.
 
 ```ts title="src/index.ts"
+import { Resonate } from "@resonatehq/sdk";
+
 async function main() {
   const resonate = new Resonate();
   resonate.register("greet", (ctx, name) => `Hello, ${name}!`);
@@ -7615,6 +7674,8 @@ The options object is useful when you want to build the wake-up time conditional
 **Sleep for a fixed duration.**
 
 ```ts
+import { Context, Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate();
 
 resonate.register("send-reminder", function* (ctx: Context, userId: string) {
@@ -7628,6 +7689,8 @@ resonate.register("send-reminder", function* (ctx: Context, userId: string) {
 **Sleep until a calendar time.**
 
 ```ts
+import { Context, Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate();
 
 resonate.register("schedule-digest", function* (ctx: Context, userId: string) {
@@ -8206,13 +8269,13 @@ DBOS ships SDKs for TypeScript, Python, Go, and Java. There is no DBOS Rust SDK,
 
 ```rust
 #[resonate::function]
-async fn greet(ctx: &Context, name: String) -> Result {
+async fn greet(ctx: &Context, name: String) -> Result<String> {
     let greeting = ctx.run(format_greeting, name).await?;
     Ok(greeting)
 }
 
 #[resonate::function]
-async fn format_greeting(name: String) -> Result {
+async fn format_greeting(name: String) -> Result<String> {
     Ok(format!("Hello, {name}!"))
 }
 ```
@@ -8458,6 +8521,8 @@ await DBOS.launch(/* { conductorKey } */);
 **Resonate** — no database, no server:
 
 ```typescript
+import { Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate();
 
 // ...
@@ -8741,7 +8806,7 @@ The Resonate Rust equivalent sleeps on a native `Duration`:
 
 ```rust
 #[resonate::function]
-async fn sleeping_workflow(ctx: &Context, secs: u64) -> Result {
+async fn sleeping_workflow(ctx: &Context, secs: u64) -> Result<String> {
     ctx.sleep(Duration::from_secs(secs)).await?;   // std::time::Duration
     Ok(format!("Slept for {secs} seconds"))
 }
@@ -9170,7 +9235,7 @@ The Resonate Rust equivalent compensates inline in the error branch:
 
 ```rust
 #[resonate::function]
-async fn transfer_money(ctx: &Context, args: TransferArgs) -> Result {
+async fn transfer_money(ctx: &Context, args: TransferArgs) -> Result<TransferResult> {
     let debit_id = format!("{}-debit", args.transfer_id);
     let credit_id = format!("{}-credit", args.transfer_id);
     let reversal_id = format!("{}-reversal", args.transfer_id);
@@ -9436,6 +9501,8 @@ Restate has three service types you must choose between:
     
 
 ```typescript title="Restate Basic Service"
+import * as restate from "@restatedev/restate-sdk";
+
 export const myService = restate.service({
   name: "MyService",
   handlers: {
@@ -9455,6 +9522,8 @@ restate.serve({ services: [myService] });
     
 
 ```typescript title="Resonate - just a function"
+import { Resonate, Context } from "@resonatehq/sdk";
+
 const resonate = new Resonate();
 
 function* processOrder(ctx: Context, order: Order) {
@@ -9881,7 +9950,7 @@ pub struct HelloWorldWorkflow;
 #[workflow_methods]
 impl HelloWorldWorkflow {
     #[run]
-    pub async fn run(ctx: &mut WorkflowContext, name: String) -> WorkflowResult {
+    pub async fn run(ctx: &mut WorkflowContext<Self>, name: String) -> WorkflowResult<String> {
         ctx.start_activity(
             GreetingActivities::greet, name,
             ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
@@ -9892,7 +9961,7 @@ impl HelloWorldWorkflow {
 #[activities]
 impl GreetingActivities {
     #[activity]
-    pub async fn greet(_ctx: ActivityContext, name: String) -> Result {
+    pub async fn greet(_ctx: ActivityContext, name: String) -> Result<String, ActivityError> {
         Ok(format!("Hello, {}!", name))
     }
 }
@@ -9902,13 +9971,13 @@ impl GreetingActivities {
 
 ```rust
 #[resonate::function]
-async fn greet(ctx: &Context, name: String) -> Result {
+async fn greet(ctx: &Context, name: String) -> Result<String> {
     let greeting = ctx.run(format_greeting, name).await?;
     Ok(greeting)
 }
 
 #[resonate::function]
-async fn format_greeting(name: String) -> Result {
+async fn format_greeting(name: String) -> Result<String> {
     Ok(format!("Hello, {name}!"))
 }
 ```
@@ -10118,6 +10187,8 @@ resonate = Resonate.local()
     
 
 ```typescript
+import { Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate();
 
 // ...
@@ -10223,13 +10294,13 @@ pub struct MessagePassingWorkflow { counter: i32 }
 #[workflow_methods]
 impl MessagePassingWorkflow {
     #[run]
-    pub async fn run(ctx: &mut WorkflowContext, target: i32) -> WorkflowResult<i32> {
+    pub async fn run(ctx: &mut WorkflowContext<Self>, target: i32) -> WorkflowResult<i32> {
         ctx.wait_condition(|s| s.counter >= target).await;   // blocks here
         Ok(ctx.state(|s| s.counter))
     }
 
     #[signal]
-    pub fn increment(&mut self, _ctx: &mut SyncWorkflowContext, amount: i32) {
+    pub fn increment(&mut self, _ctx: &mut SyncWorkflowContext<Self>, amount: i32) {
         self.counter += amount;
     }
 }
@@ -10444,7 +10515,7 @@ See it in action: [example-durable-sleep-ts](https://github.com/resonatehq-examp
 
 ```rust
 #[run]
-pub async fn run(ctx: &mut WorkflowContext) -> WorkflowResult {
+pub async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<String> {
     ctx.timer(Duration::from_secs(1)).await;   // durable timer
     // …select! race + cancellable-timer demo omitted…
 }
@@ -10454,7 +10525,7 @@ pub async fn run(ctx: &mut WorkflowContext) -> WorkflowResult {
 
 ```rust
 #[resonate::function]
-async fn sleeping_workflow(ctx: &Context, secs: u64) -> Result {
+async fn sleeping_workflow(ctx: &Context, secs: u64) -> Result<String> {
     ctx.sleep(Duration::from_secs(secs)).await?;   // std::time::Duration
     Ok(format!("Slept for {secs} seconds"))
 }
@@ -10700,7 +10771,7 @@ See it in action: [example-saga-booking-ts](https://github.com/resonatehq-exampl
 
 ```rust
 #[run]
-pub async fn run(ctx: &mut WorkflowContext, trip_id: String) -> WorkflowResult> {
+pub async fn run(ctx: &mut WorkflowContext<Self>, trip_id: String) -> WorkflowResult<Vec<String>> {
     let mut saga = Saga::new(ctx, activity_opts());
     match Self::book_trip(&mut saga, trip_id).await {
         Ok(ids) => Ok(ids),
@@ -10714,7 +10785,7 @@ pub async fn run(ctx: &mut WorkflowContext, trip_id: String) -> WorkflowResult> 
 
 ```rust
 #[resonate::function]
-async fn transfer_money(ctx: &Context, args: TransferArgs) -> Result {
+async fn transfer_money(ctx: &Context, args: TransferArgs) -> Result<TransferResult> {
     // Step 1 — debit the source (durable checkpoint).
     ctx.run(apply_entry, EntryArgs {
         op_id: format!("{}-debit", args.transfer_id),
@@ -10907,7 +10978,7 @@ This pattern currently has a Resonate example in TypeScript only.
 **Temporal** — `samples-typescript/mutex/src/workflows.ts` (excerpt):
 
 ```typescript
-export async function lockWorkflow(requests = Array()): Promise<void> {
+export async function lockWorkflow(requests = Array<LockRequest>()): Promise<void> {
   setHandler(lockRequestSignal, (req) => { requests.push(req); });
   while (!workflowInfo().continueAsNewSuggested) {
     await condition(() => requests.length > 0);
@@ -10953,7 +11024,7 @@ This pattern currently has a Resonate example in TypeScript only.
 
 ```typescript
 export class EncryptionCodec implements PayloadCodec {
-  async encode(payloads: Payload[]): Promise {
+  async encode(payloads: Payload[]): Promise<Payload[]> {
     return Promise.all(payloads.map(async (payload) => ({
       metadata: {
         [METADATA_ENCODING_KEY]: encode(ENCODING),
@@ -10962,7 +11033,7 @@ export class EncryptionCodec implements PayloadCodec {
       data: await encrypt(temporal.api.common.v1.Payload.encode(payload).finish(), this.keys.get(this.defaultKeyId)!),
     })));
   }
-  async decode(payloads: Payload[]): Promise { /* …mirror of encode… */ }
+  async decode(payloads: Payload[]): Promise<Payload[]> { /* …mirror of encode… */ }
 }
 ```
 
@@ -11394,7 +11465,7 @@ resonate dev \
 ```
 
 
-`--transports-bash-exec-enabled` requires `true` or `false`. A bare flag will error with `a value is required for '--transports-bash-exec-enabled '`.
+`--transports-bash-exec-enabled` requires `true` or `false`. A bare flag will error with `a value is required for '--transports-bash-exec-enabled <BOOL>'`.
 
 
 Verify in another shell:
@@ -11653,7 +11724,7 @@ See `resonate dev --help` for options.
 ```shell title="Start with PostgreSQL"
 resonate serve \
   --storage-type postgres \
-  --storage-postgres-url "postgres://:@localhost:5432/resonate"
+  --storage-postgres-url "postgres://<USER>:<PASSWORD>@localhost:5432/resonate"
 ```
 
 See `resonate serve --help` for all flags, or [Run a server](/deploy/run-server) for the full configuration story (`resonate.toml` + env vars + flags).
@@ -11738,7 +11809,7 @@ The Resonate server is configured by layering, in this order: defaults → `reso
 resonate serve \
   --auth-publickey /etc/resonate/auth/public.pem \
   --storage-type postgres \
-  --storage-postgres-url "postgres://:@localhost:5432/resonate"
+  --storage-postgres-url "postgres://<USER>:<PASSWORD>@localhost:5432/resonate"
 ```
 
 The same configuration as a [`resonate.toml`](/deploy/run-server#resonatetoml):
@@ -11751,7 +11822,7 @@ publickey = "/etc/resonate/auth/public.pem"
 type = "postgres"
 
 [storage.postgres]
-url = "postgres://:@localhost:5432/resonate"
+url = "postgres://<USER>:<PASSWORD>@localhost:5432/resonate"
 ```
 
 Run `resonate serve --help` for all available flags.
@@ -11910,7 +11981,7 @@ def weather_data(ctx, latitude, longitude, year, month, timezone="America/Edmont
 use resonate::prelude::*;
 
 #[resonate::function]
-async fn get_forecast(ctx: &Context, lat: f64, lon: f64) -> Result {
+async fn get_forecast(ctx: &Context, lat: f64, lon: f64) -> Result<String> {
     // ctx.run checkpoints the HTTP call — a retry of the MCP tool with the
     // same lat/lon reconnects to this workflow rather than re-fetching.
     let json = ctx.run(fetch_nws, (lat, lon)).await?;
@@ -11918,7 +11989,7 @@ async fn get_forecast(ctx: &Context, lat: f64, lon: f64) -> Result {
 }
 
 #[resonate::function]
-async fn fetch_nws(lat: f64, lon: f64) -> Result {
+async fn fetch_nws(lat: f64, lon: f64) -> Result<String> {
     let url = format!("https://api.weather.gov/points/{lat},{lon}");
     // ...HTTP call returning the response body.
 }
@@ -11973,7 +12044,7 @@ def await_result(job_names):
 #[tool_router(server_handler)]
 impl WeatherBridge {
     #[tool(description = "Get the forecast for the given lat/lon.")]
-    async fn get_forecast(&self, Parameters(p): Parameters) -> Result {
+    async fn get_forecast(&self, Parameters(p): Parameters<ForecastArgs>) -> Result<CallToolResult> {
         let id = format!("forecast-{}-{}", p.lat, p.lon);
         // Same id reconnects to an in-flight execution rather than re-fetching.
         let result: String = self.resonate
@@ -12111,6 +12182,10 @@ Two processes: a **gateway** that accepts HTTP requests and a **worker** that ru
 
 
 ```typescript title="gateway.ts"
+import express from "express";
+import { randomUUID } from "node:crypto";
+import { Resonate } from "@resonatehq/sdk";
+
 const app = express();
 app.use(express.json());
 
@@ -12193,12 +12268,12 @@ use axum::{routing::{get, post}, Json, Router};
 use resonate::prelude::*;
 use uuid::Uuid;
 
-async fn begin(State(r): State, Json(body): Json) -> impl IntoResponse {
+async fn begin(State(r): State<Resonate>, Json(body): Json<Value>) -> impl IntoResponse {
     let id = body.get("id").and_then(|v| v.as_str()).map(String::from)
         .unwrap_or_else(|| Uuid::new_v4().to_string());
 
     // .spawn() returns a handle without blocking on completion.
-    let _: ResonateHandle = r
+    let _: ResonateHandle<Value> = r
         .rpc(&id, "foo", body.clone())
         .target("poll://any@worker")
         .spawn()
@@ -12208,9 +12283,9 @@ async fn begin(State(r): State, Json(body): Json) -> impl IntoResponse {
     Json(json!({ "promise": id, "status": "pending", "wait": format!("/wait?id={id}") }))
 }
 
-async fn wait(State(r): State, Query(q): Query>) -> impl IntoResponse {
+async fn wait(State(r): State<Resonate>, Query(q): Query<HashMap<String, String>>) -> impl IntoResponse {
     let id = q.get("id").cloned().unwrap_or_default();
-    let handle: ResonateHandle = r.get(&id).await.unwrap();
+    let handle: ResonateHandle<Value> = r.get(&id).await.unwrap();
     if handle.done().await.unwrap() {
         let result = handle.result().await.unwrap();
         return Json(json!({ "status": "resolved", "promise_id": id, "result": result }));
@@ -12232,6 +12307,8 @@ async fn wait(State(r): State, Query(q): Query>) -> impl IntoResponse {
 
 
 ```typescript title="worker.ts"
+import { Resonate, type Context } from "@resonatehq/sdk";
+
 const resonate = new Resonate({ url: "http://localhost:8001", group: "worker" });
 
 // Inputs and return value must be JSON-serializable.
@@ -12275,7 +12352,7 @@ use resonate::prelude::*;
 use serde_json::Value;
 
 #[resonate::function]
-async fn foo(_: &Context, data: Value) -> Result {
+async fn foo(_: &Context, data: Value) -> Result<Value> {
     // Real workloads call ctx.run(stepFn, ...) for checkpointed side effects.
     Ok(json!({ "result": format!("Processed: {data}"), "timestamp": now() }))
 }
@@ -12757,7 +12834,7 @@ def research(ctx: Context, topic: str, depth: int):
 
 ```rust title="src/main.rs"
 #[resonate::function]
-async fn research(ctx: &Context, topic: String, depth: u32) -> Result {
+async fn research(ctx: &Context, topic: String, depth: u32) -> Result<String> {
     let mut messages = vec![
         json!({"role": "system", "content": SYSTEM_PROMPT}),
         json!({"role": "user", "content": format!("Research {topic}")}),
@@ -12915,6 +12992,8 @@ The whole workflow is a generator. The Cloud Function entry point is one line: r
 ### The countdown workflow
 
 ```typescript title="src/count.ts"
+import type { Context } from "@resonatehq/sdk";
+
 export function* countdown(
   ctx: Context,
   count: number,
@@ -12938,6 +13017,9 @@ async function notify(_ctx: Context, url: string, msg: string) {
 ### The Cloud Function entry point
 
 ```typescript title="src/index.ts"
+import { Resonate } from "@resonatehq/gcp";
+import { countdown } from "./count";
+
 const resonate = new Resonate();
 resonate.register("countdown", countdown);
 
@@ -13027,6 +13109,9 @@ Two pieces inside the Lambda handler — start the workflow, poll its status —
 
 
 ```typescript title="src/handler.ts"
+import { Resonate } from "@resonatehq/sdk";
+import { processDocument, type DocumentJob } from "./workflow.js";
+
 // Module-level: created once per cold start, reused across warm invocations.
 const resonate = new Resonate({ url: process.env["RESONATE_URL"] });
 resonate.register("processDocument", processDocument);
@@ -13099,6 +13184,8 @@ Same `jobId` deduplicates retries — API Gateway can re-fire the request withou
 
 
 ```typescript title="src/workflow.ts"
+import type { Context } from "@resonatehq/sdk";
+
 export function* processDocument(ctx: Context, job: DocumentJob) {
   // Each ctx.run is a checkpoint. Crash mid-step, resume from the next.
   const pageCount = yield* ctx.run(downloadDocument, job);
@@ -13262,6 +13349,9 @@ The whole pattern is one line: `yield* ctx.sleep(ms)`. Everything around it is j
 
 
 ```typescript title="worker.ts"
+import { Resonate } from "@resonatehq/sdk";
+import type { Context } from "@resonatehq/sdk";
+
 const resonate = new Resonate({
   url: "http://localhost:8001",
   group: "workers",
@@ -13308,7 +13398,7 @@ use resonate::prelude::*;
 use std::time::Duration;
 
 #[resonate::function]
-async fn sleeping_workflow(ctx: &Context, secs: u64) -> Result {
+async fn sleeping_workflow(ctx: &Context, secs: u64) -> Result<String> {
     println!("sleeping for {secs} seconds...");
     ctx.sleep(Duration::from_secs(secs)).await?;
     Ok(format!("slept for {secs} seconds"))
@@ -13328,6 +13418,8 @@ The client uses async RPC to dispatch by ID. Reusing the same ID reconnects to a
 
 
 ```typescript title="client.ts"
+import { Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate({
   url: "http://localhost:8001",
   group: "client",
@@ -13522,6 +13614,9 @@ The fan-out is N spawn calls. The fan-in is N awaits. The fact that each is dura
 
 
 ```typescript title="src/workflow.ts"
+import type { Context } from "@resonatehq/sdk";
+import { sendEmail, sendSms, sendSlack, sendPush, type OrderEvent } from "./channels";
+
 export function* notifyAll(ctx: Context, event: OrderEvent, simulateCrash: boolean) {
   const start = Date.now();
 
@@ -13597,7 +13692,7 @@ struct WorkItem { id: u32, data: String }
 struct WorkResult { id: u32, output: String }
 
 #[resonate::function]
-async fn fan_out_fan_in(ctx: &Context, items: Vec) -> Result> {
+async fn fan_out_fan_in(ctx: &Context, items: Vec<WorkItem>) -> Result<Vec<WorkResult>> {
     // Fan-out: spawn three items in parallel.
     let h1 = ctx.run(process_item, items[0].clone()).spawn().await?;
     let h2 = ctx.run(process_item, items[1].clone()).spawn().await?;
@@ -13611,7 +13706,7 @@ async fn fan_out_fan_in(ctx: &Context, items: Vec) -> Result> {
 }
 
 #[resonate::function]
-async fn process_item(item: WorkItem) -> Result {
+async fn process_item(item: WorkItem) -> Result<WorkResult> {
     Ok(WorkResult {
         id: item.id,
         output: format!("Processed: {} (item #{})", item.data, item.id),
@@ -13842,6 +13937,9 @@ The workflow is a generator (TypeScript and Python) or `#[resonate::function]` a
 
 
 ```typescript title="index.ts"
+import { Resonate } from "@resonatehq/sdk";
+import type { Context } from "@resonatehq/sdk";
+
 const resonate = new Resonate();
 
 async function bar(_: Context, greetee: string) {
@@ -13905,13 +14003,13 @@ print(result)
 use resonate::prelude::*;
 
 #[resonate::function]
-async fn greet(ctx: &Context, name: String) -> Result {
+async fn greet(ctx: &Context, name: String) -> Result<String> {
     let greeting = ctx.run(format_greeting, name).await?;
     Ok(greeting)
 }
 
 #[resonate::function]
-async fn format_greeting(name: String) -> Result {
+async fn format_greeting(name: String) -> Result<String> {
     Ok(format!("Hello, {name}! Welcome to durable execution."))
 }
 
@@ -14109,7 +14207,7 @@ def foo(ctx, workflow_id):
 use resonate::prelude::*;
 
 #[resonate::function]
-async fn foo(ctx: &Context, workflow_id: String) -> Result {
+async fn foo(ctx: &Context, workflow_id: String) -> Result<String> {
     // Latent durable promise — resolved externally.
     let blocking_promise = ctx.promise::<bool>();
     let promise_id = blocking_promise.id().await?;
@@ -14198,11 +14296,11 @@ use std::sync::Arc;
 struct StartReq { workflow_id: String }
 
 #[derive(Clone)]
-struct AppState { resonate: Arc }
+struct AppState { resonate: Arc<Resonate> }
 
 async fn start_workflow(
-    State(state): State,
-    Json(req): Json,
+    State(state): State<AppState>,
+    Json(req): Json<StartReq>,
 ) -> impl IntoResponse {
     // Same workflow_id reconnects to a PENDING execution rather than starting a new one.
     let result: String = state.resonate
@@ -14214,8 +14312,8 @@ async fn start_workflow(
 }
 
 async fn resolve(
-    State(state): State,
-    Path(promise_id): Path,
+    State(state): State<AppState>,
+    Path(promise_id): Path<String>,
 ) -> impl IntoResponse {
     state.resonate.promises.resolve(&promise_id, Value::from_serializable(json!(true)).unwrap()).await.unwrap();
     Json(json!({ "message": "promise resolved" }))
@@ -14413,6 +14511,8 @@ The pattern is a small consume loop that hands each message to `workflow.begin_r
 
 
 ```typescript title="src/workflow.ts"
+import { Resonate, type Context } from "@resonatehq/sdk";
+
 export const resonate = new Resonate({
   url: "http://localhost:8001",
   group: "workers",
@@ -14716,6 +14816,9 @@ Each worker process is identical except for the `group` it joins. Run as many as
 
 
 ```typescript title="worker.ts"
+import { Resonate } from "@resonatehq/sdk";
+import type { Context } from "@resonatehq/sdk";
+
 const resonate = new Resonate({
   url: "http://localhost:8001",
   group: "workers",
@@ -14841,6 +14944,9 @@ The caller picks a target with the `poll://any@<group>` schema. `any` means "whi
 
 
 ```typescript title="client.ts"
+import { Resonate } from "@resonatehq/sdk";
+import { v4 as uuid } from "uuid";
+
 const resonate = new Resonate({
   url: "http://localhost:8001",
   group: "client",
@@ -15178,7 +15284,7 @@ The deterministic `op_id` (`{transfer_id}-debit`, `-credit`, `-reversal`) plus a
 async fn transfer_money(
     ctx: &Context, transfer_id: String, source: String, target: String,
     amount: f64, simulate_credit_failure: bool,
-) -> Result {
+) -> Result<TransferResult> {
     let debit_id = format!("{transfer_id}-debit");
     let credit_id = format!("{transfer_id}-credit");
     let reversal_id = format!("{transfer_id}-reversal");
@@ -15200,13 +15306,13 @@ async fn transfer_money(
 }
 ```
 
-The Rust example uses `Resonate.local()` (embedded mode, no server required) plus `with_dependency::>(...)` to inject the SQLite handle. `ctx.run(...).await` returns a `Result`, so saga compensation is just an `if let Err`.
+The Rust example uses `Resonate.local()` (embedded mode, no server required) plus `with_dependency::<Mutex<Connection>>(...)` to inject the SQLite handle. `ctx.run(...).await` returns a `Result`, so saga compensation is just an `if let Err`.
 
 
 
 
 
-`ctx.getDependency('db')` / `ctx.get_dependency("db")` / `info.get_dependency::()` (Rust) lets the step functions see the database without exposing it as a workflow argument — important, because workflow arguments must be serializable, and a DB handle is not.
+`ctx.getDependency('db')` / `ctx.get_dependency("db")` / `info.get_dependency::<T>()` (Rust) lets the step functions see the database without exposing it as a workflow argument — important, because workflow arguments must be serializable, and a DB handle is not.
 
 ## Run it locally
 
@@ -15327,6 +15433,9 @@ The orchestrator is one generator function that calls three plain agent function
 
 
 ```typescript title="src/workflow.ts"
+import type { Context } from "@resonatehq/sdk";
+import { researcher, writer, reviewer } from "./agents";
+
 export function* orchestrate(
   ctx: Context,
   topic: string,
@@ -15529,6 +15638,8 @@ The pattern is one self-recursive function plus a client that kicks it off.
 
 
 ```typescript title="factorialWorker.ts"
+import { Resonate, type Context } from "@resonatehq/sdk";
+
 const resonate = new Resonate({
   url: "http://localhost:8001",
   group: "factorial-workers",
@@ -15681,6 +15792,8 @@ The client looks identical to any other RPC call — Resonate doesn't care that 
 
 
 ```typescript title="factorialClient.ts"
+import { Resonate } from "@resonatehq/sdk";
+
 const resonate = new Resonate({
   url: "http://localhost:8001",
   group: "factorial-client",
@@ -15923,6 +16036,9 @@ Two scripts: a one-shot **schedule registration** that tells the server about th
 
 
 ```typescript title="src/schedule.ts"
+import { Resonate } from "@resonatehq/sdk";
+import { generateReport } from "./report";
+
 const resonate = new Resonate({ url: "http://localhost:8001" });
 resonate.register("generateReport", generateReport);
 
@@ -15997,6 +16113,9 @@ The schedule lives on the server, not in the worker. You can run the registratio
 
 
 ```typescript title="src/worker.ts"
+import { Resonate } from "@resonatehq/sdk";
+import { generateReport } from "./report";
+
 const resonate = new Resonate({ url: "http://localhost:8001" });
 resonate.register("generateReport", generateReport);
 console.log("Worker started. Waiting for scheduled executions...");
@@ -16437,6 +16556,8 @@ A countdown loop that survives restarts — minutes, hours, or days.
 
 
 ```typescript title="countdown.ts"
+import { Resonate, type Context } from "@resonatehq/sdk";
+
 function* countdown(context: Context, count: number, delay: number) {
   for (let i = count; i > 0; i--) {
     // Run a function, persist its result
@@ -16867,12 +16988,12 @@ resonate serve
 # Postgres
 resonate serve \
   --storage-type postgres \
-  --storage-postgres-url "postgres://:@localhost:5432/resonate"
+  --storage-postgres-url "postgres://<USER>:<PASSWORD>@localhost:5432/resonate"
 
 # MySQL
 resonate serve \
   --storage-type mysql \
-  --storage-mysql-url "mysql://:@localhost:3306/resonate"
+  --storage-mysql-url "mysql://<USER>:<PASSWORD>@localhost:3306/resonate"
 ```
 
 Source: [`resonate/src/cli.rs:338-356`](https://github.com/resonatehq/resonate/blob/main/src/cli.rs#L338-L356). Loading order: built-in defaults → optional `resonate.toml` → environment variables → CLI flags ([`resonate/src/cli.rs:10-13`](https://github.com/resonatehq/resonate/blob/main/src/cli.rs#L10-L13)).
@@ -17231,7 +17352,7 @@ resonate schedules search --limit 100 | jq '.schedules | max_by(.createdAt)'
 
 ## Environment variables
 
-The CLI itself reads no env vars — every flag is explicit. But the **server** (when started via `resonate serve` / `resonate dev`) reads `RESONATE___` for every config field. See:
+The CLI itself reads no env vars — every flag is explicit. But the **server** (when started via `resonate serve` / `resonate dev`) reads `RESONATE_<SECTION>__<FIELD>` for every config field. See:
 
 - [Defaults reference › Environment variables](/reference/defaults#environment-variables) — SDK + shared env vars
 - [Run a server › Environment variables](/deploy/run-server#environment-variables) — server-side `RESONATE_*` map
@@ -17528,7 +17649,7 @@ The SDKs share a common set of `RESONATE_*` environment variables. Defaults belo
 | `RESONATE_TIMEOUT` | `10000` ms (TS HTTP only) | TS: `resonate-sdk-ts/src/network/http.ts:60-62` |
 | `RESONATE_URL` HTTP fallback | `"http://localhost:8001"` (TS `HttpNetwork` constructor) | `resonate-sdk-ts/src/network/http.ts:58` |
 
-Server-side `RESONATE_*` environment variables (storage, auth, transports) follow the `RESONATE___` convention. See [Run a server › Environment variables](/deploy/run-server#environment-variables) for the complete list — those defaults track the server flag table above.
+Server-side `RESONATE_*` environment variables (storage, auth, transports) follow the `RESONATE_<SECTION>__<FIELD>` convention. See [Run a server › Environment variables](/deploy/run-server#environment-variables) for the complete list — those defaults track the server flag table above.
 
 ---
 
@@ -17687,7 +17808,7 @@ The only guarantee is that if a process experiences a receive event, there is a 
 Every component may issue a `Send(address, message)` command that emits a `Send(address, message)` event.
 
 ```text
-command Send(address : Address, message : T)
+command Send<T>(address : Address, message : T)
 ```
 
 The Send command is the foundation of Distributed Async Await's failover mechanics: Send's anycast semantics enable both routing and transparent rerouting in case of failure. This allows distributed executions to adapt dynamically to changes in process topology.

--- a/scripts/generate-llms-txt.mjs
+++ b/scripts/generate-llms-txt.mjs
@@ -32,9 +32,11 @@ function extractFrontmatter(content) {
   return { title, description, body };
 }
 
-function stripJsx(content) {
-  // Remove JSX component tags but keep their text children.
-  return content
+function stripProse(text) {
+  // Remove JSX component tags but keep their text children. Only ever run on
+  // prose segments — never on code (see stripJsx), or it would eat angle
+  // brackets that are legitimate syntax (e.g. Rust generics).
+  return text
     // Components that carry link content the LLM corpus needs must be expanded
     // to markdown BEFORE the generic tag strip below, or they vanish entirely.
     .replace(
@@ -43,7 +45,29 @@ function stripJsx(content) {
         `See it in action: [${repo}](${href ?? `https://github.com/resonatehq-examples/${repo}`})`
     )
     .replace(/<\/?[A-Z][A-Za-z]*[^>]*>/g, "")
-    .replace(/import\s+.*?from\s+['"].*?['"];?\s*/g, "")
+    .replace(/import\s+.*?from\s+['"].*?['"];?\s*/g, "");
+}
+
+function stripJsx(content) {
+  // Strip JSX from prose while preserving code verbatim. Code such as Rust
+  // generics — WorkflowResult<Vec<String>> or WorkflowContext<Self> — would
+  // otherwise be mangled by the tag regex (anything matching <[A-Z]...> gets
+  // deleted), corrupting the corpus.
+  //
+  // Replace every fenced code block (```...```) and inline code span (`...`)
+  // with an opaque placeholder BEFORE running the JSX stripper, then restore
+  // them after. Protecting code first (rather than splitting prose on code
+  // boundaries) keeps JSX tags intact even when an attribute value itself
+  // contains backticks — e.g. <Callout title="`localnet` requires ...">, which
+  // a split-on-code approach would tear apart so the tag could no longer be
+  // matched and stripped.
+  const code = [];
+  const protectedContent = content.replace(
+    /```[\s\S]*?```|`[^`\n]*`/g,
+    (match) => `\x00CODE${code.push(match) - 1}\x00`
+  );
+  return stripProse(protectedContent)
+    .replace(/\x00CODE(\d+)\x00/g, (_m, i) => code[Number(i)])
     .trim();
 }
 


### PR DESCRIPTION
## What

Adds CI for this docs site and fixes a corpus-generator bug that was silently corrupting the RAG corpus. Two commits:

1. **`fix(llms): preserve code-block angle brackets in corpus generator`**
2. **`ci: add build, link-check, llms-sync, and secret-scan workflow`**

## Why — the generator bug (fixed first)

`scripts/generate-llms-txt.mjs` ran its JSX/HTML tag stripper over the **entire** MDX body, including fenced code blocks and inline code. Any capitalized angle-bracket sequence got eaten:

| Source (correct) | Old `llms-full.txt` (corrupt) |
| --- | --- |
| `WorkflowResult<Vec<String>>` | `WorkflowResult>` |
| `WorkflowContext<Self>` | `WorkflowContext` |
| `Option<String>` | `Option` |
| `postgres://<USER>:<PASSWORD>@host` | `postgres://:@host` |

Lowercase generics (`<i32>`) survived, which is why it went unnoticed. The fix splits the body into fenced/inline **code** vs **prose** and runs the stripper only on prose; code is preserved verbatim. Prose JSX components (`<CardGrid>`, `<SeeItInAction/>`, MDX imports) are still stripped/expanded exactly as before.

Regenerating restored the mangled generics **and** code-example `import` lines / placeholder credentials the old stripper had been quietly deleting from the corpus. Verified locally:

- `grep -c 'WorkflowResult>' public/llms-full.txt` → **0** (was 1)
- `grep -c 'WorkflowResult<Vec<String>>' public/llms-full.txt` → **1**
- prose components (`CardGrid`, `SeeItInAction`) still **0** in output; `See it in action:` link expansions intact.

## The workflow (`.github/workflows/ci.yml`)

Node 20, `npm ci` with npm cache. There is no `.nvmrc`/`engines` in the repo, so Node 20 LTS was chosen.

- **Build + internal link check** (PR + push): `npm run build`, which runs `postbuild` (`scripts/check-links.mjs`) — boots `next start` and crawls every page. Internal broken links fail CI; unreachable external links stay warn-only. `check-links.mjs` already implemented this exit behaviour correctly (`cleanup(internalBroken > 0 ? 1 : 0)`), so no change was needed there — verified both directions locally:
  - clean tree → `0 internal broken, 8 external unreachable (warn-only)`, exit 0. The 8 are the expected `localhost` metrics/tracing demo links.
  - a deliberately broken internal link on a crawled page → `1 internal broken`, **exit 1**.
- **llms sync check** (PR): after the build, `git diff --exit-code public/llms.txt public/llms-full.txt`. If the committed corpus is stale, the PR fails with a message to run `npm run build` and commit the regenerated files. This is the primary enforcement and needs no special permissions.
- **Auto-regen on push to `main`**: if the rebuilt corpus drifted, it's committed back to `main` (bot identity, author `cullywakelin@gmail.com`, `[skip ci]` to prevent a loop). Uses `permissions: contents: write` + the default `GITHUB_TOKEN`.
- **Secret scan** (gitleaks): runs from the pinned image (no org license key needed), allowlisting the documentation placeholder connection strings (`postgres://<USER>:<PASSWORD>@…`) and build artifacts. Verified locally: **no leaks found**, exit 0, while the placeholder URLs are present in the scanned tree (allowlist is doing real work).

> **Branch-protection note:** the auto-regen step pushes to `main` from Actions. If branch protection blocks that, the step degrades to a warning and the **PR-time sync check remains the enforcing gate** — no corpus drift slips through either way.

## Verification

`npm ci && npm run build` run locally: build green, link check green, generator fix proven by before/after grep, gitleaks green.

Draft per repo convention — leaving for human review/merge.
