### PR TITLE
docs: deploy/evaluate fixes + three new pages

### DIFF
--- a/content/docs/deploy/index.mdx
+++ b/content/docs/deploy/index.mdx
@@ -176,9 +176,10 @@ Do you have variable/unpredictable load?
 ```yaml
 services:
   resonate-server:
-    image: resonatehq/resonate:latest
+    image: resonatehqio/resonate:v0.9.8
     environment:
-      RESONATE_STORE_POSTGRES_HOST: your-postgres.rds.amazonaws.com
+      RESONATE_STORAGE__TYPE: postgres
+      RESONATE_STORAGE__POSTGRES__URL: postgres://<USER>:<PASSWORD>@your-postgres.rds.amazonaws.com:5432/resonate
 
   worker:
     image: your-app:latest

--- a/content/docs/deploy/index.mdx
+++ b/content/docs/deploy/index.mdx
@@ -188,7 +188,7 @@ services:
       replicas: 5
 ```
 
-**Why:** Simple, low-cost, easy to manage. Perfect for small teams.
+**Why:** Simple, low-cost, easy to manage. Perfect for small teams. See [Deploy to Railway](/deploy/railway) for a step-by-step walkthrough of the same pattern on a PaaS.
 
 ### Medium production (10-100 workers)
 

--- a/content/docs/deploy/index.mdx
+++ b/content/docs/deploy/index.mdx
@@ -130,10 +130,11 @@ See [Availability](/deploy/availability) for HA patterns.
 **If you're going to production:**
 
 1. [Deployment patterns](/deploy/deployment-patterns) - Choose your infrastructure
-2. [Availability](/deploy/availability) - Set up PostgreSQL HA
-3. [Security](/deploy/security) - Enable authentication
-4. [Scaling](/deploy/scaling) - Plan for load
-5. [Logging](/deploy/logging), [Metrics](/deploy/metrics), [Tracing](/deploy/tracing) - Observe everything
+2. [Production readiness](/deploy/production-readiness) - Configuration checklist before sending real traffic
+3. [Availability](/deploy/availability) - Set up PostgreSQL HA
+4. [Security](/deploy/security) - Enable authentication
+5. [Scaling](/deploy/scaling) - Plan for load
+6. [Logging](/deploy/logging), [Metrics](/deploy/metrics), [Tracing](/deploy/tracing) - Observe everything
 
 **If you're debugging issues:**
 Go to [Debug](/debug) - that section is for troubleshooting.

