### PR TITLE
Fix code token colors not theming in dark mode

### DIFF
--- a/source.config.ts
+++ b/source.config.ts
@@ -22,6 +22,11 @@ export default defineConfig({
         light: "github-light",
         dark: "github-dark",
       },
+      // Emit only CSS custom properties (--shiki-light / --shiki-dark) instead
+      // of also baking the light color into an inline `color` style. The inline
+      // color has higher specificity than `.dark pre code span` and would win
+      // in dark mode, leaving tokens like function args near-black on dark bg.
+      defaultColor: false,
       // Shiki bakes the language into inline styles and drops the
       // `language-x` class, so the code-block chrome had no way to label an
       // untitled block and fell back to a meaningless "code". Stamp the


### PR DESCRIPTION
## Problem

In code samples like `ctx.run(step)`, function-call arguments (and other tokens) stayed near-black in dark mode instead of switching to the dark-theme color — effectively invisible against the dark background.

## Root cause

Shiki's dual-theme mode (`github-light` / `github-dark`), without `defaultColor: false`, emits each token with a **hardcoded inline `color`** (the light-theme value) *plus* a `--shiki-dark` CSS variable:

```html
<span style="color:#24292E;--shiki-dark:#E1E4E8">(step)</span>
```

The dark-mode override in `globals.css`:

```css
.dark pre code span { color: var(--shiki-dark); }
```

can't win — an inline `style="color:…"` has specificity (1,0,0) and beats the stylesheet rule (0,1,3). So tokens kept the near-black `#24292E` in dark mode.

Notably, `globals.css` was *already* written for the `defaultColor: false` pattern (it sets both `--shiki-light` and `--shiki-dark` rules) — the config just never enabled it.

## Fix

Add `defaultColor: false` to `rehypeCodeOptions`. Shiki then emits only `--shiki-light` / `--shiki-dark` custom properties with no inline `color`, and the existing globals.css rules apply cleanly for both themes. Fixes all token scopes, not just function args.

## Test

Rebuild and view any docs page with a code block (e.g. one using `ctx.run(step)`) in dark mode — all tokens now use the dark theme palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)