### PR TITLE
Inset "See it in action" link from left border

### DIFF
--- a/components/mdx/SeeItInAction.tsx
+++ b/components/mdx/SeeItInAction.tsx
@@ -17,7 +17,7 @@ export default function SeeItInAction({ repo, href }: SeeItInActionProps) {
   // the `.docs-content a` prose rule (specificity 0,1,1) otherwise overrides the
   // utility colors (0,1,0) and this renders as a teal underlined body link.
   return (
-    <span className="not-prose mt-3 block">
+    <span className="not-prose mt-3 block pl-3">
       <a
         href={url}
         target="_blank"


### PR DESCRIPTION
Adds `pl-3` to the `SeeItInAction` wrapper so the GitHub icon is no longer flush against the container's left border.

Reported visually: the lucide GitHub icon was touching the left edge of the box that sits below code samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)