### PR TITLE
docs(evaluate): add How Resonate is tested

### DIFF
--- a/content/docs/evaluate/coming-from/byode.mdx
+++ b/content/docs/evaluate/coming-from/byode.mdx
@@ -65,7 +65,7 @@ You've built something that works, but it's bespoke. Every company reinvents the
 Your system was built to solve a specific problem. **Resonate is built on a formal protocol** - Distributed Async Await - that has been through formal methods and verification.
 
 This means:
-- **Proven correctness** - The model has been validated against common failure scenarios
+- **Proven correctness** - The model has been validated against common failure scenarios ([how Resonate is tested](/evaluate/how-resonate-is-tested))
 - **Clear semantics** - What happens on retry, crash, timeout, or split-brain is defined, not discovered
 - **Interoperability** - The protocol is language-agnostic and implementation-independent
 

--- a/content/docs/evaluate/how-resonate-is-tested.mdx
+++ b/content/docs/evaluate/how-resonate-is-tested.mdx
@@ -14,13 +14,13 @@ keywords:
 This page reflects Resonate Server v0.9.8, `@resonatehq/sdk` v0.11.2 (TypeScript), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.5.0 (Rust), `resonate-sdk` v0.1.1 (Java), and the Resonate Go SDK 0.1.0.
 </Callout>
 
-Resonate's correctness story rests on three foundations that reinforce each other: a machine-checkable formal companion to the protocol specification, differential random testing of the server implementation against a pure in-memory reference model, and deterministic simulation testing of the TypeScript SDK. Unit, integration, and end-to-end test suites across all five SDKs sit alongside these.
+Resonate's correctness story rests on three foundations that reinforce each other: an executable formal specification of the protocol in Lean 4, differential random testing of the server implementation against a pure in-memory reference model, and deterministic simulation testing of the TypeScript SDK. Unit, integration, and end-to-end test suites across all five SDKs sit alongside these.
 
-## Lean 4 executable companion
+## The Lean 4 abstract machine
 
