### PR TITLE
Python schedules: develop section, runnable example page, 0.7.4 version alignment

### DIFF
--- a/content/docs/develop/python.mdx
+++ b/content/docs/develop/python.mdx
@@ -234,10 +234,11 @@ schedule = await resonate.schedule(
 
 The function is addressed by its registered **name** (a string), not the function object — the worker that receives each invocation resolves the name in its own registry.
 `args` and `kwargs` are the arguments every fired invocation is called with, and `promise_timeout` (a `timedelta`, default 1 day) bounds each fired execution.
+All parameters can also be passed as keywords (`id=`, `cron=`, `func_name=`, ...).
 
 Cron expressions are evaluated in **UTC**, and the day-of-week field uses Quartz numbering (`1` = Sunday) — prefer day names like `MON-FRI`. See the [Schedules & cron reference](/reference/schedules) for the expression format, promise-ID templates, and the tags the server injects on fired promises.
 
-**Target routing.** Each promise the schedule fires carries a `resonate:target` tag that routes it to a worker group — without it, fired promises are never dispatched to a worker. `.schedule()` injects the tag for you from the `target` option, falling back to the handle's network group (`default` unless configured):
+**Target routing.** Each promise the schedule fires carries a `resonate:target` tag that routes it to a worker group — a schedule without it is rejected by the SDK's in-process network and by newer servers, and on servers up to v0.9.8 its fired promises are silently never dispatched (see the [Schedules & cron reference](/reference/schedules#the-resonatetarget-requirement)). `.schedule()` injects the tag for you from the `target` option, falling back to the client's configured group (`default` unless set):
 
 ```py
 await resonate.options(target="report-workers").schedule(
@@ -256,8 +257,8 @@ record = await resonate.schedules.get("nightly-report")
 print(record.cron, record.promise_id)
 ```
 
-<Callout type="caution" title="Known issue in 0.7.x">
-If the first awaited call your process makes is `.schedule()` — or any `.schedules.*` / `.promises.*` call — it fails with `http error: network has been stopped`: the SDK starts its network as a background task, and a script that calls straight in reaches the network before that task has run. Until the fix ([resonate-sdk-py#444](https://github.com/resonatehq/resonate-sdk-py/pull/444)) is released, yield to the event loop once first: `await asyncio.sleep(0)`.
+<Callout type="caution" title="Known issue in 0.7.x (remote mode)">
+On a client connected to a server (`Resonate(url=...)` or `RESONATE_URL` set), if the first awaited call your process makes is `.schedule()` — or any `.schedules.*` / `.promises.*` call — it fails with `http error: network has been stopped`: the SDK starts its network as a background task, and a script that calls straight in reaches the network before that task has run. Local mode (`Resonate()` with no URL) is unaffected. Until [resonatehq/resonate-sdk-py#443](https://github.com/resonatehq/resonate-sdk-py/issues/443) is fixed, yield to the event loop once first: `await asyncio.sleep(0)`.
 </Callout>
 
 ### `.options()`
@@ -555,7 +556,7 @@ async def foo(ctx: Context, arg):
 
 `ctx.time` and `ctx.random` from v0.6.x have been removed. There is no replacement helper.
 
-The v0.7.0 idiom for nondeterministic values that must be stable across replay is to call the nondeterministic operation inside a **leaf function** invoked via `await ctx.run(leaf, ...)`. The leaf's return value is durably checkpointed, so replay yields the same value without re-running the leaf.
+The v0.7 SDK line's idiom for nondeterministic values that must be stable across replay is to call the nondeterministic operation inside a **leaf function** invoked via `await ctx.run(leaf, ...)`. The leaf's return value is durably checkpointed, so replay yields the same value without re-running the leaf.
 
 ```py
 import time
@@ -581,6 +582,7 @@ The Python SDK ships with these key defaults.
 
 - **`Resonate()`** — `group = "default"`, `log_level = logging.INFO`. URL falls back to `RESONATE_URL`, then `RESONATE_HOST`/`RESONATE_PORT`; otherwise local mode.
 - **`ctx.run` / `Options`** — `timeout = timedelta(days=1)`, `target = "default"`, `version = 1`.
+- **`.schedule()`** — `promise_timeout = timedelta(days=1)` per fired execution; the `resonate:target` tag falls back to the client's configured group.
 - **`retry_policy`** for `ctx.run` — resolves to `Exponential(delay=1, factor=2, max_delay=2**63 - 1, max_retries=30)`.
 - **`Exponential()` required fields** — `delay`, `factor`, `max_delay`, `max_retries` (all times in seconds).
 - **`Constant()` / `Linear()` required fields** — `delay`, `max_retries`.

--- a/content/docs/develop/python.mdx
+++ b/content/docs/develop/python.mdx
@@ -9,7 +9,7 @@ pagination_prev: null
 ---
 
 <Callout type="info" title="SDK version">
-This page reflects `resonate-sdk` v0.7.0 (current on PyPI). Python ≥3.12 required. The remote-mode examples below need a running server (`resonate dev`, Rust server v0.9.x+); `Resonate()` without a `url` runs entirely in-process and needs no server.
+This page reflects `resonate-sdk` v0.7.4 (current on PyPI). Python ≥3.12 required. The remote-mode examples below need a running server (`resonate dev`, Rust server v0.9.x+); `Resonate()` without a `url` runs entirely in-process and needs no server.
 </Callout>
 
 Welcome to the Resonate Python SDK guide!
@@ -118,7 +118,7 @@ The `token` kwarg falls back to the `RESONATE_TOKEN` environment variable when o
 
 ### Concurrency
 
-A single Python worker process executes multiple functions concurrently inside a single asyncio event loop. The v0.7.0 SDK is fully async; every durable function is an `async def` coroutine and effects are `await`ed.
+A single Python worker process executes multiple functions concurrently inside a single asyncio event loop. The v0.7 SDK line is fully async; every durable function is an `async def` coroutine and effects are `await`ed.
 
 See [Scaling — Worker concurrency](/deploy/scaling#worker-concurrency) for more on concurrency strategies.
 
@@ -216,9 +216,53 @@ async def main():
 asyncio.run(main())
 ```
 
+### `.schedule()`
+
+Resonate's `.schedule()` method allows you to schedule a function to be invoked on a specified cron schedule.
+The scheduled function will be invoked until the schedule is deleted.
+`.schedule()` is async.
+
+```py
+schedule = await resonate.schedule(
+    "scheduled-foo",  # schedule ID
+    "0 * * * *",      # every hour, on the hour, UTC
+    "foo",            # the function's registered name
+    args=(1,),
+    kwargs={"greeting": "hello"},
+)
+```
+
+The function is addressed by its registered **name** (a string), not the function object — the worker that receives each invocation resolves the name in its own registry.
+`args` and `kwargs` are the arguments every fired invocation is called with, and `promise_timeout` (a `timedelta`, default 1 day) bounds each fired execution.
+
+Cron expressions are evaluated in **UTC**, and the day-of-week field uses Quartz numbering (`1` = Sunday) — prefer day names like `MON-FRI`. See the [Schedules & cron reference](/reference/schedules) for the expression format, promise-ID templates, and the tags the server injects on fired promises.
+
+**Target routing.** Each promise the schedule fires carries a `resonate:target` tag that routes it to a worker group — without it, fired promises are never dispatched to a worker. `.schedule()` injects the tag for you from the `target` option, falling back to the handle's network group (`default` unless configured):
+
+```py
+await resonate.options(target="report-workers").schedule(
+    "nightly-report",
+    "0 2 * * *",
+    "generate_report",
+)
+```
+
+**Delete and inspect.** The returned handle deletes the schedule; the `resonate.schedules` sub-client gives you direct `create` / `get` / `delete` / `search` access:
+
+```py
+await schedule.delete()  # stop future ticks (already-fired promises are unaffected)
+
+record = await resonate.schedules.get("nightly-report")
+print(record.cron, record.promise_id)
+```
+
+<Callout type="caution" title="Known issue in 0.7.x">
+If the first awaited call your process makes is `.schedule()` — or any `.schedules.*` / `.promises.*` call — it fails with `http error: network has been stopped`: the SDK starts its network as a background task, and a script that calls straight in reaches the network before that task has run. Until the fix ([resonate-sdk-py#444](https://github.com/resonatehq/resonate-sdk-py/pull/444)) is released, yield to the event loop once first: `await asyncio.sleep(0)`.
+</Callout>
+
 ### `.options()`
 
-Options can be used preceding `.run()` and `.rpc()` on the client.
+Options can be used preceding `.run()`, `.rpc()`, and `.schedule()` on the client.
 
 ```py
 from datetime import timedelta

--- a/content/docs/evaluate/coming-from/dbos.mdx
+++ b/content/docs/evaluate/coming-from/dbos.mdx
@@ -726,7 +726,7 @@ func sleepingWorkflow(ctx *resonate.Context, args SleepArgs) (string, error) {
 
 </Tabs>
 
-For recurring work, DBOS schedules a workflow on a cron expression — either the `@DBOS.scheduled(cron)` decorator (the workflow receives the scheduled and actual fire times) or the database-backed `DBOS.create_schedule(...)` / `apply_schedules(...)` API. Resonate registers a schedule with `resonate.schedule(...)` (TypeScript and Rust) or `resonate.schedules.create(...)` (Python), and the Resonate Server fires the promise on the cron.
+For recurring work, DBOS schedules a workflow on a cron expression — either the `@DBOS.scheduled(cron)` decorator (the workflow receives the scheduled and actual fire times) or the database-backed `DBOS.create_schedule(...)` / `apply_schedules(...)` API. Resonate registers a schedule with `resonate.schedule(...)` (TypeScript, Python, and Rust), and the Resonate Server fires the promise on the cron.
 
 <Callout type="caution" title="Mind the cron fields">
 DBOS uses a **6-field** cron with a leading seconds component — `* * * * * *` means *every second*. Resonate takes a **standard 5-field** cron — `* * * * *` means *every minute*. Drop the leading seconds field when migrating, or a `* * * * * *` copied across fires far more often than you intend.
@@ -753,14 +753,13 @@ def test_workflow(scheduled: datetime, actual: datetime) -> None:
     # ...
 ```
 
-**Resonate** — registers a cron schedule with the server (`example-schedule-py`):
+**Resonate** — registers a cron schedule with the server (`example-schedule-py`, `resonate-sdk` ≥0.7.4):
 
 ```python
-resonate.schedules.create(
+await resonate.schedule(
     id="my-schedule",
     cron="* * * * *",
-    promise_id="my-schedule.{{.timestamp}}",
-    # ... also required: promise_timeout, promise_data (the function-invoke payload), promise_tags
+    func_name="my_function",   # registered name; args=(...) for arguments
 )
 ```
 

--- a/content/docs/get-started/examples/async-agent-tools.mdx
+++ b/content/docs/get-started/examples/async-agent-tools.mdx
@@ -16,7 +16,7 @@ keywords:
 A FastMCP server exposes three tools — start, probe, await — backed by a durable Resonate workflow. The LLM kicks off long jobs, polls them, and collects results without blocking on the work.
 
 <Callout type="info" title="SDK versions">
-Python: `resonate-sdk` v0.7.0 (current). Rust: 0.4.0, in active development. TypeScript SDK example repo is forthcoming.
+Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. TypeScript SDK example repo is forthcoming.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/async-http-api-endpoints.mdx
+++ b/content/docs/get-started/examples/async-http-api-endpoints.mdx
@@ -16,7 +16,7 @@ keywords:
 A FastAPI gateway converts every inbound request into a durable workflow, returns a promise ID immediately, and exposes a `/wait` endpoint clients poll for completion.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/async-http-api-endpoints.mdx
+++ b/content/docs/get-started/examples/async-http-api-endpoints.mdx
@@ -16,7 +16,7 @@ keywords:
 A FastAPI gateway converts every inbound request into a durable workflow, returns a promise ID immediately, and exposes a `/wait` endpoint clients poll for completion.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/async-rpc.mdx
+++ b/content/docs/get-started/examples/async-rpc.mdx
@@ -16,7 +16,7 @@ keywords:
 A gateway calls service A, which calls service B, which calls service C. Each step uses Resonate's remote function invocation APIs, so the entire chain is durable — a crash on any service resumes the call without re-running prior steps.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current).
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/async-rpc.mdx
+++ b/content/docs/get-started/examples/async-rpc.mdx
@@ -16,7 +16,7 @@ keywords:
 A gateway calls service A, which calls service B, which calls service C. Each step uses Resonate's remote function invocation APIs, so the entire chain is durable — a crash on any service resumes the call without re-running prior steps.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current).
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/deep-research-agent.mdx
+++ b/content/docs/get-started/examples/deep-research-agent.mdx
@@ -17,7 +17,7 @@ keywords:
 A research agent receives a broad topic, asks an LLM to break it into 2–3 subtopics, and recursively dispatches each subtopic to itself. Every LLM call and every recursive subagent is a durable promise — kill the worker mid-research, the tree resumes from the last unanswered branch.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/deep-research-agent.mdx
+++ b/content/docs/get-started/examples/deep-research-agent.mdx
@@ -17,7 +17,7 @@ keywords:
 A research agent receives a broad topic, asks an LLM to break it into 2–3 subtopics, and recursively dispatches each subtopic to itself. Every LLM call and every recursive subagent is a durable promise — kill the worker mid-research, the tree resumes from the last unanswered branch.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/durable-serverless-lambda-workers.mdx
+++ b/content/docs/get-started/examples/durable-serverless-lambda-workers.mdx
@@ -16,7 +16,7 @@ keywords:
 A Lambda function behind API Gateway acts as a stateless trigger. `POST /process-document` fires a durable Resonate workflow and returns `202` immediately. The workflow itself — download, OCR, LLM analysis, storage, notification — runs on a Resonate worker that doesn't share Lambda's 15-minute ceiling.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust example repo is forthcoming.
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/durable-serverless-lambda-workers.mdx
+++ b/content/docs/get-started/examples/durable-serverless-lambda-workers.mdx
@@ -16,7 +16,7 @@ keywords:
 A Lambda function behind API Gateway acts as a stateless trigger. `POST /process-document` fires a durable Resonate workflow and returns `202` immediately. The workflow itself — download, OCR, LLM analysis, storage, notification — runs on a Resonate worker that doesn't share Lambda's 15-minute ceiling.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/durable-sleep.mdx
+++ b/content/docs/get-started/examples/durable-sleep.mdx
@@ -15,7 +15,7 @@ keywords:
 A workflow yields `ctx.sleep` and the runtime suspends it. Hours, days, or weeks later the worker wakes the workflow up exactly where it stopped — no cron, no scheduler, no external state.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/durable-sleep.mdx
+++ b/content/docs/get-started/examples/durable-sleep.mdx
@@ -15,7 +15,7 @@ keywords:
 A workflow yields `ctx.sleep` and the runtime suspends it. Hours, days, or weeks later the worker wakes the workflow up exactly where it stopped — no cron, no scheduler, no external state.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/fan-out-fan-in.mdx
+++ b/content/docs/get-started/examples/fan-out-fan-in.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow spawns four notification channels (email, SMS, Slack, push) in parallel and joins their results. Total wall time approaches the slowest channel, not the sum. If one channel fails and retries, the others stay checkpointed — they don't re-send.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>
@@ -134,7 +134,7 @@ async def notify_all(ctx: Context, event: dict, simulate_crash: bool):
     }
 ```
 
-In v0.7.0, `ctx.run(...)` returns a handle immediately without blocking, so issuing all four calls first starts every channel concurrently; awaiting each handle then collects the results. Each `ctx.run` is a durable child checkpoint, so if push retries, email/SMS/Slack stay checkpointed and do not re-execute.
+In the v0.7 SDK line, `ctx.run(...)` returns a handle immediately without blocking, so issuing all four calls first starts every channel concurrently; awaiting each handle then collects the results. Each `ctx.run` is a durable child checkpoint, so if push retries, email/SMS/Slack stay checkpointed and do not re-execute.
 
 </TabItem>
 

--- a/content/docs/get-started/examples/fan-out-fan-in.mdx
+++ b/content/docs/get-started/examples/fan-out-fan-in.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow spawns four notification channels (email, SMS, Slack, push) in parallel and joins their results. Total wall time approaches the slowest channel, not the sum. If one channel fails and retries, the others stay checkpointed — they don't re-send.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/hello-world.mdx
+++ b/content/docs/get-started/examples/hello-world.mdx
@@ -15,7 +15,7 @@ keywords:
 The smallest example that exercises the durable execution loop. A registered workflow function calls two leaf functions through `ctx.run`, and Resonate checkpoints each return value.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/hello-world.mdx
+++ b/content/docs/get-started/examples/hello-world.mdx
@@ -15,7 +15,7 @@ keywords:
 The smallest example that exercises the durable execution loop. A registered workflow function calls two leaf functions through `ctx.run`, and Resonate checkpoints each return value.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/human-in-the-loop.mdx
+++ b/content/docs/get-started/examples/human-in-the-loop.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow blocks on a durable promise, prints a callback URL, and resumes the moment a human resolves it — from any process, any machine, any time.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust: 0.4.0, in active development — published on crates.io as `resonate-sdk`; this example pulls it as a git dependency from `resonate-sdk-rs` to track `main`.
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development — published on crates.io as `resonate-sdk`; this example pulls it as a git dependency from `resonate-sdk-rs` to track `main`.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/human-in-the-loop.mdx
+++ b/content/docs/get-started/examples/human-in-the-loop.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow blocks on a durable promise, prints a callback URL, and resumes the moment a human resolves it — from any process, any machine, any time.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development — published on crates.io as `resonate-sdk`; this example pulls it as a git dependency from `resonate-sdk-rs` to track `main`.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development — published on crates.io as `resonate-sdk`; this example pulls it as a git dependency from `resonate-sdk-rs` to track `main`.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/kafka-worker.mdx
+++ b/content/docs/get-started/examples/kafka-worker.mdx
@@ -16,7 +16,7 @@ keywords:
 A consumer pulls messages from a Kafka topic and dispatches each one through a durable Resonate workflow. Per-message state lives in durable promises, so a worker that dies mid-batch resumes cleanly without redoing completed steps.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <Callout type="note" title="Kafka or Redpanda — same code">

--- a/content/docs/get-started/examples/kafka-worker.mdx
+++ b/content/docs/get-started/examples/kafka-worker.mdx
@@ -16,7 +16,7 @@ keywords:
 A consumer pulls messages from a Kafka topic and dispatches each one through a durable Resonate workflow. Per-message state lives in durable promises, so a worker that dies mid-batch resumes cleanly without redoing completed steps.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <Callout type="note" title="Kafka or Redpanda — same code">

--- a/content/docs/get-started/examples/load-balancing.mdx
+++ b/content/docs/get-started/examples/load-balancing.mdx
@@ -15,7 +15,7 @@ keywords:
 Run several workers in the same group. Calls to `target: "poll://any@<group>"` get dispatched to whichever worker claims them first. When a worker dies mid-execution, Resonate reassigns the work to a survivor — no service registry, no leader election, no glue.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/load-balancing.mdx
+++ b/content/docs/get-started/examples/load-balancing.mdx
@@ -15,7 +15,7 @@ keywords:
 Run several workers in the same group. Calls to `target: "poll://any@<group>"` get dispatched to whichever worker claims them first. When a worker dies mid-execution, Resonate reassigns the work to a survivor — no service registry, no leader election, no glue.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/money-transfer.mdx
+++ b/content/docs/get-started/examples/money-transfer.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow debits the source account, credits the target account, and returns confirmations. Each account update is a durable checkpoint, the transfer ID is the idempotency key, and the same ID retried in seconds, hours, or days returns the cached result instead of double-spending.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/money-transfer.mdx
+++ b/content/docs/get-started/examples/money-transfer.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow debits the source account, credits the target account, and returns confirmations. Each account update is a durable checkpoint, the transfer ID is the idempotency key, and the same ID retried in seconds, hours, or days returns the cached result instead of double-spending.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/multi-agent-orchestration.mdx
+++ b/content/docs/get-started/examples/multi-agent-orchestration.mdx
@@ -16,7 +16,7 @@ keywords:
 Three specialist agents — researcher, writer, reviewer — chained through an orchestrator. Each agent's output is a durable checkpoint, so a flaky LLM call mid-pipeline retries only the failing agent and the prior outputs stay cached.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/multi-agent-orchestration.mdx
+++ b/content/docs/get-started/examples/multi-agent-orchestration.mdx
@@ -16,7 +16,7 @@ keywords:
 Three specialist agents — researcher, writer, reviewer — chained through an orchestrator. Each agent's output is a durable checkpoint, so a flaky LLM call mid-pipeline retries only the failing agent and the prior outputs stay cached.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust example repo is forthcoming.
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/recursive-factorial.mdx
+++ b/content/docs/get-started/examples/recursive-factorial.mdx
@@ -15,7 +15,7 @@ keywords:
 A workflow that computes `n!` by calling itself with `n-1`. Each recursive call dispatches via `ctx.rpc` to whichever worker in the group claims it — recursion ends up distributed across machines without any explicit coordination, and every step is checkpointed so a worker crash mid-recursion resumes cleanly.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/recursive-factorial.mdx
+++ b/content/docs/get-started/examples/recursive-factorial.mdx
@@ -15,7 +15,7 @@ keywords:
 A workflow that computes `n!` by calling itself with `n-1`. Each recursive call dispatches via `ctx.rpc` to whichever worker in the group claims it — recursion ends up distributed across machines without any explicit coordination, and every step is checkpointed so a worker crash mid-recursion resumes cleanly.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/schedule.mdx
+++ b/content/docs/get-started/examples/schedule.mdx
@@ -94,8 +94,7 @@ from report import generate_report
 
 
 async def main() -> None:
-    url = os.environ.get("RESONATE_URL", "http://localhost:8001")
-    resonate = Resonate(url=url)
+    resonate = Resonate(url=os.environ.get("RESONATE_URL", "http://localhost:8001"))
     resonate.register(generate_report)
 
     # Yield to the event loop once so the SDK's background network task
@@ -103,14 +102,18 @@ async def main() -> None:
     # the fix (resonate-sdk-py#444) is released.
     await asyncio.sleep(0)
 
-    await resonate.schedule(
-        "daily_report",            # schedule ID — re-running this script is a no-op once it exists
-        "* * * * *",               # cron: every minute (use "0 9 * * *" for daily 9am UTC)
-        "generate_report",         # registered function name
-        args=(123,),               # user_id
-    )
-    print("Schedule created. Start the worker to process executions.")
-    await resonate.stop()
+    try:
+        # Schedule generate_report to run every minute.
+        # Re-running this script is a no-op once the schedule exists.
+        await resonate.schedule(
+            id="daily_report",
+            cron="* * * * *",          # every minute (change to "0 9 * * *" for daily at 9am UTC)
+            func_name="generate_report",
+            args=(123,),               # user_id
+        )
+        print("Schedule created. Start the worker to process executions.")
+    finally:
+        await resonate.stop()
 
 
 if __name__ == "__main__":

--- a/content/docs/get-started/examples/schedule.mdx
+++ b/content/docs/get-started/examples/schedule.mdx
@@ -16,7 +16,7 @@ keywords:
 Register a function to run on a cron expression and Resonate handles the rest. Every fired execution is a durable workflow — a worker that crashes mid-run hands off to a survivor, and a missed run because all workers were down still gets dispatched when one comes back.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
 </Callout>
 
 <CloneRepoGrid>
@@ -88,7 +88,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-from datetime import timedelta
 
 from resonate.resonate import Resonate
 from report import generate_report
@@ -99,11 +98,16 @@ async def main() -> None:
     resonate = Resonate(url=url)
     resonate.register(generate_report)
 
+    # Yield to the event loop once so the SDK's background network task
+    # starts before the first call -- needed on resonate-sdk 0.7.x until
+    # the fix (resonate-sdk-py#444) is released.
+    await asyncio.sleep(0)
+
     await resonate.schedule(
-        "daily_report",        # schedule ID — re-running this script is a no-op once it exists
-        "* * * * *",           # cron: every minute
-        func_name="generate_report",
-        promise_timeout=timedelta(minutes=10),
+        "daily_report",            # schedule ID — re-running this script is a no-op once it exists
+        "* * * * *",               # cron: every minute (use "0 9 * * *" for daily 9am UTC)
+        "generate_report",         # registered function name
+        args=(123,),               # user_id
     )
     print("Schedule created. Start the worker to process executions.")
     await resonate.stop()

--- a/content/docs/get-started/examples/schedule.mdx
+++ b/content/docs/get-started/examples/schedule.mdx
@@ -99,7 +99,7 @@ async def main() -> None:
 
     # Yield to the event loop once so the SDK's background network task
     # starts before the first call -- needed on resonate-sdk 0.7.x until
-    # the fix (resonate-sdk-py#444) is released.
+    # resonatehq/resonate-sdk-py#443 is fixed.
     await asyncio.sleep(0)
 
     try:
@@ -111,7 +111,7 @@ async def main() -> None:
             func_name="generate_report",
             args=(123,),               # user_id
         )
-        print("Schedule created. Start the worker to process executions.")
+        print("Schedule registered. Start the worker to process executions.")
     finally:
         await resonate.stop()
 

--- a/content/docs/get-started/examples/webhook-handler.mdx
+++ b/content/docs/get-started/examples/webhook-handler.mdx
@@ -16,7 +16,7 @@ keywords:
 A webhook receives a payment event, kicks off a durable workflow keyed by the provider's event ID, and acknowledges immediately. Duplicate deliveries (network retries, slow ACKs) reconnect to the in-flight execution rather than re-charging the card. A crash mid-processing resumes from the next unfinished step.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/webhook-handler.mdx
+++ b/content/docs/get-started/examples/webhook-handler.mdx
@@ -16,7 +16,7 @@ keywords:
 A webhook receives a payment event, kicks off a durable workflow keyed by the provider's event ID, and acknowledges immediately. Duplicate deliveries (network retries, slow ACKs) reconnect to the in-flight execution rather than re-charging the card. A crash mid-processing resumes from the next unfinished step.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.0 (current). Rust example repo is forthcoming.
+TypeScript: `@resonatehq/sdk` v0.10.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/quickstart.mdx
+++ b/content/docs/get-started/quickstart.mdx
@@ -41,7 +41,7 @@ npm install @resonatehq/sdk
 
 <TabItem value="python">
 
-<Callout type="note" title="The Resonate Python SDK (v0.7.0) requires **Python ≥3.12**.">
+<Callout type="note" title="The Resonate Python SDK (v0.7.4) requires **Python ≥3.12**.">
 
 </Callout>
 

--- a/content/docs/reference/schedules.mdx
+++ b/content/docs/reference/schedules.mdx
@@ -51,14 +51,14 @@ Cron expressions are evaluated in **UTC**. There is no per-schedule or per-serve
 
 ## The `resonate:target` requirement
 
-Every fired promise needs a routing target, or no worker group will ever receive it. The server therefore **rejects** `schedule.create` when `promiseTags` lacks a `resonate:target` tag ([`resonate/src/types.rs:641-643`](https://github.com/resonatehq/resonate/blob/main/src/types.rs#L641-L643)):
+Every fired promise needs a routing target, or no worker group will ever receive it. Starting with the server release after v0.9.8, the server therefore **rejects** `schedule.create` when `promiseTags` lacks a `resonate:target` tag ([`resonate/src/types.rs:641-643`](https://github.com/resonatehq/resonate/blob/main/src/types.rs#L641-L643)):
 
 ```text
 400 promiseTags must include a resonate:target tag
 ```
 
-<Callout type="note" title="Server versions">
-This validation is on the server's `main` branch and ships in the release after v0.9.8. A v0.9.8 (or earlier) server **accepts** an untagged `schedule.create` — the schedule fires, but its promises are never dispatched to any worker. SDK releases that carry the schedule fixes (Python `resonate-sdk` ≥0.7.4) enforce the same rejection in their in-process (local) networks regardless of server version.
+<Callout type="note" title="Server version">
+On v0.9.8 (the current release) and earlier, the server **accepts** an untagged `schedule.create` — the schedule fires, but its promises are never dispatched to any worker. SDK releases that carry the schedule fixes (Python `resonate-sdk` ≥0.7.4) enforce the rejection above in their in-process (local) networks regardless of server version.
 </Callout>
 
 The value is an address like `poll://any@default` — the same convention as `resonate invoke --target` and the SDKs' `target` option. The high-level `schedule()` APIs that inject this tag for you take the target from the same option surface as `run`/`rpc`; the low-level schedule sub-clients and the CLI require you to pass it explicitly:

--- a/content/docs/reference/schedules.mdx
+++ b/content/docs/reference/schedules.mdx
@@ -57,6 +57,10 @@ Every fired promise needs a routing target, or no worker group will ever receive
 400 promiseTags must include a resonate:target tag
 ```
 
+<Callout type="note" title="Server versions">
+This validation is on the server's `main` branch and ships in the release after v0.9.8. A v0.9.8 (or earlier) server **accepts** an untagged `schedule.create` — the schedule fires, but its promises are never dispatched to any worker. SDK releases that carry the schedule fixes (Python `resonate-sdk` ≥0.7.4) enforce the same rejection in their in-process (local) networks regardless of server version.
+</Callout>
+
 The value is an address like `poll://any@default` — the same convention as `resonate invoke --target` and the SDKs' `target` option. The high-level `schedule()` APIs that inject this tag for you take the target from the same option surface as `run`/`rpc`; the low-level schedule sub-clients and the CLI require you to pass it explicitly:
 
 ```shell


### PR DESCRIPTION
## What

Python SDK **0.7.4** is the first release whose schedule fires carry the `resonate:target` routing tag, which makes Python scheduling documentable end to end. This PR:

- **`develop/python.mdx`** — adds the missing `.schedule()` section, mirroring the TypeScript section's shape: what `schedule()` does, target routing via `options(target=...)` with the network-group fallback, delete via the returned handle, the `schedules` sub-client (`create`/`get`/`delete`/`search`), and a link to [/reference/schedules](https://docs.resonatehq.io/reference/schedules) for cron format/UTC/Quartz DOW. Includes a caution about the 0.7.x first-call issue (a script whose first awaited call is `.schedule()`/`.schedules.*`/`.promises.*` fails with `network has been stopped`) and its one-line interim workaround, until resonatehq/resonate-sdk-py#444 is released.
- **`get-started/examples/schedule.mdx`** — the Python tab now actually runs on 0.7.4: function addressed by registered name, `args=(123,)` matching the report function's signature, and the startup yield. SDK version callout refreshed (TS `0.11.2`, Python `0.7.4`; both verified — see below).
- **`reference/schedules.mdx`** — qualifies the `resonate:target` rejection by server version: released v0.9.8 **accepts** an untagged `schedule.create` (the schedule fires but its promises are never dispatched); the 400 rejection ships in the next server release. SDK releases carrying the schedule fixes (Python ≥0.7.4) enforce the rejection in their local networks.
- **Version notices** — `resonate-sdk` v0.7.0 → v0.7.4 across 16 example pages, the quickstart Python callout, and the Python SDK guide header.

## Verification

- Every Python code block (both changed pages) executed against installed `resonate-sdk==0.7.4` + live `resonate dev` (v0.9.8): schedule created, tags verified (`poll://any@default` default, `poll://any@report-workers` via `options(target=...)`), handle `.delete()` + sub-client `get`/`search`/`delete` all exercised, cron fire observed end to end (worker executed the scheduled function).
- The schedule example page's TS tabs executed against `@resonatehq/sdk` 0.11.2 + the same server (schedule created, worker executed a fire) to back the TS version-callout bump.
- v0.9.8-accepts-untagged verified empirically (create succeeded, tags `{}`); `main`'s validation confirmed at `src/types.rs:641-643`; Python 0.7.4 localnet rejection verified with the exact `400 promiseTags must include a resonate:target tag`.
- `npm run build` clean; check-links: 454 links, **0 internal broken** (external warns are the pre-existing localhost dev URLs).

Rust/Java schedule docs intentionally untouched (their SDK releases don't carry the schedule fixes yet). Part of #241.