### PR TITLE
Tighten copy on evaluate, get-started, and landing pages

### DIFF
--- a/content/docs/evaluate/coming-from/byode.mdx
+++ b/content/docs/evaluate/coming-from/byode.mdx
@@ -89,7 +89,7 @@ function* processOrder(ctx: Context, order: Order) {
 }
 ```
 
-That's it. No queue abstraction to learn. No lease management. No state machine diagrams. Just functions.
+The code above is complete — ordinary functions, checkpointed at each step. There's no queue abstraction, lease management, or state-machine diagram to learn.
 
 **If the process crashes**, Resonate resumes from the last completed step. **If chargeCard succeeds but reserveItems fails**, the retry doesn't re-charge the card.
 

--- a/content/docs/evaluate/coming-from/restate.mdx
+++ b/content/docs/evaluate/coming-from/restate.mdx
@@ -42,7 +42,7 @@ Restate has three service types you must choose between:
 - **Virtual Object**: Stateful entity with a key
 - **Workflow**: Once-per-ID execution with signals/queries
 
-**In Resonate, there's no such distinction.** You write functions. That's it.
+**In Resonate, there's no such distinction** — stateless handlers, stateful entities, and workflows are all written as ordinary functions.
 
 
 

--- a/content/docs/get-started/examples/webhook-handler.mdx
+++ b/content/docs/get-started/examples/webhook-handler.mdx
@@ -34,7 +34,7 @@ TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (
 
 ## The problem
 
-Webhook providers retry on any timeout, slow ACK, or 5xx response — that's the whole point. Your handler has to be idempotent, or duplicate deliveries double-charge the customer. The conventional fix is a "processed events" table you check before doing work, paired with a worker that polls a queue, paired with retry logic for partial failures. Three moving parts, and any one of them not being idempotent breaks the whole shape.
+Webhook providers are built to retry — any timeout, slow ACK, or 5xx response triggers a redelivery. Your handler has to be idempotent, or duplicate deliveries double-charge the customer. The conventional fix is a "processed events" table you check before doing work, paired with a worker that polls a queue, paired with retry logic for partial failures. Three moving parts, and any one of them not being idempotent breaks the whole shape.
 
 ## Resonate's solution
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -12,7 +12,7 @@ description: Resonate — agent-native durable execution. Generated, optimized, 
 Resonate is built on three pillars:
 
 - **Agent-native** — The SDK, docs, tool definitions, and operational surface are designed for agent consumption, not just human developers. CLIs over dashboards. Skill files over screenshots. Agents are the new developers, and Resonate is the platform they reach for.
-- **Generated & optimized** — Open-source pluggable components plus stack-specific generated servers. AI constrained by formal specs and protocols — not slop, but highly optimized software. Exactly what your stack needs, nothing more.
+- **Generated & optimized** — Open-source pluggable components plus stack-specific generated servers. AI constrained by formal specs and protocols, producing highly optimized software tuned to exactly what your stack needs.
 - **Cost-efficient by design** — Serverless-native architecture means you pay only for active execution. Workloads that cost ~$80K/year on hosted alternatives can run for under $100/year on Resonate. Orders of magnitude, not percentages.
 
 Build agents, workflows, pipelines, and services without thinking about retries or recovery — in a few lines of code.


### PR DESCRIPTION
Small copy pass over four pages — replaces fragment-tag phrasing with full sentences, no content changes:

- **evaluate/coming-from/byode** — "That's it. No queue abstraction to learn. …" → "The code above is complete — ordinary functions, checkpointed at each step. There's no queue abstraction, lease management, or state-machine diagram to learn."
- **evaluate/coming-from/restate** — "You write functions. That's it." → "stateless handlers, stateful entities, and workflows are all written as ordinary functions."
- **get-started/examples/webhook-handler** — "…retry on any timeout, slow ACK, or 5xx response — that's the whole point." → "Webhook providers are built to retry — any timeout, slow ACK, or 5xx response triggers a redelivery."
- **index (Generated & optimized pillar)** — "…not slop, but highly optimized software. Exactly what your stack needs, nothing more." → "…producing highly optimized software tuned to exactly what your stack needs."

`public/llms-full.txt` regenerated via `scripts/generate-llms-txt.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)