-The [Distributed Async Await specification](https://distributed-async-await.io/spec) is the authoritative prose description of Resonate's protocol — the state machine governing promises, tasks, and schedules. Alongside it sits a Lean 4 executable, machine-checkable companion: [`resonatehq/resonate-specification`](https://github.com/resonatehq/resonate-specification).
+The Distributed Async Await protocol is specified twice, on purpose. [`resonatehq/resonate-specification`](https://github.com/resonatehq/resonate-specification) is the executable abstract machine in Lean 4 — the normative, machine-checkable definition of the protocol's core handlers and state transitions: promises, tasks, and schedules. The [prose specification](https://distributed-async-await.io/spec) is the human-readable companion that explains the same protocol. Where prose and Lean disagree, the Lean model wins.
 
-The companion encodes each protocol handler as a pure, deterministic, total function:
+The Lean model encodes each protocol handler as a pure, deterministic, total function:
 
 ```lean
 -- every handler has this shape:
@@ -30,13 +30,13 @@ def promiseCreate (req : PromiseCreateReq) (now : Nat) : M PromiseCreateRes
 
 State is touched only through named atomic effects — `getPromise` / `setPromise`, `getTask` / `setTask`, `getSchedule` / `setSchedule` / `delSchedule`, timeout management, and outbox writes. Handlers compose these effects and nothing else, which makes the model directly auditable and buildable with a single command:
 
-```shell title="Build the Lean companion"
+```shell title="Build the Lean model"
 cd spec && lake build
 ```
 
-The companion currently covers twenty handlers in full: five promise handlers (create, get, settle, register\_callback, register\_listener), ten task handlers (get, create, acquire, fence, heartbeat, suspend, fulfill, release, halt, continue), three schedule handlers (get, create, delete), and the two internal transitions (resume, timeouts). The three search handlers return a placeholder `501` response while their specs are being written.
+The model currently covers twenty handlers in full: five promise handlers (create, get, settle, register\_callback, register\_listener), ten task handlers (get, create, acquire, fence, heartbeat, suspend, fulfill, release, halt, continue), three schedule handlers (get, create, delete), and the two internal transitions (resume, timeouts). The three search handlers return a placeholder `501` response while their specs are being written.
 
-The companion also states the protocol's central safety property — the durable-execution guarantee — as an executable predicate, in [`spec/02-actions/04-guarantee.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/04-guarantee.lean):
+The model also states the protocol's central safety property — the durable-execution guarantee — as an executable predicate, in [`spec/02-actions/04-guarantee.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/04-guarantee.lean):
 
 ```lean title="The durable-execution guarantee"
 def durableExecutionGuarantee (s : ServerState) : Bool :=
@@ -62,7 +62,7 @@ def durableExecutionGuarantee (s : ServerState) : Bool :=
 
 In words: if a task has suspended on awaited promises, and one of those promises settles while the task's own promise is still pending and unexpired, an `execute` message must be queued. The same file checks the predicate against concrete scenarios; a general theorem over all reachable states is not yet proven, and the file says so.
 
-This is a companion to the prose specification, not a replacement for it. Its purpose is to make the protocol contract machine-verifiable — a second, checkable representation of the same rules that a prose reader can audit independently.
+Having the protocol in two representations is the point: the Lean model is the definition the compiler checks, and the prose specification explains the same rules for human readers. Anyone can audit one against the other.
 
 ## Resonate Server
 
@@ -72,7 +72,7 @@ The Resonate Server ([`resonatehq/resonate`](https://github.com/resonatehq/reson
 
 [`diff/differential.rs`](https://github.com/resonatehq/resonate/blob/main/diff/differential.rs) defines a test named `differential_random`. It drives the same randomly-generated sequence of API operations through multiple backends at once — always an in-memory SQLite instance and an in-memory Oracle reference model; optionally Postgres and MySQL when environment variables supply connection URLs. After every operation the test asserts two things: that every backend returned the same HTTP status and response body, and that the complete server state (promises, tasks, messages, timeouts) matches across all backends.
 
-The Oracle is a pure Rust in-memory implementation of the protocol state machine, derived from the same handler rules encoded in the Lean 4 companion. A disagreement between the Oracle and any concrete storage backend is an immediate test failure, with a precise field-level diff showing the divergence.
+The Oracle is a pure Rust in-memory implementation of the protocol state machine, derived from the same handler rules encoded in the Lean 4 model. A disagreement between the Oracle and any concrete storage backend is an immediate test failure, with a precise field-level diff showing the divergence.
 
 Coverage is enforced: the test runs until all twenty-two operation kinds in the API have each produced at least one 2xx response, then continues until no new operation signatures appear for twenty consecutive batches of two hundred steps. CI runs this against all three storage backends — SQLite, Postgres, and MySQL — as a matrix on every pull request.
 

--- a/content/docs/evaluate/how-resonate-is-tested.mdx
+++ b/content/docs/evaluate/how-resonate-is-tested.mdx
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <Callout type="info" title="Versions">
-This page reflects Resonate Server v0.9.8, `@resonatehq/sdk` v0.11.2 (TypeScript), `resonate-sdk` v0.7.3 (Python), `resonate-sdk` v0.5.0 (Rust), `resonate-sdk` v0.1.1 (Java), and the Resonate Go SDK 0.1.0.
+This page reflects Resonate Server v0.9.8, `@resonatehq/sdk` v0.11.2 (TypeScript), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.5.0 (Rust), `resonate-sdk` v0.1.1 (Java), and the Resonate Go SDK 0.1.0.
 </Callout>
 
 Resonate's correctness story rests on three foundations that reinforce each other: a machine-checkable formal companion to the protocol specification, differential random testing of the server implementation against a pure in-memory reference model, and deterministic simulation testing of the TypeScript SDK. Unit, integration, and end-to-end test suites across all five SDKs sit alongside these.
@@ -36,11 +36,37 @@ cd spec && lake build
 
 The companion currently covers twenty handlers in full: five promise handlers (create, get, settle, register\_callback, register\_listener), ten task handlers (get, create, acquire, fence, heartbeat, suspend, fulfill, release, halt, continue), three schedule handlers (get, create, delete), and the two internal transitions (resume, timeouts). The three search handlers return a placeholder `501` response while their specs are being written.
 
+The companion also states the protocol's central safety property — the durable-execution guarantee — as an executable predicate, in [`spec/02-actions/04-guarantee.lean`](https://github.com/resonatehq/resonate-specification/blob/main/spec/02-actions/04-guarantee.lean):
+
+```lean title="The durable-execution guarantee"
+def durableExecutionGuarantee (s : ServerState) : Bool :=
+  s.tasks.all (fun t =>
+    match t.state with
+    | .pending | .acquired | .halted | .fulfilled =>
+      true
+    | .suspended =>
+      match s.promises.find? (·.id == t.id) with
+      | none => true
+      | some tP =>
+        if tP.state != .pending || tP.timeoutAt <= tP.createdAt then
+          true
+        else
+          let awaitedIds := t.resumes
+          let anySettled := s.promises.any (fun p =>
+            awaitedIds.contains p.id && awaitedSettledLive p tP)
+          if !anySettled then
+            true
+          else
+            hasExecuteInOutbox t.id s.outbox)
+```
+
+In words: if a task has suspended on awaited promises, and one of those promises settles while the task's own promise is still pending and unexpired, an `execute` message must be queued. The same file checks the predicate against concrete scenarios; a general theorem over all reachable states is not yet proven, and the file says so.
+
 This is a companion to the prose specification, not a replacement for it. Its purpose is to make the protocol contract machine-verifiable — a second, checkable representation of the same rules that a prose reader can audit independently.
 
 ## Resonate Server
 
-The Resonate Server ([`resonatehq/resonate`](https://github.com/resonatehq/resonate), written in Rust) uses two test strategies on every pull request.
+The Resonate Server ([`resonatehq/resonate`](https://github.com/resonatehq/resonate), written in Rust) is tested in several layers on every pull request.
 
 ### Differential random testing
 
@@ -66,6 +92,10 @@ TEST_MYSQL_URL=mysql://<USER>:<PASSWORD>@localhost:3306/resonate \
 
 The server's unit tests run with `cargo test --all-features` and cover configuration parsing, transport message handling, and individual processing modules. CI gates every pull request on format (`cargo fmt`), compilation (`cargo check`), and linting (`cargo clippy --all-features -- -D warnings`) before tests run.
 
+### Conformance and linearizability
+
+A separate conformance testbed is checked out and run in the server's CI matrix on every pull request (visible in [`ci.yml`](https://github.com/resonatehq/resonate/blob/main/.github/workflows/ci.yml)): state-machine transition tests, randomized fuzz runs, and linearizability checking of concurrent operation histories with [Porcupine](https://github.com/anishathalye/porcupine). The testbed itself is not yet public — the CI steps that fetch and run it are.
+
 ## TypeScript SDK
 
 The TypeScript SDK ([`resonatehq/resonate-sdk-ts`](https://github.com/resonatehq/resonate-sdk-ts)) carries a conventional Jest test suite and a dedicated deterministic simulation test.
@@ -78,7 +108,7 @@ The harness uses a seeded linear-congruential PRNG. From a single integer seed, 
 
 A default run executes 10,000 steps. Three simulated worker processes and one simulated server process receive and process messages inside the harness, exercising recursive fan-out patterns (Fibonacci with local and remote calls) and multi-step chained functions.
 
-Determinism is verified explicitly: CI runs each seed twice and diffs the two log files. Different output from the same seed is a failing run. When a run fails, a GitHub issue is filed automatically with the seed, the commit SHA, and the exact command to reproduce it:
+Determinism is verified explicitly: CI runs each seed twice and diffs the two log files. Different output from the same seed is a failing run. When a run fails, a GitHub issue is filed automatically with the seed, the commit SHA, and the exact command to reproduce it — [issue #414](https://github.com/resonatehq/resonate-sdk-ts/issues/414) is one such report, filed by the harness with the seed, commit, and command included:
 
 ```shell title="Reproduce a DST failure"
 npm run dst -- --seed <seed> --steps 10000
@@ -107,3 +137,7 @@ The Go SDK ([`resonatehq/resonate-sdk-go`](https://github.com/resonatehq/resonat
 ## Java SDK
 
 The Java SDK ([`resonatehq/resonate-sdk-java`](https://github.com/resonatehq/resonate-sdk-java)) compiles against Java 21 and runs its test suite against Java 21, 24, and 25 via `./gradlew test`. CI also runs the SDK's examples end-to-end against a live server.
+
+## Where to go next
+
+To see the system these tests protect, the [quickstart](/get-started/quickstart) gets a durable function running in a few minutes. Questions about the testing approach are welcome in [Discord](https://resonatehq.io/discord).

--- a/content/docs/evaluate/how-resonate-is-tested.mdx
+++ b/content/docs/evaluate/how-resonate-is-tested.mdx
@@ -1,0 +1,109 @@
+---
+title: How Resonate is tested
+description: Testing approach across the Resonate server, each SDK, and the Lean 4 executable specification.
+keywords:
+  - evaluate
+  - testing
+  - correctness
+  - dst
+  - deterministic simulation
+  - specification
+---
+
+<Callout type="info" title="Versions">
+This page reflects Resonate Server v0.9.8, `@resonatehq/sdk` v0.11.2 (TypeScript), `resonate-sdk` v0.7.3 (Python), `resonate-sdk` v0.5.0 (Rust), `resonate-sdk` v0.1.1 (Java), and the Resonate Go SDK 0.1.0.
+</Callout>
+
+Resonate's correctness story rests on three foundations that reinforce each other: a machine-checkable formal companion to the protocol specification, differential random testing of the server implementation against a pure in-memory reference model, and deterministic simulation testing of the TypeScript SDK. Unit, integration, and end-to-end test suites across all five SDKs sit alongside these.
+
+## Lean 4 executable companion
+
+The [Distributed Async Await specification](https://distributed-async-await.io/spec) is the authoritative prose description of Resonate's protocol — the state machine governing promises, tasks, and schedules. Alongside it sits a Lean 4 executable, machine-checkable companion: [`resonatehq/resonate-specification`](https://github.com/resonatehq/resonate-specification).
+
+The companion encodes each protocol handler as a pure, deterministic, total function:
+
+```lean
+-- every handler has this shape:
+-- M = StateM ServerState, so "now" is the only input that carries time
+def promiseCreate (req : PromiseCreateReq) (now : Nat) : M PromiseCreateRes
+```
+
+State is touched only through named atomic effects — `getPromise` / `setPromise`, `getTask` / `setTask`, `getSchedule` / `setSchedule` / `delSchedule`, timeout management, and outbox writes. Handlers compose these effects and nothing else, which makes the model directly auditable and buildable with a single command:
+
+```shell title="Build the Lean companion"
+cd spec && lake build
+```
+
+The companion currently covers twenty handlers in full: five promise handlers (create, get, settle, register\_callback, register\_listener), ten task handlers (get, create, acquire, fence, heartbeat, suspend, fulfill, release, halt, continue), three schedule handlers (get, create, delete), and the two internal transitions (resume, timeouts). The three search handlers return a placeholder `501` response while their specs are being written.
+
+This is a companion to the prose specification, not a replacement for it. Its purpose is to make the protocol contract machine-verifiable — a second, checkable representation of the same rules that a prose reader can audit independently.
+
+## Resonate Server
+
+The Resonate Server ([`resonatehq/resonate`](https://github.com/resonatehq/resonate), written in Rust) uses two test strategies on every pull request.
+
+### Differential random testing
+
+[`diff/differential.rs`](https://github.com/resonatehq/resonate/blob/main/diff/differential.rs) defines a test named `differential_random`. It drives the same randomly-generated sequence of API operations through multiple backends at once — always an in-memory SQLite instance and an in-memory Oracle reference model; optionally Postgres and MySQL when environment variables supply connection URLs. After every operation the test asserts two things: that every backend returned the same HTTP status and response body, and that the complete server state (promises, tasks, messages, timeouts) matches across all backends.
+
+The Oracle is a pure Rust in-memory implementation of the protocol state machine, derived from the same handler rules encoded in the Lean 4 companion. A disagreement between the Oracle and any concrete storage backend is an immediate test failure, with a precise field-level diff showing the divergence.
+
+Coverage is enforced: the test runs until all twenty-two operation kinds in the API have each produced at least one 2xx response, then continues until no new operation signatures appear for twenty consecutive batches of two hundred steps. CI runs this against all three storage backends — SQLite, Postgres, and MySQL — as a matrix on every pull request.
+
+To run it locally:
+
+```shell title="Run the differential test locally"
+# SQLite + Oracle only (no external database required):
+cargo test --test differential -- --nocapture
+
+# All backends:
+TEST_POSTGRES_URL=postgres://<USER>:<PASSWORD>@localhost:5432/resonate \
+TEST_MYSQL_URL=mysql://<USER>:<PASSWORD>@localhost:3306/resonate \
+  cargo test --test differential -- --nocapture
+```
+
+### Unit tests
+
+The server's unit tests run with `cargo test --all-features` and cover configuration parsing, transport message handling, and individual processing modules. CI gates every pull request on format (`cargo fmt`), compilation (`cargo check`), and linting (`cargo clippy --all-features -- -D warnings`) before tests run.
+
+## TypeScript SDK
+
+The TypeScript SDK ([`resonatehq/resonate-sdk-ts`](https://github.com/resonatehq/resonate-sdk-ts)) carries a conventional Jest test suite and a dedicated deterministic simulation test.
+
+### Deterministic simulation testing
+
+The DST harness lives in [`sim/`](https://github.com/resonatehq/resonate-sdk-ts/tree/main/sim) and runs on a schedule via [`.github/workflows/dst.yml`](https://github.com/resonatehq/resonate-sdk-ts/blob/main/.github/workflows/dst.yml) — every twenty minutes, across Ubuntu, Windows, and macOS, against Node 18, 20, and 22.
+
+The harness uses a seeded linear-congruential PRNG. From a single integer seed, it derives the full behavior of the run: which function to invoke at each step, whether a message is dropped, duplicated, or delayed, and whether a worker process goes inactive. Configurable probabilities — `dropProb`, `duplProb`, `randomDelay`, `deactivateProb`, `activateProb` — default to values drawn from the same PRNG so the entire run is reproducible from the seed alone.
+
+A default run executes 10,000 steps. Three simulated worker processes and one simulated server process receive and process messages inside the harness, exercising recursive fan-out patterns (Fibonacci with local and remote calls) and multi-step chained functions.
+
+Determinism is verified explicitly: CI runs each seed twice and diffs the two log files. Different output from the same seed is a failing run. When a run fails, a GitHub issue is filed automatically with the seed, the commit SHA, and the exact command to reproduce it:
+
+```shell title="Reproduce a DST failure"
+npm run dst -- --seed <seed> --steps 10000
+```
+
+### Jest unit and integration suite
+
+The Jest suite covers the core execution engine, coroutine scheduling, retry policies, network transport, codec, encryption, and function registry. It runs via `npm test` in CI alongside linting and type checks.
+
+## Python SDK
+
+The Python SDK ([`resonatehq/resonate-sdk-py`](https://github.com/resonatehq/resonate-sdk-py)) runs `pytest` with branch coverage on Python 3.12, 3.13, and 3.14 across Ubuntu, macOS, and Windows.
+
+The suite includes [`tests/test_invariants.py`](https://github.com/resonatehq/resonate-sdk-py/blob/main/tests/test_invariants.py), which formalizes the structural replay contract of the SDK's execution tree model. The invariants capture properties from the internal `tree.md` specification — among them that a node's settler type is fixed across replays (R1), that settled promise records never retreat to pending (R2), that the execution tree reaches a fixed point after the first replay under an unchanged cache, and that the frontier shrinks monotonically as steps settle. Each invariant is driven across a battery of workflow shapes, and the test asserts the property at every step of the settle-to-done trajectory rather than only at the final state.
+
+CI also runs the Python SDK's examples end-to-end against a live Resonate server binary, downloaded from the public release page.
+
+## Rust SDK
+
+The Rust SDK ([`resonatehq/resonate-sdk-rs`](https://github.com/resonatehq/resonate-sdk-rs)) runs `cargo test --workspace` for its unit suite and `cargo test -p resonate-sdk --test e2e` for end-to-end tests against a live server. The e2e suite runs in CI against a server container on every pull request and covers durable function execution, fan-out/fan-in, promise resolution, retry behavior, and heartbeating.
+
+## Go SDK
+
+The Go SDK ([`resonatehq/resonate-sdk-go`](https://github.com/resonatehq/resonate-sdk-go)) runs `go test -race -timeout 5m ./...` — the Go race detector is enabled on every test run. End-to-end tests in [`e2e_test.go`](https://github.com/resonatehq/resonate-sdk-go/blob/main/e2e_test.go) target a live Resonate server and cover the full execution lifecycle: durable sleep, fan-out, promise resolution, and load balancing across worker groups. Without `RESONATE_URL` set, the e2e tests skip cleanly so `go test ./...` works without a server.
+
+## Java SDK
+
+The Java SDK ([`resonatehq/resonate-sdk-java`](https://github.com/resonatehq/resonate-sdk-java)) compiles against Java 21 and runs its test suite against Java 21, 24, and 25 via `./gradlew test`. CI also runs the SDK's examples end-to-end against a live server.

--- a/content/docs/evaluate/index.mdx
+++ b/content/docs/evaluate/index.mdx
@@ -16,5 +16,6 @@ Evaluate Resonate to understand its capabilities and how it works.
   <Card title="Why Resonate" description="Understand Resonate's capabilities and how you can benefit." href="/evaluate/why-resonate" />
   <Card title="How Resonate works" description="Architecture overview of checkpoints, replay, and message flow." href="/evaluate/how-it-works" />
   <Card title="Coming from other systems" description="Compare Resonate with Temporal, Restate, DBOS, and more." href="/evaluate/coming-from" />
+  <Card title="How Resonate is tested" description="The specification, differential testing, and simulation behind the correctness story." href="/evaluate/how-resonate-is-tested" />
 </CardGrid>
 

--- a/content/docs/evaluate/why-resonate.mdx
+++ b/content/docs/evaluate/why-resonate.mdx
@@ -53,7 +53,7 @@ Two things should give you confidence in Resonate&apos;s correctness:
 
 **Deterministic Simulation Testing.** Every major component &mdash; the Resonate Server and each SDK &mdash; is subjected to DST. This finds complex edge cases long before they reach production, on top of conventional unit and integration tests.
 
-The new server is also linearizable. Combined with DST, this is the foundation of the correctness story. The full approach &mdash; with links to the test code, the CI workflows, and the Lean 4 companion &mdash; is on [How Resonate is tested](/evaluate/how-resonate-is-tested).
+The new server is also linearizable. Combined with DST, this is the foundation of the correctness story. The full approach &mdash; with links to the test code, the CI workflows, and the Lean 4 model &mdash; is on [How Resonate is tested](/evaluate/how-resonate-is-tested).
 
 ## Open everything
 

--- a/content/docs/evaluate/why-resonate.mdx
+++ b/content/docs/evaluate/why-resonate.mdx
@@ -53,7 +53,7 @@ Two things should give you confidence in Resonate&apos;s correctness:
 
 **Deterministic Simulation Testing.** Every major component &mdash; the Resonate Server and each SDK &mdash; is subjected to DST. This finds complex edge cases long before they reach production, on top of conventional unit and integration tests.
 
-The new server is also linearizable. Combined with DST, this is the foundation of the correctness story.
+The new server is also linearizable. Combined with DST, this is the foundation of the correctness story. The full approach &mdash; with links to the test code, the CI workflows, and the Lean 4 companion &mdash; is on [How Resonate is tested](/evaluate/how-resonate-is-tested).
 
 ## Open everything
 


### PR DESCRIPTION
Adds an Evaluate page documenting the testing approach across the estate, plus two cross-links.

**New page: `/evaluate/how-resonate-is-tested`**
- Lean 4 executable companion: handler coverage (twenty in full, three search stubs), and the durable-execution guarantee quoted as the executable predicate from `spec/02-actions/04-guarantee.lean`, with an honest note that a general theorem is not yet proven.
- Resonate Server: differential random testing (`diff/differential.rs` — oracle vs SQLite always, Postgres/MySQL via env vars, 22 operation kinds), unit tests, and the conformance/linearizability testbed run in CI (disclosed as not yet public; the CI steps that fetch it are linked).
- TypeScript SDK: the `sim/` DST harness, the 20-minute cron across 3 OS × 3 Node × 2 reproducibility runs, and a link to an example auto-filed seed issue (#414).
- Per-SDK test suites for Python (invariants), Rust, Go, and Java.
- Closing pointers to the quickstart and Discord.

**Cross-links**
- `why-resonate` "Quality is not optional" now links to the new page (previously anchored to itself).
- `coming-from/byode` "Proven correctness" bullet links to the new page.

Build + link check pass locally (471 links, 0 internal broken). Version callout reflects current releases (server v0.9.8, TS v0.11.2, Python v0.7.4, Rust 0.5.0, Java v0.1.1, Go 0.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)