### PR TITLE
fix(deploy): correct stale compose examples — Postgres env vars and image name

### DIFF
--- a/content/docs/deploy/index.mdx
+++ b/content/docs/deploy/index.mdx
@@ -176,9 +176,10 @@ Do you have variable/unpredictable load?
 ```yaml
 services:
   resonate-server:
-    image: resonatehq/resonate:latest
+    image: resonatehqio/resonate:v0.9.8
     environment:
-      RESONATE_STORE_POSTGRES_HOST: your-postgres.rds.amazonaws.com
+      RESONATE_STORAGE__TYPE: postgres
+      RESONATE_STORAGE__POSTGRES__URL: postgres://<USER>:<PASSWORD>@your-postgres.rds.amazonaws.com:5432/resonate
 
   worker:
     image: your-app:latest

--- a/content/docs/deploy/scaling.mdx
+++ b/content/docs/deploy/scaling.mdx
@@ -189,14 +189,12 @@ Scale workers using container orchestration:
 version: '3.8'
 services:
   resonate-server:
-    image: resonatehq/resonate:latest
+    image: resonatehqio/resonate:v0.9.8
     ports:
       - "8001:8001"
     environment:
-      RESONATE_STORE_POSTGRES_HOST: postgres
-      RESONATE_STORE_POSTGRES_DATABASE: resonate
-      RESONATE_STORE_POSTGRES_USERNAME: resonate
-      RESONATE_STORE_POSTGRES_PASSWORD: secret
+      RESONATE_STORAGE__TYPE: postgres
+      RESONATE_STORAGE__POSTGRES__URL: postgres://<USER>:<PASSWORD>@postgres:5432/resonate
     depends_on:
       - postgres
 


### PR DESCRIPTION
## What
Two Docker Compose examples (deploy overview, scaling) still configured Postgres through `RESONATE_STORE_POSTGRES_{HOST,DATABASE,USERNAME,PASSWORD}` and pulled `resonatehq/resonate:latest`.

## Why
The server reads storage configuration from `RESONATE_STORAGE__TYPE` and `RESONATE_STORAGE__POSTGRES__URL` — `RESONATE_` prefix, double-underscore nesting, URL-form connection string. The `PostgresConfig` struct has only `url` and `pool_size` fields, so the old `HOST/DATABASE/USERNAME/PASSWORD` variables are silently ignored and the example server would start on SQLite. The Docker Hub image is `resonatehqio/resonate`; pinned to `v0.9.8` to match the run-server and deployment-patterns pages.

## Verification
- Env var convention and `PostgresConfig` fields verified against the server's `src/config.rs` on current main.
- Image name and tags verified on Docker Hub and against `deploy/run-server`.
- `npm run build` green, `check-links` 0 internal broken.
