### PR TITLE
docs(evaluate): add How Resonate is tested

### DIFF
--- a/content/docs/evaluate/how-resonate-is-tested.mdx
+++ b/content/docs/evaluate/how-resonate-is-tested.mdx
@@ -1,0 +1,97 @@
+---
+title: How Resonate is tested
+description: Testing approach across the Resonate server, each SDK, and the Lean 4 executable specification.
+keywords:
+  - evaluate
+  - testing
+  - correctness
+  - dst
+  - deterministic simulation
+  - specification
+---
+
+<Callout type="info" title="Versions">
+This page reflects Resonate Server v0.9.8, `@resonatehq/sdk` v0.11.2 (TypeScript), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.5.0 (Rust), `resonate-sdk` v0.1.1 (Java), and the Resonate Go SDK 0.1.0.
+</Callout>
+
+Resonate's correctness story rests on three foundations that reinforce each other: a machine-checkable formal companion to the protocol specification, differential random testing of the server implementation against a pure in-memory reference model, and deterministic simulation testing of the TypeScript SDK. Unit, integration, and end-to-end test suites across all five SDKs sit alongside these.
+
+## Lean 4 executable companion
+
+The [Distributed Async Await specification](https://distributed-async-await.io/spec) is the authoritative prose description of Resonate's protocol — the state machine governing promises, tasks, and schedules. Alongside it sits a Lean 4 executable, machine-checkable companion: [`resonatehq/resonate-specification`](https://github.com/resonatehq/resonate-specification).
+
+The companion encodes each protocol handler as a pure, deterministic, total function:
+
+```lean
+-- every handler has this shape:
+-- M = StateM ServerState, so "now" is the only input that carries time
+def promiseCreate (req : PromiseCreateReq) (now : Nat) : M PromiseCreateRes
+```
+
+State is touched only through named atomic effects — `getPromise` / `setPromise`, `getTask` / `setTask`, `getSchedule` / `setSchedule` / `delSchedule`, timeout management, and outbox writes. Handlers compose these effects and nothing else, which makes the model directly auditable and buildable with a single command:
+
+```shell title="Build the Lean companion"
+cd spec && lake build
+```
+
+The companion currently covers twenty handlers in full: five promise handlers (create, get, settle, register\_callback, register\_listener), ten task handlers (get, create, acquire, fence, heartbeat, suspend, fulfill, release, halt, continue), three schedule handlers (get, create, delete), and the two internal transitions (resume, timeouts). The three search handlers return a placeholder `501` response while their specs are being written.
+
+This is a companion to the prose specification, not a replacement for it. Its purpose is to make the protocol contract machine-verifiable — a second, checkable representation of the same rules that a prose reader can audit independently.
+
+## Resonate Server
+
+The Resonate Server ([`resonatehq/resonate`](https://github.com/resonatehq/resonate), written in Rust) uses two test strategies on every pull request.
+
+### Differential random testing
+
+[`diff/differential.rs`](https://github.com/resonatehq/resonate/blob/main/diff/differential.rs) defines a test named `differential_random`. It drives the same randomly-generated sequence of API operations through multiple backends at once — always an in-memory SQLite instance and an in-memory Oracle reference model; optionally Postgres and MySQL when environment variables supply connection URLs. After every operation the test asserts two things: that every backend returned the same HTTP status and response body, and that the complete server state (promises, tasks, messages, timeouts) matches across all backends.
+
+The Oracle is a pure Rust in-memory implementation of the protocol state machine, derived from the same handler rules encoded in the Lean 4 companion. A disagreement between the Oracle and any concrete storage backend is an immediate test failure, with a precise field-level diff showing the divergence.
+
+Coverage is enforced: the test runs until all twenty-two operation kinds in the API have each produced at least one 2xx response, then continues until no new operation signatures appear for twenty consecutive batches of two hundred steps. CI runs this against all three storage backends — SQLite, Postgres, and MySQL — as a matrix on every pull request.
+
+### Unit tests
+
+The server's unit tests run with `cargo test --all-features` and cover configuration parsing, transport message handling, and individual processing modules. CI gates every pull request on format (`cargo fmt`), compilation (`cargo check`), and linting (`cargo clippy --all-features -- -D warnings`) before tests run.
+
+## TypeScript SDK
+
+The TypeScript SDK ([`resonatehq/resonate-sdk-ts`](https://github.com/resonatehq/resonate-sdk-ts)) carries a conventional Jest test suite and a dedicated deterministic simulation test.
+
+### Deterministic simulation testing
+
+The DST harness lives in [`sim/`](https://github.com/resonatehq/resonate-sdk-ts/tree/main/sim) and runs on a schedule via [`.github/workflows/dst.yml`](https://github.com/resonatehq/resonate-sdk-ts/blob/main/.github/workflows/dst.yml) — every twenty minutes, across Ubuntu, Windows, and macOS, against Node 18, 20, and 22.
+
+The harness uses a seeded linear-congruential PRNG. From a single integer seed, it derives the full behavior of the run: which function to invoke at each step, whether a message is dropped, duplicated, or delayed, and whether a worker process goes inactive. Configurable probabilities — `dropProb`, `duplProb`, `randomDelay`, `deactivateProb`, `activateProb` — default to values drawn from the same PRNG so the entire run is reproducible from the seed alone.
+
+A default run executes 10,000 steps. Three simulated worker processes and one simulated server process receive and process messages inside the harness, exercising recursive fan-out patterns (Fibonacci with local and remote calls) and multi-step chained functions.
+
+Determinism is verified explicitly: CI runs each seed twice and diffs the two log files. Different output from the same seed is a failing run. When a run fails, a GitHub issue is filed automatically with the seed, the commit SHA, and the exact command to reproduce it:
+
+```shell title="Reproduce a DST failure"
+npm run dst -- --seed <seed> --steps 10000
+```
+
+### Jest unit and integration suite
+
+The Jest suite covers the core execution engine, coroutine scheduling, retry policies, network transport, codec, encryption, and function registry. It runs via `npm test` in CI alongside linting and type checks.
+
+## Python SDK
+
+The Python SDK ([`resonatehq/resonate-sdk-py`](https://github.com/resonatehq/resonate-sdk-py)) runs `pytest` with branch coverage on Python 3.12, 3.13, and 3.14 across Ubuntu, macOS, and Windows.
+
+The suite includes [`tests/test_invariants.py`](https://github.com/resonatehq/resonate-sdk-py/blob/main/tests/test_invariants.py), which formalizes the structural replay contract of the SDK's execution tree model. The invariants capture properties from the internal `tree.md` specification — among them that a node's settler type is fixed across replays (R1), that settled promise records never retreat to pending (R2), that the execution tree reaches a fixed point after the first replay under an unchanged cache, and that the frontier shrinks monotonically as steps settle. Each invariant is driven across a battery of workflow shapes, and the test asserts the property at every step of the settle-to-done trajectory rather than only at the final state.
+
+CI also runs the Python SDK's examples end-to-end against a live Resonate server binary, downloaded from the public release page.
+
+## Rust SDK
+
+The Rust SDK ([`resonatehq/resonate-sdk-rs`](https://github.com/resonatehq/resonate-sdk-rs)) runs `cargo test --workspace` for its unit suite and `cargo test -p resonate-sdk --test e2e` for end-to-end tests against a live server. The e2e suite runs in CI against a server container on every pull request and covers durable function execution, fan-out/fan-in, promise resolution, retry behavior, and heartbeating.
+
+## Go SDK
+
+The Go SDK ([`resonatehq/resonate-sdk-go`](https://github.com/resonatehq/resonate-sdk-go)) runs `go test -race -timeout 5m ./...` — the Go race detector is enabled on every test run. End-to-end tests in [`e2e_test.go`](https://github.com/resonatehq/resonate-sdk-go/blob/main/e2e_test.go) target a live Resonate server and cover the full execution lifecycle: durable sleep, fan-out, promise resolution, and load balancing across worker groups. Without `RESONATE_URL` set, the e2e tests skip cleanly so `go test ./...` works without a server.
+
+## Java SDK
+
+The Java SDK ([`resonatehq/resonate-sdk-java`](https://github.com/resonatehq/resonate-sdk-java)) compiles against Java 21 and runs its test suite against Java 21, 24, and 25 via `./gradlew test`. CI also runs the SDK's examples end-to-end against a live server.

--- a/content/docs/evaluate/index.mdx
+++ b/content/docs/evaluate/index.mdx
@@ -16,5 +16,6 @@ Evaluate Resonate to understand its capabilities and how it works.
   <Card title="Why Resonate" description="Understand Resonate's capabilities and how you can benefit." href="/evaluate/why-resonate" />
   <Card title="How Resonate works" description="Architecture overview of checkpoints, replay, and message flow." href="/evaluate/how-it-works" />
   <Card title="Coming from other systems" description="Compare Resonate with Temporal, Restate, DBOS, and more." href="/evaluate/coming-from" />
+  <Card title="How Resonate is tested" description="The specification, differential testing, and simulation behind the correctness story." href="/evaluate/how-resonate-is-tested" />
 </CardGrid>
 


### PR DESCRIPTION
## What
New evaluate-section page describing how correctness is checked across the project: the Lean 4 executable, machine-checkable companion to the distributed-async-await.io prose specification; the server's differential random testing against a pure in-memory Oracle across SQLite/Postgres/MySQL; the TypeScript SDK's scheduled deterministic simulation testing; and the unit/integration/e2e suites in each of the five SDK repos. Registers a card on the evaluate index.

## Why
"How is this tested?" is a recurring evaluation question with no page to point at. Everything on the page traces to a public repo, workflow file, or source file, linked inline.

## Verification
- Every claim was checked against the public repos before writing: handler coverage counts and `lake build` in resonate-specification; `diff/differential.rs` (test name, Oracle, coverage/exit rules, CI matrix); `sim/` + `dst.yml` cadence and matrix in resonate-sdk-ts; `tests/test_invariants.py` and CI matrices in resonate-sdk-py; e2e suites in the Rust/Go/Java SDKs.
- Deliberately omitted: any claim of SDK-wide DST (only the TypeScript SDK has a public DST workflow) and any formal linearizability-proof claim (no public checker exists).
- `npm run build` green, `check-links` 0 internal broken.
