### PR TITLE
Add schedules & cron reference page; fix CLI guide schedule/search examples

### DIFF
--- a/content/docs/develop/go.mdx
+++ b/content/docs/develop/go.mdx
@@ -352,9 +352,30 @@ Calling `Stop` on a worker (an RPC service, a queue consumer, an MCP server, or 
 The worker keeps running but silently stops processing work. Workers should stay up; let process termination (SIGINT / SIGTERM) end the lifecycle.
 </Callout>
 
-<Callout type="note" title="No `Schedule` or top-level promises sub-client yet">
-The Go SDK does not (yet) expose a `Schedule` API or a top-level promises sub-client. To create or settle a durable promise from outside a workflow — for human-in-the-loop and external-coordination patterns — create the promise from inside a workflow with [`ctx.Promise`](#ctxpromise) and settle it via the Resonate CLI (`resonate promise resolve <id>`) or the server's HTTP API. These surfaces will land as the API settles toward the first tag.
-</Callout>
+### `Resonate.Promises`
+
+`r.Promises()` is the direct promise API — `Get` / `Create` / `Resolve` / `Reject` / `Cancel` — for creating or settling a durable promise from outside a workflow (human-in-the-loop and external-coordination patterns).
+
+### `Resonate.Schedules`
+
+`r.Schedules()` is the direct schedule API: `Get`, `Create`, and `Delete`. A schedule creates a fresh promise on every cron firing, from a promise-ID template.
+
+There is no high-level `Schedule()` that binds a registered function yet, so the caller supplies everything the fired promises need — including the `resonate:target` routing tag, which the server **requires** (creates without it are rejected). Encode the payload your workers expect, and tag the promises with the group that should execute them:
+
+```go
+_, err := r.Schedules().Create(context.TODO(),
+    "nightly-report",          // schedule ID
+    "0 2 * * *",               // cron — evaluated in UTC
+    "report-{{.timestamp}}",   // promise-ID template
+    time.Hour,                 // timeout of each fired promise
+    resonate.ScheduleCreateOptions{
+        PromiseParam: payload,
+        PromiseTags:  map[string]string{"resonate:target": "poll://any@report-workers"},
+    },
+)
+```
+
+Cron expressions are evaluated in **UTC**, with Quartz day-of-week numbering (`1` = Sunday) — prefer day names like `MON-FRI`. See the [Schedules & cron reference](/reference/schedules) for the expression format, template variables, and the tags the server injects on fired promises.
 
 ## Context APIs
 

--- a/content/docs/develop/typescript.mdx
+++ b/content/docs/develop/typescript.mdx
@@ -399,10 +399,32 @@ The scheduled function will be invoked until the schedule is deleted.
 ```ts
 const schedule = await resonate.schedule(
   "scheduled-foo",
-  "0 * * * *", // every hour
+  "0 * * * *", // every hour, on the hour, UTC
   foo,
   ...args
 );
+```
+
+Cron expressions are evaluated in **UTC**, and the day-of-week field uses Quartz numbering (`1` = Sunday) — prefer day names like `MON-FRI`. See the [Schedules & cron reference](/reference/schedules) for the expression format, promise-ID templates, and the tags the server injects on fired promises.
+
+**Target routing.** Each promise the schedule fires carries a `resonate:target` tag that routes it to a worker group — without it the server rejects the schedule. `.schedule()` injects the tag for you from the `target` option (as the final argument, same as `.run()`/`.rpc()`), defaulting to the `default` group:
+
+```ts
+await resonate.schedule(
+  "nightly-report",
+  "0 2 * * *",
+  generateReport,
+  resonate.options({ target: "poll://any@report-workers" })
+);
+```
+
+**Delete and inspect.** The returned handle deletes the schedule; the `resonate.schedules` sub-client gives you direct `get` / `create` / `delete` access:
+
+```ts
+await schedule.delete(); // stop future ticks (already-fired promises are unaffected)
+
+const record = await resonate.schedules.get("nightly-report");
+console.log(record.nextRunAt);
 ```
 
 ### `.options()`

--- a/content/docs/get-started/cli-guide.mdx
+++ b/content/docs/get-started/cli-guide.mdx
@@ -95,7 +95,7 @@ resonate promises get order-123
 **Search for promises:**
 
 ```shell title="Find pending promises"
-resonate promises search "*" --state pending --limit 10
+resonate promises search --state pending --limit 10
 ```
 
 ### Work with schedules
@@ -106,13 +106,16 @@ resonate promises search "*" --state pending --limit 10
 resonate schedules create hourly-sync \
   --cron "0 * * * *" \
   --promise-id "sync-{{.timestamp}}" \
-  --description "Hourly data sync"
+  --promise-timeout 1h \
+  --promise-tags '{"resonate:target": "poll://any@default"}'
 ```
+
+The `resonate:target` tag routes each fired promise to a worker group — the server rejects a schedule without it. Cron expressions are evaluated in UTC; see the [Schedules & cron reference](/reference/schedules) for the format and day-of-week convention.
 
 **List schedules:**
 
 ```shell title="See all schedules"
-resonate schedules search "*"
+resonate schedules search --limit 10
 ```
 
 **Delete a schedule:**
@@ -161,16 +164,21 @@ Run `resonate serve --help` for all available flags.
 
 ## Tips and tricks
 
-### Use wildcards for search
+### Filter searches with flags
 
-```shell title="Search for promises by pattern"
-resonate promises search "order-*" --limit 20
+`promises search` filters by `--state` and `--tags` (there is no ID-pattern argument):
+
+```shell title="Search promises by state and tags"
+resonate promises search --state resolved --limit 20
+resonate promises search --tags '{"resonate:target": "poll://any@default"}' --limit 20
 ```
 
-### Format output as JSON
+### Pipe JSON output to jq
+
+Every command already prints JSON to stdout, so scripting is a pipe away:
 
 ```shell title="Get machine-readable output"
-resonate promises get order-123 --output json
+resonate promises get order-123 | jq -r '.promise.state'
 ```
 
 Useful for scripting and automation.

--- a/content/docs/reference/cli.mdx
+++ b/content/docs/reference/cli.mdx
@@ -317,7 +317,7 @@ Subcommands ([`resonate/src/cli.rs:1101-1145`](https://github.com/resonatehq/res
 
 ### `resonate schedules create`
 
-`--cron` accepts a standard 5-field cron expression. `--promise-id` is a **template**; `{{.timestamp}}` is substituted with the firing time so each run gets a unique promise ID.
+`--cron` accepts a 5-, 6-, or 7-field cron expression, evaluated in **UTC only** with Quartz day-of-week numbering (`1` = Sunday — prefer day names like `MON-FRI`); see the [Schedules & cron reference](/reference/schedules) for the full format. `--promise-id` is a **template**; `{{.id}}` is substituted with the schedule's ID and `{{.timestamp}}` with the firing time (epoch ms) so each run gets a unique promise ID.
 
 ```shell
 resonate schedules create nightly-rollup \

--- a/content/docs/reference/index.mdx
+++ b/content/docs/reference/index.mdx
@@ -1,18 +1,20 @@
 ---
 title: Reference
-description: Canonical, source-cited reference for Resonate defaults and the resonate CLI.
+description: Canonical, source-cited reference for Resonate defaults, the resonate CLI, and schedule/cron behavior.
 keywords:
   - reference
   - defaults
   - cli
+  - schedules
+  - cron
 ---
 
 <img src="/images/banner-reference-dark.png" alt="Reference section" className="hidden dark:block" />
 <img src="/images/banner-reference-light.png" alt="Reference section" className="block dark:hidden" />
 
-The reference section is the **single source of truth** for the facts that don't change with the page you're reading — default values across the server and SDKs, and the surface of the `resonate` CLI.
+The reference section is the **single source of truth** for the facts that don't change with the page you're reading — default values across the server and SDKs, the surface of the `resonate` CLI, and how schedules and cron expressions behave.
 
-Both pages cite every value back to a specific file and line in the canonical source repositories. If a default or a flag changes in source, the page is wrong until it is updated.
+Every page cites every value back to a specific file and line in the canonical source repositories. If a default or a flag changes in source, the page is wrong until it is updated.
 
 ## What's here
 
@@ -44,12 +46,26 @@ Every `resonate` subcommand, with scenarios and worked examples:
 
 Use it when you need to know "what command do I run for X?" and want a working example.
 
+### [Schedules & cron reference](/reference/schedules)
+
+How schedules behave on the server, independent of SDK or CLI:
+
+- **Cron expression format** — 5/6/7-field layouts, with examples
+- **Day-of-week convention** — Quartz numbering (`1` = Sunday), why day names like `MON-FRI` are the safe form
+- **Timezone** — expressions evaluate in UTC only; there is no timezone option
+- **The `resonate:target` requirement** — the routing tag every schedule must carry, and the exact error when it's missing
+- **Promise-ID templates** — the two substituted variables (`{{.id}}`, `{{.timestamp}}`) and why templates need `{{.timestamp}}`
+- **Tags on fired promises** — what the server injects at fire time, and how to search fired promises
+
+Use it when a schedule fires at the wrong time, fires and nothing runs, or won't create.
+
 ## How to use the reference pages
 
-The two pages are sister surfaces:
+The pages are sister surfaces:
 
 - **Defaults** answers "*what* is the default for X?" — read it when you need a value.
 - **CLI** answers "*how* do I run X?" — read it when you need a command.
+- **Schedules & cron** answers "*why* did my schedule do that?" — read it when cron behavior surprises you.
 
 If a CLI flag's default surprises you, the CLI page links to the matching row on the defaults page. If a default value's owner isn't obvious, the defaults page links to the command that exposes it.
 

--- a/content/docs/reference/meta.json
+++ b/content/docs/reference/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Reference",
-  "pages": ["defaults", "cli"]
+  "pages": ["defaults", "cli", "schedules"]
 }

--- a/content/docs/reference/schedules.mdx
+++ b/content/docs/reference/schedules.mdx
@@ -1,0 +1,115 @@
+---
+title: Schedules & cron reference
+description: Canonical reference for Resonate schedules — cron expression format, day-of-week convention, UTC timezone, the resonate:target requirement, promise-ID templates, and the tags the server injects at fire time.
+keywords:
+  - reference
+  - schedules
+  - cron
+  - cron expression
+  - day of week
+  - timezone
+  - UTC
+  - resonate:target
+  - promise-id template
+---
+
+This page is the **single source of truth** for how Resonate schedules behave, independent of which SDK (or the CLI) you create them with. Every fact below is sourced from a specific file and line in [`resonatehq/resonate`](https://github.com/resonatehq/resonate); if the server changes, this page is wrong until it is updated.
+
+For the CLI commands that operate on schedules, see [CLI reference › `resonate schedules`](/reference/cli#resonate-schedules).
+
+## What a schedule is
+
+A schedule is a server-side cron rule that creates a new durable promise on every tick. The schedule stores a **promise-ID template**, a **promise timeout**, an optional **promise param** (the payload workers decode to know what to run), and **promise tags** (copied onto every fired promise). Workers never poll the schedule itself — they receive the fired promises, routed by the `resonate:target` tag.
+
+## Cron expression format
+
+The server parses cron expressions with the [`cron` crate](https://docs.rs/cron) ([`resonate/Cargo.toml:34`](https://github.com/resonatehq/resonate/blob/main/Cargo.toml#L34)), which accepts 5, 6, or 7 fields:
+
+| Fields | Layout | Example | Meaning |
+|---|---|---|---|
+| 5 | `min hour dom month dow` | `0 2 * * *` | Daily at 02:00 |
+| 6 | `sec min hour dom month dow` | `*/30 * * * * *` | Every 30 seconds |
+| 7 | `sec min hour dom month dow year` | `0 0 9 * * MON-FRI 2027` | Weekday mornings in 2027 only |
+
+### Day-of-week: use names, not numbers
+
+The day-of-week field follows the **Quartz convention**: `1` = Sunday through `7` = Saturday. This silently differs from POSIX cron (`0`–`6` = Sunday–Saturday), so numeric day-of-week expressions copied from a crontab do not mean what they meant there:
+
+- `1-5` means **Sunday through Thursday**, not Monday through Friday
+- `0` is not a valid day — the create fails with `Invalid cron expression`
+
+Day **names** are unambiguous and always mean the same thing. Prefer them:
+
+```text
+0 9 * * MON-FRI    # 09:00 on weekdays — says what it means
+0 9 * * 2-6        # the same thing in Quartz numbering — avoid
+```
+
+### Timezone: UTC only
+
+Cron expressions are evaluated in **UTC**. There is no per-schedule or per-server timezone option — no config field exists for it. `0 9 * * MON-FRI` fires at 09:00 UTC, which is 02:00 in Los Angeles (PDT) and 10:00 in Berlin (CEST). Convert your local time to UTC when writing the expression, and remember the UTC offset of a civil time changes across daylight-saving transitions.
+
+## The `resonate:target` requirement
+
+Every fired promise needs a routing target, or no worker group will ever receive it. The server therefore **rejects** `schedule.create` when `promiseTags` lacks a `resonate:target` tag ([`resonate/src/types.rs:641-643`](https://github.com/resonatehq/resonate/blob/main/src/types.rs#L641-L643)):
+
+```text
+400 promiseTags must include a resonate:target tag
+```
+
+The value is an address like `poll://any@default` — the same convention as `resonate invoke --target` and the SDKs' `target` option. The high-level `schedule()` APIs that inject this tag for you take the target from the same option surface as `run`/`rpc`; the low-level schedule sub-clients and the CLI require you to pass it explicitly:
+
+```shell
+resonate schedules create nightly-rollup \
+  --cron "0 2 * * *" \
+  --promise-id "nightly-{{.timestamp}}" \
+  --promise-timeout 1h \
+  --promise-tags '{"resonate:target": "poll://any@default"}'
+```
+
+## Promise-ID templates
+
+The schedule's `promiseId` is a template. The server substitutes **exactly two** variables at fire time ([`resonate/src/oracle.rs:1875-1877`](https://github.com/resonatehq/resonate/blob/main/src/oracle.rs#L1875-L1877)):
+
+| Variable | Substituted with |
+|---|---|
+| `{{.id}}` | The schedule's ID |
+| `{{.timestamp}}` | The tick's fire time, as a Unix epoch timestamp in **milliseconds** |
+
+Anything else in the template is literal text. A template of `report.{{.id}}.{{.timestamp}}` on a schedule named `nightly` produces promise IDs like `report.nightly.1783978446000`.
+
+Include `{{.timestamp}}` in every template: promise creation is idempotent by ID, so a template without it produces the **same** promise ID on every tick — the first tick creates the promise and every later tick is a no-op against it.
+
+## Tags on fired promises
+
+Each fired promise carries the schedule's `promiseTags` (including your `resonate:target`) plus five tags the server injects at fire time ([`resonate/src/oracle.rs:1874-1881`](https://github.com/resonatehq/resonate/blob/main/src/oracle.rs#L1874-L1881)):
+
+| Tag | Value |
+|---|---|
+| `resonate:schedule` | The schedule's ID |
+| `resonate:origin` | The fired promise's own ID |
+| `resonate:branch` | The fired promise's own ID |
+| `resonate:parent` | The fired promise's own ID |
+| `resonate:prefix` | The fired promise's own ID |
+
+Each fired promise is the **root** of its own call graph — origin, branch, parent, and prefix all point at itself, exactly like a top-level `run`/`rpc` promise. Two useful consequences:
+
+- `resonate tree <fired-promise-id>` shows the full call graph of that one tick
+- `resonate promises search --tags '{"resonate:schedule": "<schedule-id>"}'` lists every promise a schedule has ever fired
+
+## Delete and search
+
+Deleting a schedule stops future ticks; promises already fired are unaffected and settle (or time out) on their own:
+
+```shell
+resonate schedules delete nightly-rollup
+```
+
+Schedules are searchable with cursor pagination. The `--tags` filter matches against each schedule's **promise tags** ([`resonate/src/oracle.rs:1581-1587`](https://github.com/resonatehq/resonate/blob/main/src/oracle.rs#L1581-L1587)) — a schedule has no separate tag set of its own:
+
+```shell
+resonate schedules search --limit 100
+resonate schedules search --tags '{"resonate:target": "poll://any@default"}' --limit 100
+```
+
+The equivalent operations exist on every SDK's `schedules` sub-client.


### PR DESCRIPTION
Part of #241 (cron reference items + the CLI-guide scope extension in the issue comments).

## New page: [Schedules & cron reference](/reference/schedules)

One cross-SDK page for server-side schedule behavior, every fact cited file:line to `resonatehq/resonate`:

- Cron expression format (5/6/7-field), with examples
- Quartz day-of-week convention (`1` = Sunday, `0` = parse error) with day names (`MON-FRI`) as the recommended form
- UTC-only evaluation — no timezone option exists
- The `resonate:target` requirement and the exact 400 error text
- Promise-ID template variables: `{{.id}}` (schedule ID) and `{{.timestamp}}` (fire time, epoch **ms**) — the only two the server substitutes
- The five tags the server injects on fired promises (`resonate:schedule/origin/branch/parent/prefix`)
- Delete/search semantics (search `--tags` matches the schedule's promise tags)

Nav wired: `reference/meta.json` pages array + a "What's here" entry and refreshed frontmatter on `reference/index.mdx`.

## Fixes

- **get-started/cli-guide.mdx** — the schedule/search examples did not run: `schedules create` omitted the required `--promise-timeout`, used a nonexistent `--description` flag, and lacked the required `resonate:target` promise tag; three search examples passed a positional pattern the CLI rejects (clap error); one tip used a nonexistent `--output` flag (same class, found while verifying the page). All replaced with commands that run.
- **reference/cli.mdx** — cron caveat at `--cron` (UTC-only, Quartz DOW) linking to the new page; `{{.id}}` documented alongside `{{.timestamp}}`.
- **develop/typescript.mdx** — `.schedule()` section now covers target routing (the injected `resonate:target`), delete/inspect via the `schedules` sub-client, and links the cron caveats.
- **develop/go.mdx** — removed the stale callout claiming no promises/schedules sub-clients exist; both are documented, including that the low-level schedule API requires the caller to set `resonate:target` until a high-level API lands.

## Verification

- Every shell command on the touched pages was run verbatim against the live CLI (`resonate` 0.9.8) and a dev server, including the tag-validation boundary (create without `resonate:target` → `400 promiseTags must include a resonate:target tag`, with it → 200).
- Quartz DOW checked empirically: `--cron "0 9 * * 6"` → next run Friday; `0` in DOW → "Invalid cron expression"; `MON-FRI` and 6/7-field forms accepted; `{{.id}}` substitution observed.
- The Go snippet compile-checked against the SDK at main; TS claims checked against `resonate-sdk-ts` source.
- `npm run build` green; `check-links`: 454 links, 0 internal broken.