### PR TITLE
Fix Supabase shim install instruction (JSR, not npm)

### DIFF
--- a/content/docs/deploy/serverless-workers.mdx
+++ b/content/docs/deploy/serverless-workers.mdx
@@ -105,8 +105,10 @@ Ready to use example apps:
 
 **Quick example:**
 
+Supabase Edge Functions run on Deno, so the shim is published on [JSR](https://jsr.io/@resonatehq/supabase) rather than npm.
+
 ```shell title="Install the shim package"
-npm install @resonatehq/supabase
+deno add jsr:@resonatehq/supabase
 ```
 
 Instead of importing Resonate from the SDK package, import it from the Supabase shim package.

--- a/content/docs/deploy/serverless-workers.mdx
+++ b/content/docs/deploy/serverless-workers.mdx
@@ -103,9 +103,9 @@ Ready to use example apps:
 
 [Supabase Edge Functions worker shim | **TypeScript**](https://github.com/resonatehq/resonate-faas-supabase-ts)
 
-**Quick example:**
+Supabase Edge Functions run on Deno; the shim is published on [JSR](https://jsr.io/@resonatehq/supabase) rather than npm.
 
-Supabase Edge Functions run on Deno, so the shim is published on [JSR](https://jsr.io/@resonatehq/supabase) rather than npm.
+**Quick example:**
 
 ```shell title="Install the shim package"
 deno add jsr:@resonatehq/supabase


### PR DESCRIPTION
The Supabase Edge Functions section on the serverless workers page instructs `npm install @resonatehq/supabase`, but the shim is published on JSR (Supabase Edge Functions run on Deno). Following the current instruction fails — the package does not exist on npm.

Replaces the install block with `deno add jsr:@resonatehq/supabase` (which keeps the existing bare-specifier import in the code sample working) and adds a one-line note that the shim lives on JSR, distinct from the Node-based FaaS shims on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)