--- a/content/docs/deploy/production-readiness.mdx
+++ b/content/docs/deploy/production-readiness.mdx
@@ -1,0 +1,153 @@
+---
+title: Production readiness
+description: Recommended deployment shape, server constraints, and operational checklist for running the Resonate server in production.
+keywords:
+  - deploy
+  - production
+  - operations
+  - checklist
+  - health
+  - metrics
+---
+
+This page describes the recommended production configuration for the Resonate server, what operational surface the server exposes, and what to verify before you send real traffic.
+
+## Recommended deployment shape
+
+The standard production deployment has three layers:
+
+1. **One Resonate server** — coordinates promises, schedules tasks, routes work to workers. Runs as a single process backed by persistent storage.
+2. **A managed PostgreSQL database with HA** — stores all execution state. The server's durability guarantee is only as strong as the database's.
+3. **Horizontally scaled workers** — execute your application code. Add as many as the workload requires; there is no fixed limit.
+
+Workers scale horizontally without any server-side coordination because they pull work from the server rather than requiring the server to know about them statically. The server does not execute your functions, so worker pod restarts or crashes do not lose in-flight execution state — state is always in the database.
+
+For the Kubernetes manifest that wires this together, see [Run server](/deploy/run-server#run-on-kubernetes). For the full set of infrastructure patterns (Cloud Run, Fargate, bare-metal systemd), see [Deployment patterns](/deploy/deployment-patterns).
+
+## Server constraints
+
+### No horizontal server scaling
+
+The server runs as a single instance — multi-server coordination is not yet implemented (true of the current released version, v0.9.8, and of `main`). In practice this is rarely a capacity limit: the server coordinates work but never executes your functions, so a single instance comfortably handles thousands of task dispatches per second. Scale vertically if you observe the server as a bottleneck, and keep scaling workers horizontally; see [Scaling](/deploy/scaling). Two independent servers sharing one database race to process the same timeouts and task queues, so keep `replicas: 1` (or `--max-instances=1` on Cloud Run) — the checklist below carries this as its first server item.
+
+### State in the database
+
+All durable promise state lives in PostgreSQL (or MySQL). A server restart is safe — workers detect the disconnect, reconnect automatically, and resume from their last checkpoint. This also means database availability is the primary availability concern. See [Availability](/deploy/availability) for PostgreSQL HA options.
+
+## Health and readiness endpoints
+
+The server exposes `GET /health` (liveness — always `200` while the process is up) and `GET /ready` (readiness — `503` when storage is unreachable, logged as `Readiness check failed: storage database unavailable`) on the API port (`:8001` by default). A liveness probe on `/health` and a readiness probe on `/ready` is the recommended Kubernetes configuration. See [Run server > Health and readiness](/deploy/run-server#health-and-readiness) for the endpoint reference, probe configuration, and examples; the checklist below captures what to configure in your orchestrator.
+
+## Prometheus metrics
+
+The server runs a separate HTTP listener that exposes Prometheus metrics. The default port is `9090`; the endpoint is `GET /metrics`.
+
+```shell title="Scrape metrics"
+curl http://localhost:9090/metrics
+```
+
+The metrics port is controlled by `RESONATE_OBSERVABILITY__METRICS_PORT`. Set it to `0` to disable the endpoint entirely — for example, when your platform routes all external traffic through port `8001` and you want to block metrics from being publicly reachable:
+
+```toml title="resonate.toml — disable metrics"
+[observability]
+metrics_port = 0
+```
+
+Or via environment variable:
+
+```shell
+RESONATE_OBSERVABILITY__METRICS_PORT=0
+```
+
+See [Metrics](/deploy/metrics) for the full metrics catalog, Prometheus scrape configuration, and Grafana dashboard examples.
+
+<Callout type="caution" title="PaaS port routing">
+Platforms that auto-detect a single primary port (Railway, Render, Fly.io) may route traffic to `:9090` instead of `:8001`. Explicitly route your platform to port `8001`. Consider disabling the metrics port or binding it to a private network interface if the platform exposes both ports publicly.
+</Callout>
+
+## Logs
+
+The server writes structured key-value logs to stdout via the Rust `tracing` ecosystem. The default log level is `info`. Set `RESONATE_LEVEL=debug` for verbose request-level diagnostics; revert to `info` in production once the issue is resolved, since debug output is significantly higher volume.
+
+For log aggregation, alerting on critical error patterns, and correlation with metrics, see [Logging](/deploy/logging).
+
+## Graceful shutdown
+
+The server handles `SIGTERM` and `SIGINT` for graceful shutdown. When a signal is received, the server:
+
+1. Stops accepting new connections on the API port.
+2. Signals background processing loops (timeout scanner, message dispatcher) to stop.
+3. Waits up to the configured `shutdown_timeout` for background tasks to finish, then exits.
+
+The default `shutdown_timeout` is `10000` milliseconds (10 seconds). Raise it if background loops are consistently interrupted before completing:
+
+```toml title="resonate.toml"
+[server]
+shutdown_timeout = 30000  # milliseconds
+```
+
+Or via environment variable:
+
+```shell
+RESONATE_SERVER__SHUTDOWN_TIMEOUT=30000
+```
+
+Because all execution state is persisted in the database, a forceful exit during the shutdown window does not lose work — workers reconnect and tasks are reassigned after the server comes back up.
+
+## Configuration for production
+
+Configuration fields are reachable as environment variables (`RESONATE_` prefix, double-underscore nesting) or via `resonate.toml`; the full surface, defaults, and layering order are in [Run a server > Configuration](/deploy/run-server#configuration). The settings below are the ones with production-specific consequences:
+
+| Setting | Default | Production guidance |
+|---|---|---|
+| `RESONATE_STORAGE__TYPE` | `sqlite` | Set to `postgres` — SQLite is not recommended for shared production workloads |
+| `RESONATE_SERVER__URL` | — | No runtime default; set to the externally-reachable URL so workers can call back. Required on Cloud Run and similar |
+| `RESONATE_TASKS__RETRY_TIMEOUT` | `30000` (ms) | Set to `500` for chained or recursive workflows; the default adds significant latency per suspend/wake cycle |
+| `RESONATE_AUTH__PUBLICKEY` | — | Strongly recommended; without it the server logs `Auth disabled — all requests accepted`. See [Security](/deploy/security) |
+
+Inject secrets (`RESONATE_STORAGE__POSTGRES__URL`, key paths, push-auth tokens) via environment variables or a secret manager — never commit them.
+
+## Pre-launch checklist
+
+Use this list before sending production traffic to a new deployment.
+
+**Storage**
+- [ ] `RESONATE_STORAGE__TYPE=postgres` — SQLite is not recommended for shared or multi-user production workloads
+- [ ] PostgreSQL is a managed HA instance (Multi-AZ, Cloud SQL HA, Supabase, or equivalent)
+- [ ] Connection string uses a dedicated database user with the minimum required permissions
+- [ ] Backup and point-in-time recovery are confirmed and tested
+
+**Server**
+- [ ] `replicas: 1` (or equivalent) — multi-server is not supported; verify the container scheduler will not auto-scale the server
+- [ ] `RESONATE_SERVER__BIND=0.0.0.0` so the API port is reachable from workers and the orchestrator
+- [ ] `RESONATE_SERVER__URL` is set to the externally-reachable URL when workers call back from outside the server's local network
+- [ ] `RESONATE_TASKS__RETRY_TIMEOUT` is tuned — `500` for chained workflows, `30000` only if low latency is not required
+
+**Authentication**
+- [ ] `RESONATE_AUTH__PUBLICKEY` is configured — the server logs `Auth disabled — all requests accepted` at startup when auth is off
+- [ ] JWT keys are generated with `openssl genpkey -algorithm Ed25519`; private key is in a secret manager, not on disk or in a repo
+- [ ] See [Security](/deploy/security) for the full auth configuration guide
+
+**Observability**
+- [ ] Liveness probe on `GET /health` (port `8001`)
+- [ ] Readiness probe on `GET /ready` (port `8001`)
+- [ ] Prometheus scraper pointed at port `9090` (or the configured `RESONATE_OBSERVABILITY__METRICS_PORT`)
+- [ ] Log aggregation ingesting stdout from the server container
+- [ ] Alert on `Readiness check failed: storage database unavailable` in server logs
+- [ ] Alert on `Background tasks did not finish within shutdown timeout, forcing exit` in server logs
+
+**Workers**
+- [ ] Workers connect to the server via the `RESONATE_URL` environment variable (or equivalent SDK config)
+- [ ] Worker Deployment has at least 2 replicas so worker restarts do not stall in-flight promises
+- [ ] `RESONATE_TASKS__LEASE_TIMEOUT` on the server is larger than the maximum expected task execution time; otherwise tasks will be re-queued while still in progress
+
+{/* Maintainers: if you have public-facing production users who have consented to being named, add a brief "Used by" or "Case studies" section here. Do not add users without explicit consent. */}
+
+## Related pages
+
+- [Run server](/deploy/run-server) — full configuration reference, CLI flags, and platform-specific manifests
+- [Availability](/deploy/availability) — PostgreSQL HA setup, server restart procedures, and rolling update process
+- [Security](/deploy/security) — JWT authentication, CORS, and outbound push auth
+- [Scaling](/deploy/scaling) — worker scaling patterns and when to scale
+- [Metrics](/deploy/metrics) — full Prometheus metrics catalog, Grafana setup, and alerting rules
+- [Logging](/deploy/logging) — log levels, aggregation patterns, and critical error reference

--- a/content/docs/deploy/railway.mdx
+++ b/content/docs/deploy/railway.mdx
@@ -1,0 +1,126 @@
+---
+title: Deploy to Railway
+description: Run the Resonate server on Railway with a managed Postgres database.
+keywords:
+  - deploy
+  - railway
+  - server
+  - configuration
+  - postgres
+---
+
+This page walks through deploying the Resonate server to [Railway](https://railway.com) using the official Docker image and Railway's managed Postgres database.
+
+## Prerequisites
+
+- A Railway account with a project created
+- The Resonate server Docker image: [`resonatehqio/resonate`](https://hub.docker.com/r/resonatehqio/resonate)
+
+## Overview
+
+You will create two services in one Railway environment:
+
+1. **Postgres** — Railway's managed Postgres database, provisioned directly from the project canvas
+2. **resonate-server** — the Resonate server, deployed from the official Docker Hub image
+
+Workers run separately (in your own services or elsewhere) and connect to the Resonate server over Railway's private network or via its public URL.
+
+## Step 1 — Add a Postgres database
+
+From your Railway project canvas, click **+ New** and choose **Database > Postgres**. Railway provisions the database and immediately exposes connection variables, including `DATABASE_URL`, on the Postgres service.
+
+No additional configuration is required. The database is ready to accept connections once the provisioning step completes.
+
+## Step 2 — Add the Resonate server service
+
+From the project canvas, click **+ New** and choose **Docker Image**. Enter the image path:
+
+```
+resonatehqio/resonate:v0.9.8
+```
+
+Railway pulls the image from Docker Hub. The service is created in a stopped state — you configure environment variables before the first deploy in the next step.
+
+<Callout type="tip" title="Image tags">
+Tags track server release versions (e.g. `v0.9.8`) plus a rolling `latest`. Pin to a version tag in production so redeployments are predictable.
+</Callout>
+
+## Step 3 — Configure environment variables
+
+Open the Resonate server service, go to **Variables**, and add the following:
+
+```shell title="Environment variables"
+# Tell Railway which port to route external traffic to.
+# Without this, Railway may pick the metrics port (9090) and return 502 errors.
+PORT=8001
+
+# Use Railway's managed Postgres as the storage backend.
+RESONATE_STORAGE__TYPE=postgres
+RESONATE_STORAGE__POSTGRES__URL=${{Postgres.DATABASE_URL}}
+
+# Set the externally-reachable URL so task dispatch headers are correct.
+# Fill this in after generating a public domain in Step 4.
+RESONATE_SERVER__URL=https://<your-railway-domain>
+
+# Lower the task retry interval for chained workflows.
+# The 30-second default adds significant latency to multi-step executions.
+RESONATE_TASKS__RETRY_TIMEOUT=500
+```
+
+The `${{Postgres.DATABASE_URL}}` syntax is Railway's [service variable reference](https://docs.railway.com/guides/variables). Replace `Postgres` with the exact name of your Postgres service if you renamed it.
+
+<Callout type="caution" title="PORT and the metrics port">
+The Resonate server listens on two ports: `8001` (HTTP API) and `9090` (Prometheus metrics).
+Railway's port detection picks one port to route public traffic to. Setting `PORT=8001` tells Railway to route to the API port.
+Without this, Railway may route to `9090` and all API requests will receive unexpected responses.
+</Callout>
+
+## Step 4 — Generate a public domain and configure health checks
+
+In the Resonate server service settings:
+
+1. Under **Networking > Public Networking**, click **Generate Domain**. Copy the generated URL.
+2. Go back to **Variables** and set `RESONATE_SERVER__URL` to the generated URL (e.g. `https://resonate-server-production.up.railway.app`).
+3. Under **Health Checks**, set the **Path** to `/health`. The server also exposes `/ready`, which returns `503` when Postgres is not reachable — useful for readiness gating, though Railway's health check mechanism uses a single path. See [Run server > Health and readiness](/deploy/run-server#health-and-readiness) for the full endpoint spec.
+
+## Step 5 — Deploy
+
+Trigger a deploy. Railway pulls `resonatehqio/resonate:v0.9.8`, starts the container, and runs the health check against `/health` on port `8001`. Postgres migrations are applied automatically on first startup — no manual migration step is required.
+
+Once the deploy reports healthy, confirm the server is up:
+
+```shell title="Verify the deployment"
+curl -s -o /dev/null -w "%{http_code}\n" https://<your-railway-domain>/health
+# 200
+```
+
+## Connecting workers
+
+Workers running inside the same Railway environment can reach the Resonate server over Railway's private network using the internal DNS hostname:
+
+```
+http://resonate-server.railway.internal:8001
+```
+
+Replace `resonate-server` with the exact name of your Railway service if you renamed it. Private networking is zero-configuration — no additional setup is needed for services in the same project environment.
+
+Workers running outside Railway (or in a different Railway environment) use the public domain generated in Step 4.
+
+Configure your worker SDK to point at the server URL. Example for TypeScript:
+
+```typescript
+import { Resonate } from "@resonatehq/sdk";
+
+const resonate = new Resonate({
+  url: process.env.RESONATE_URL, // set to the internal or public server URL
+  group: "workers",
+});
+```
+
+Set the `RESONATE_URL` environment variable on your worker service to:
+- `http://resonate-server.railway.internal:8001` — for workers in the same Railway environment
+- `https://<your-railway-domain>` — for workers outside Railway
+
+## Environment variable reference
+
+Full variable reference: [Run a server > Environment variables](/deploy/run-server#environment-variables). The two Railway-specific pieces — `PORT` (tells Railway which port to route external traffic to; not a Resonate variable) and the `${{Postgres.DATABASE_URL}}` service variable reference — are shown in Step 3 above.

--- a/content/docs/deploy/scaling.mdx
+++ b/content/docs/deploy/scaling.mdx
@@ -189,14 +189,12 @@ Scale workers using container orchestration:
 version: '3.8'
 services:
   resonate-server:
-    image: resonatehq/resonate:latest
+    image: resonatehqio/resonate:v0.9.8
     ports:
       - "8001:8001"
     environment:
-      RESONATE_STORE_POSTGRES_HOST: postgres
-      RESONATE_STORE_POSTGRES_DATABASE: resonate
-      RESONATE_STORE_POSTGRES_USERNAME: resonate
-      RESONATE_STORE_POSTGRES_PASSWORD: secret
+      RESONATE_STORAGE__TYPE: postgres
+      RESONATE_STORAGE__POSTGRES__URL: postgres://<USER>:<PASSWORD>@postgres:5432/resonate
     depends_on:
       - postgres
 

--- a/content/docs/develop/go.mdx
+++ b/content/docs/develop/go.mdx
@@ -9,8 +9,8 @@ keywords:
   - resonate-sdk
 ---
 
-<Callout type="caution" title="Pre-release">
-The Go SDK has no semver-tagged release yet and is in active development. APIs may change before the first tag is cut. Use `@latest` to track the most recent `main`, or pin a specific commit for stability, and check the [open issues](https://github.com/resonatehq/resonate-sdk-go/issues) for known gaps. The internal protocol is stable; the Go API surface is still settling.
+<Callout type="caution" title="Early release">
+[0.1.0](https://github.com/resonatehq/resonate-sdk-go/releases/tag/0.1.0) is the Go SDK's first tagged release, and the SDK is in active development — APIs may still change between releases. Check the [open issues](https://github.com/resonatehq/resonate-sdk-go/issues) for known gaps. The internal protocol is stable; the Go API surface is still settling.
 </Callout>
 
 Whether you are a human or an AI agent, this skill guide will help you develop applications using the Resonate Go SDK.
@@ -32,7 +32,7 @@ The Go SDK is a standard Go module. Add it with `go get`:
 go get github.com/resonatehq/resonate-sdk-go@latest
 ```
 
-No semver tag is published yet — `@latest` resolves to a Go module pseudo-version (a generated string like `v0.0.0-<timestamp>-<commit>`) pinned to the latest `main` commit. Pin to a specific commit if you need stability before the first tag is cut:
+The current git tag is `0.1.0` (no `v` prefix), which Go's module resolver does not recognize as a module version — so `@v0.1.0` does not resolve, and `@latest` resolves to a Go module pseudo-version (a generated string like `v0.0.0-<timestamp>-<commit>`) pinned to the latest `main` commit. Pin to a specific commit if you need a reproducible build:
 
 ```shell
 go get github.com/resonatehq/resonate-sdk-go@<commit-sha>

--- a/content/docs/evaluate/coming-from/restate.mdx
+++ b/content/docs/evaluate/coming-from/restate.mdx
@@ -7,7 +7,11 @@ keywords:
 ---
 
 <Callout type="info" title="SDK version">
-This page reflects `@resonatehq/sdk` v0.10.2 (current on npm) and `resonate-sdk` v0.6.7 for Python.
+This page reflects `@resonatehq/sdk` v0.11.2 (current on npm) and `resonate-sdk` v0.7.4 for Python.
+</Callout>
+
+<Callout type="note" title="Two TypeScript engines">
+Since v0.11.0 the TypeScript SDK ships two interchangeable engines: the generator engine (`function*` with `yield* ctx.run(fn)`, shown in the examples on this page) and an async/await engine, where workflows are ordinary `async function`s and durable steps are `await ctx.run(() => ...)`. The async engine is imported from `@resonatehq/sdk/async`; its class is named `Resonate`. If you are coming from Restate, the async engine will look closest to what you already write.
 </Callout>
 
 **Are you coming from experience with Restate?**
@@ -31,7 +35,7 @@ Both Resonate and Restate provide durable execution for reliable distributed app
 
 **Restate's approach:** Define your application using three different service types depending on your needs (stateless handlers, stateful objects, or workflows), wrap non-deterministic operations in `ctx.run()`, and deploy behind endpoints that register with the Restate Server.
 
-**Resonate's approach:** Write normal async/await code. Resonate's distributed async/await automatically makes it durable without wrapper functions or service type abstractions.
+**Resonate's approach:** Write ordinary functions. A durable step is any call wrapped in `ctx.run()` — there is no service-type hierarchy to choose from, and no endpoint registration.
 
 ## Programming model
 
@@ -128,7 +132,7 @@ const result = yield* ctx.run(doDbRequest);
 
 </Tabs>
 
-Both achieve the same goal - making non-deterministic operations durable - but Resonate's generator-based approach enables automatic checkpointing of the entire call stack.
+Both achieve the same goal - making non-deterministic operations durable. Resonate's generator engine checkpoints the entire call stack automatically; the async/await engine (v0.11.0+) creates a durable promise eagerly at each `ctx.run()` call site.
 
 ### State management
 
@@ -257,7 +261,7 @@ You can develop and test without any infrastructure. Add the server when you nee
 
 Both systems support human-in-the-loop patterns.
 
-**Restate:** Uses workflow promises or signals
+**Restate:** Uses workflow promises or signals. The `ctx.promise()` API below is specific to Restate Workflows; Restate Services and Virtual Objects use awakeables instead (`ctx.awakeable<T>()`, which returns an ID and a promise).
 
 ```typescript title="Restate workflow promise"
 // In workflow
@@ -286,7 +290,7 @@ Same concept, similar API. Resonate's version works with any function, not just 
 If you're moving from Restate to Resonate:
 
 1. **Start simple:** Remove service type abstractions - your handlers become functions
-2. **Adjust syntax:** Change `await ctx.run(() => fn())` to `yield* ctx.run(fn)`  
+2. **Adjust syntax:** The async engine (`@resonatehq/sdk/async`) is the closest match to Restate — `await ctx.run(() => fn())` carries over nearly unchanged. If you prefer the generator engine, the equivalent is `yield* ctx.run(fn)`.
 3. **Rethink state:** If using Virtual Object state, decide whether to use external DB or Durable Promises
 4. **Simplify deployment:** Remove endpoint registration step - just deploy and connect
 5. **Test locally:** Take advantage of zero-dependency mode for faster iteration
@@ -370,7 +374,7 @@ Same logic, fewer abstractions. The Resonate version is a plain function with ge
 | Virtual Object | Function + external state or Durable Promise |
 | Workflow | Function with Durable Promises |
 | Handler | Function |
-| ctx.run() | ctx.run() (with generator syntax) |
+| ctx.run() | ctx.run() (generator or async engine) |
 | ctx.promise() (workflow) | ctx.promise() (any function) |
 | ctx.sleep() | ctx.sleep() |
 | ctx.get/set (state) | External DB or Durable Promise |

--- a/content/docs/evaluate/how-resonate-is-tested.mdx
+++ b/content/docs/evaluate/how-resonate-is-tested.mdx
@@ -1,0 +1,97 @@
+---
+title: How Resonate is tested
+description: Testing approach across the Resonate server, each SDK, and the Lean 4 executable specification.
+keywords:
+  - evaluate
+  - testing
+  - correctness
+  - dst
+  - deterministic simulation
+  - specification
+---
+
+<Callout type="info" title="Versions">
+This page reflects Resonate Server v0.9.8, `@resonatehq/sdk` v0.11.2 (TypeScript), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.5.0 (Rust), `resonate-sdk` v0.1.1 (Java), and the Resonate Go SDK 0.1.0.
+</Callout>
+
+Resonate's correctness story rests on three foundations that reinforce each other: a machine-checkable formal companion to the protocol specification, differential random testing of the server implementation against a pure in-memory reference model, and deterministic simulation testing of the TypeScript SDK. Unit, integration, and end-to-end test suites across all five SDKs sit alongside these.
+
+## Lean 4 executable companion
+
+The [Distributed Async Await specification](https://distributed-async-await.io/spec) is the authoritative prose description of Resonate's protocol — the state machine governing promises, tasks, and schedules. Alongside it sits a Lean 4 executable, machine-checkable companion: [`resonatehq/resonate-specification`](https://github.com/resonatehq/resonate-specification).
+
+The companion encodes each protocol handler as a pure, deterministic, total function:
+
+```lean
+-- every handler has this shape:
+-- M = StateM ServerState, so "now" is the only input that carries time
+def promiseCreate (req : PromiseCreateReq) (now : Nat) : M PromiseCreateRes
+```
+
+State is touched only through named atomic effects — `getPromise` / `setPromise`, `getTask` / `setTask`, `getSchedule` / `setSchedule` / `delSchedule`, timeout management, and outbox writes. Handlers compose these effects and nothing else, which makes the model directly auditable and buildable with a single command:
+
+```shell title="Build the Lean companion"
+cd spec && lake build
+```
+
+The companion currently covers twenty handlers in full: five promise handlers (create, get, settle, register\_callback, register\_listener), ten task handlers (get, create, acquire, fence, heartbeat, suspend, fulfill, release, halt, continue), three schedule handlers (get, create, delete), and the two internal transitions (resume, timeouts). The three search handlers return a placeholder `501` response while their specs are being written.
+
+This is a companion to the prose specification, not a replacement for it. Its purpose is to make the protocol contract machine-verifiable — a second, checkable representation of the same rules that a prose reader can audit independently.
+
+## Resonate Server
+
+The Resonate Server ([`resonatehq/resonate`](https://github.com/resonatehq/resonate), written in Rust) uses two test strategies on every pull request.
+
+### Differential random testing
+
+[`diff/differential.rs`](https://github.com/resonatehq/resonate/blob/main/diff/differential.rs) defines a test named `differential_random`. It drives the same randomly-generated sequence of API operations through multiple backends at once — always an in-memory SQLite instance and an in-memory Oracle reference model; optionally Postgres and MySQL when environment variables supply connection URLs. After every operation the test asserts two things: that every backend returned the same HTTP status and response body, and that the complete server state (promises, tasks, messages, timeouts) matches across all backends.
+
+The Oracle is a pure Rust in-memory implementation of the protocol state machine, derived from the same handler rules encoded in the Lean 4 companion. A disagreement between the Oracle and any concrete storage backend is an immediate test failure, with a precise field-level diff showing the divergence.
+
+Coverage is enforced: the test runs until all twenty-two operation kinds in the API have each produced at least one 2xx response, then continues until no new operation signatures appear for twenty consecutive batches of two hundred steps. CI runs this against all three storage backends — SQLite, Postgres, and MySQL — as a matrix on every pull request.
+
+### Unit tests
+
+The server's unit tests run with `cargo test --all-features` and cover configuration parsing, transport message handling, and individual processing modules. CI gates every pull request on format (`cargo fmt`), compilation (`cargo check`), and linting (`cargo clippy --all-features -- -D warnings`) before tests run.
+
+## TypeScript SDK
+
+The TypeScript SDK ([`resonatehq/resonate-sdk-ts`](https://github.com/resonatehq/resonate-sdk-ts)) carries a conventional Jest test suite and a dedicated deterministic simulation test.
+
+### Deterministic simulation testing
+
+The DST harness lives in [`sim/`](https://github.com/resonatehq/resonate-sdk-ts/tree/main/sim) and runs on a schedule via [`.github/workflows/dst.yml`](https://github.com/resonatehq/resonate-sdk-ts/blob/main/.github/workflows/dst.yml) — every twenty minutes, across Ubuntu, Windows, and macOS, against Node 18, 20, and 22.
+
+The harness uses a seeded linear-congruential PRNG. From a single integer seed, it derives the full behavior of the run: which function to invoke at each step, whether a message is dropped, duplicated, or delayed, and whether a worker process goes inactive. Configurable probabilities — `dropProb`, `duplProb`, `randomDelay`, `deactivateProb`, `activateProb` — default to values drawn from the same PRNG so the entire run is reproducible from the seed alone.
+
+A default run executes 10,000 steps. Three simulated worker processes and one simulated server process receive and process messages inside the harness, exercising recursive fan-out patterns (Fibonacci with local and remote calls) and multi-step chained functions.
+
+Determinism is verified explicitly: CI runs each seed twice and diffs the two log files. Different output from the same seed is a failing run. When a run fails, a GitHub issue is filed automatically with the seed, the commit SHA, and the exact command to reproduce it:
+
+```shell title="Reproduce a DST failure"
+npm run dst -- --seed <seed> --steps 10000
+```
+
+### Jest unit and integration suite
+
+The Jest suite covers the core execution engine, coroutine scheduling, retry policies, network transport, codec, encryption, and function registry. It runs via `npm test` in CI alongside linting and type checks.
+
+## Python SDK
+
+The Python SDK ([`resonatehq/resonate-sdk-py`](https://github.com/resonatehq/resonate-sdk-py)) runs `pytest` with branch coverage on Python 3.12, 3.13, and 3.14 across Ubuntu, macOS, and Windows.
+
+The suite includes [`tests/test_invariants.py`](https://github.com/resonatehq/resonate-sdk-py/blob/main/tests/test_invariants.py), which formalizes the structural replay contract of the SDK's execution tree model. The invariants capture properties from the internal `tree.md` specification — among them that a node's settler type is fixed across replays (R1), that settled promise records never retreat to pending (R2), that the execution tree reaches a fixed point after the first replay under an unchanged cache, and that the frontier shrinks monotonically as steps settle. Each invariant is driven across a battery of workflow shapes, and the test asserts the property at every step of the settle-to-done trajectory rather than only at the final state.
+
+CI also runs the Python SDK's examples end-to-end against a live Resonate server binary, downloaded from the public release page.
+
+## Rust SDK
+
+The Rust SDK ([`resonatehq/resonate-sdk-rs`](https://github.com/resonatehq/resonate-sdk-rs)) runs `cargo test --workspace` for its unit suite and `cargo test -p resonate-sdk --test e2e` for end-to-end tests against a live server. The e2e suite runs in CI against a server container on every pull request and covers durable function execution, fan-out/fan-in, promise resolution, retry behavior, and heartbeating.
+
+## Go SDK
+
+The Go SDK ([`resonatehq/resonate-sdk-go`](https://github.com/resonatehq/resonate-sdk-go)) runs `go test -race -timeout 5m ./...` — the Go race detector is enabled on every test run. End-to-end tests in [`e2e_test.go`](https://github.com/resonatehq/resonate-sdk-go/blob/main/e2e_test.go) target a live Resonate server and cover the full execution lifecycle: durable sleep, fan-out, promise resolution, and load balancing across worker groups. Without `RESONATE_URL` set, the e2e tests skip cleanly so `go test ./...` works without a server.
+
+## Java SDK
+
+The Java SDK ([`resonatehq/resonate-sdk-java`](https://github.com/resonatehq/resonate-sdk-java)) compiles against Java 21 and runs its test suite against Java 21, 24, and 25 via `./gradlew test`. CI also runs the SDK's examples end-to-end against a live server.

--- a/content/docs/evaluate/index.mdx
+++ b/content/docs/evaluate/index.mdx
@@ -16,5 +16,6 @@ Evaluate Resonate to understand its capabilities and how it works.
   <Card title="Why Resonate" description="Understand Resonate's capabilities and how you can benefit." href="/evaluate/why-resonate" />
   <Card title="How Resonate works" description="Architecture overview of checkpoints, replay, and message flow." href="/evaluate/how-it-works" />
   <Card title="Coming from other systems" description="Compare Resonate with Temporal, Restate, DBOS, and more." href="/evaluate/coming-from" />
+  <Card title="How Resonate is tested" description="The specification, differential testing, and simulation behind the correctness story." href="/evaluate/how-resonate-is-tested" />
 </CardGrid>
 


### PR DESCRIPTION
This is a combined preview of the six changes in drafts #243–#248 — all six are included here. Merge either this PR **or** the individual drafts, not both: if this merges, close #243–#248 without merging them; if any individual draft merges first, close this one once the remaining changes have landed.

## Fixes
- **Stale compose examples** (deploy overview, scaling): `RESONATE_STORE_POSTGRES_{HOST,DATABASE,USERNAME,PASSWORD}` are not read by the server — replaced with `RESONATE_STORAGE__TYPE` + `RESONATE_STORAGE__POSTGRES__URL`, and the image corrected from `resonatehq/resonate:latest` to `resonatehqio/resonate:v0.9.8`. (#243)
- **develop/go**: 0.1.0 is the Go SDK's first tagged release; the tag has no `v` prefix, so `@v0.1.0` does not resolve and `@latest` still resolves to a pseudo-version. (#244)
- **Coming from Restate refresh**: version callout to current releases (ts v0.11.2 / py v0.7.4); notes the v0.11 async/await engine alongside the generator engine; corrects "durable without wrapper functions"; adds the Workflow-vs-awakeables distinction for Restate human-in-the-loop. Restate claims verified against the current docs.restate.dev. (#248)

## New pages
- **evaluate/how-resonate-is-tested** — the Lean 4 executable, machine-checkable companion to the distributed-async-await.io prose spec; the server's differential random testing against the in-memory Oracle across SQLite/Postgres/MySQL; the TypeScript SDK's scheduled deterministic simulation testing; unit/integration/e2e suites across all five SDKs. Every claim links its public artifact. (#245)
- **deploy/production-readiness** — recommended production shape, the single-instance server constraint, health/readiness pointers, metrics, graceful shutdown, production-critical settings, pre-launch checklist. Registered in the deploy index's "going to production" path. (#246)
- **deploy/railway** — Railway Postgres + the `resonatehqio/resonate` image, `PORT` routing, env vars, public domain + health checks, worker connection over private networking. Steps were verified against Railway's current docs, Docker Hub, and the server source — not live-tested on a Railway account. (#247)

## Verification
Each change was verified against primary sources before writing (server `config.rs`/`server.rs`/`main.rs`, SDK repos and release tags, Docker Hub, docs.railway.com, docs.restate.dev). `npm run build` + `check-links` green on this combined branch (478 links, 0 internal broken).
