### PR TITLE
Format human-in-the-loop code blocks to match house style

### DIFF
--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -440,9 +440,7 @@ In Temporal, you can use Signals to unblock a Workflow Execution with input from
 
 <TabItem value="python">
 
-`samples-python/hello/hello_signal.py`:
-
-```python
+```python title="Temporal — samples-python/hello/hello_signal.py"
 @workflow.defn
 class GreetingWorkflow:
     @workflow.run
@@ -460,15 +458,15 @@ class GreetingWorkflow:
         self._exit = True
 ```
 
-Unblock it externally: `await handle.signal(GreetingWorkflow.exit)`.
+```python title="Unblock it externally"
+await handle.signal(GreetingWorkflow.exit)
+```
 
 </TabItem>
 
 <TabItem value="typescript">
 
-`samples-typescript/signals-queries/src/workflows.ts`:
-
-```typescript
+```typescript title="Temporal — samples-typescript/signals-queries/src/workflows.ts"
 export const unblockSignal = wf.defineSignal('unblock');
 export const isBlockedQuery = wf.defineQuery<boolean>('isBlocked');
 
@@ -480,15 +478,15 @@ export async function unblockOrCancel(): Promise<void> {
 }
 ```
 
-Unblock it externally: `await handle.signal(unblockSignal);`.
+```typescript title="Unblock it externally"
+await handle.signal(unblockSignal);
+```
 
 </TabItem>
 
 <TabItem value="rust">
 
-`sdk-rust/crates/sdk/examples/message_passing/workflows.rs`:
-
-```rust
+```rust title="Temporal — sdk-rust/crates/sdk/examples/message_passing/workflows.rs"
 #[workflow]
 pub struct MessagePassingWorkflow { counter: i32 }
 
@@ -514,9 +512,7 @@ equivalent is in the tabs below.
 
 <TabItem value="go">
 
-`samples-go/await-signals/await_signals_workflow.go` (excerpt):
-
-```go
+```go title="Temporal — samples-go/await-signals/await_signals_workflow.go (excerpt)"
 func AwaitSignalsWorkflow(ctx workflow.Context) (err error) {
     var a AwaitSignals
     workflow.Go(ctx, a.Listen)                     // signal handlers in a goroutine

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -10155,9 +10155,7 @@ In Temporal, you can use Signals to unblock a Workflow Execution with input from
 
 
 
-`samples-python/hello/hello_signal.py`:
-
-```python
+```python title="Temporal — samples-python/hello/hello_signal.py"
 @workflow.defn
 class GreetingWorkflow:
     @workflow.run
@@ -10175,15 +10173,15 @@ class GreetingWorkflow:
         self._exit = True
 ```
 
-Unblock it externally: `await handle.signal(GreetingWorkflow.exit)`.
+```python title="Unblock it externally"
+await handle.signal(GreetingWorkflow.exit)
+```
 
 
 
 
 
-`samples-typescript/signals-queries/src/workflows.ts`:
-
-```typescript
+```typescript title="Temporal — samples-typescript/signals-queries/src/workflows.ts"
 export const unblockSignal = wf.defineSignal('unblock');
 export const isBlockedQuery = wf.defineQuery<boolean>('isBlocked');
 
@@ -10195,15 +10193,15 @@ export async function unblockOrCancel(): Promise<void> {
 }
 ```
 
-Unblock it externally: `await handle.signal(unblockSignal);`.
+```typescript title="Unblock it externally"
+await handle.signal(unblockSignal);
+```
 
 
 
 
 
-`sdk-rust/crates/sdk/examples/message_passing/workflows.rs`:
-
-```rust
+```rust title="Temporal — sdk-rust/crates/sdk/examples/message_passing/workflows.rs"
 #[workflow]
 pub struct MessagePassingWorkflow { counter: i32 }
 
@@ -10229,9 +10227,7 @@ equivalent is in the tabs below.
 
 
 
-`samples-go/await-signals/await_signals_workflow.go` (excerpt):
-
-```go
+```go title="Temporal — samples-go/await-signals/await_signals_workflow.go (excerpt)"
 func AwaitSignalsWorkflow(ctx workflow.Context) (err error) {
     var a AwaitSignals
     workflow.Go(ctx, a.Listen)                     // signal handlers in a goroutine


### PR DESCRIPTION
The **Human-in-the-loop** section of the Temporal migration guide was the only place in the file using two off-pattern formats:

1. Floating `` `path`: `` inline-code filename chips above each block (rendered as a code chip with a dangling colon).
2. An `Unblock it externally: \`call\`.` prose caption with a trailing period hanging off the inline code.

Every other code block in this file (40+) uses the fence `title="Temporal — path"` / `title="Resonate — path"` convention, which renders a proper header bar (filename + language + copy button).

### Changes
- Moved the four Temporal filenames into the fence `title=` bar.
- Promoted the Python/TS external-unblock calls into their own `title="Unblock it externally"` blocks — mirroring how the Resonate-equivalent block below shows the external resolve as a labeled code block, and giving the snippet a copy button.
- Left the Rust note as prose: it points at the tabs below and has no concrete external call to show without inventing API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)