### PR TITLE
docs(rust): align Rust SDK docs to 0.6.0

### DIFF
--- a/content/docs/develop/rust.mdx
+++ b/content/docs/develop/rust.mdx
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <Callout type="caution" title="Early development">
-The Rust SDK is at 0.4.0 and in active development. APIs may change between releases.
+The Rust SDK is at 0.6.0 and in active development. APIs may change between releases.
 </Callout>
 
 Whether you are a human or an AI agent, this skill guide will help you develop applications using the Resonate Rust SDK.
@@ -29,7 +29,7 @@ The Rust SDK is published on crates.io as `resonate-sdk`. Add it to your `Cargo.
 
 ```toml title="Cargo.toml"
 [dependencies]
-resonate = { package = "resonate-sdk", version = "0.4" }
+resonate = { package = "resonate-sdk", version = "0.6" }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 ```
@@ -87,6 +87,38 @@ let resonate = Resonate::local();
 Local development mode can be suitable for awhile.
 However, when you want to run multiple worker processes, persist state across restarts, or share work between machines, you will need to connect to a Resonate Server.
 See the [Quickstart guide](/get-started/quickstart) or [How to run a Resonate Server](/deploy/run-server) for guidance on getting a server up and running.
+
+### Postgres-backed durable execution
+
+Alongside the in-memory local network and a remote Resonate Server, the Rust SDK can run durable execution directly on **Postgres** — with no separate Resonate Server process. The Resonate protocol runs as stored procedures in a `resonate` schema in your database (see [resonate-pg](https://github.com/resonatehq/resonate-pg)), and your workers talk to Postgres directly.
+
+Add the Postgres network crate alongside the SDK:
+
+```toml title="Cargo.toml"
+[dependencies]
+resonate = { package = "resonate-sdk", version = "0.6" }
+resonate-postgres = { package = "resonate-sdk-postgres", version = "0.6" }
+```
+
+Apply the `resonate.sql` schema (from [resonate-pg](https://github.com/resonatehq/resonate-pg)) to a Postgres 16+ database, then wire a `PostgresNetwork` into the Resonate instance:
+
+```rust title="main.rs"
+use std::sync::Arc;
+use resonate::prelude::*;
+use resonate_postgres::PostgresNetwork;
+
+// Pass your Postgres connection string (for example, from the DATABASE_URL environment variable).
+let network = PostgresNetwork::builder("postgres://localhost:5432/mydb")
+    .group("workers")
+    .build();
+
+let resonate = Resonate::new(ResonateConfig {
+    network: Some(Arc::new(network)),
+    ..Default::default()
+});
+```
+
+Workers receive dispatched work over Postgres `LISTEN`/`NOTIFY` (with a periodic fallback poll), and due timers advance whenever a worker is running. This keeps the entire durable-execution stack on infrastructure you already run — a good fit for serverless and Postgres-centric deployments.
 
 ### Authentication
 
@@ -256,14 +288,14 @@ Resonate's `.rpc()` method (Remote Procedure Call) invokes a function in a remot
 You can think of it as a "run somewhere else" invocation.
 
 ```rust
-let result: String = resonate.rpc("invocation-id", "my_workflow", "input".into()).await?;
+let result: String = resonate.rpc("invocation-id", "my_workflow", "input").await?;
 ```
 
 The builder supports `.timeout()`, `.version()`, `.tags()`, and `.target()`:
 
 ```rust
 let result: String = resonate
-    .rpc("invocation-id", "my_workflow", "input".into())
+    .rpc("invocation-id", "my_workflow", "input")
     .target("poll://any@workers")
     .await?;
 ```
@@ -274,7 +306,7 @@ Schedule a function to be invoked on a cron schedule.
 
 ```rust
 let schedule = resonate
-    .schedule("my-schedule", "0 * * * *", "my_workflow", "input".into())
+    .schedule("my-schedule", "0 * * * *", "my_workflow", "input")
     .await?;
 
 // Later, delete the schedule
@@ -380,8 +412,8 @@ Use `.spawn()` to run in parallel and get a `DurableFuture` handle:
 ```rust
 #[resonate::function]
 async fn my_workflow(ctx: &Context) -> Result<(String, String)> {
-    let future_a = ctx.run(process, "a".into()).spawn().await?;
-    let future_b = ctx.run(process, "b".into()).spawn().await?;
+    let future_a = ctx.run(process, "a".into()).spawn()?;
+    let future_b = ctx.run(process, "b".into()).spawn()?;
 
     let result_a = future_a.await?;
     let result_b = future_b.await?;
@@ -408,8 +440,8 @@ Use `.spawn()` for parallel remote invocations:
 ```rust
 #[resonate::function]
 async fn my_workflow(ctx: &Context) -> Result<()> {
-    let f1 = ctx.rpc::<String>("worker-a", "data".into()).spawn().await?;
-    let f2 = ctx.rpc::<String>("worker-b", "data".into()).spawn().await?;
+    let f1 = ctx.rpc::<String>("worker-a", "data").spawn()?;
+    let f2 = ctx.rpc::<String>("worker-b", "data").spawn()?;
 
     f1.await?;
     f2.await?;

--- a/content/docs/develop/rust.mdx
+++ b/content/docs/develop/rust.mdx
@@ -430,7 +430,7 @@ The calling function blocks until the remote function returns.
 ```rust
 #[resonate::function]
 async fn my_workflow(ctx: &Context) -> Result<String> {
-    let result = ctx.rpc::<String>("remote-func", "input".into()).await?;
+    let result = ctx.rpc::<String>("remote-func", "input").await?;
     Ok(result)
 }
 ```

--- a/content/docs/develop/rust.mdx
+++ b/content/docs/develop/rust.mdx
@@ -320,7 +320,7 @@ schedule.delete().await?;
 Get a handle to an existing execution by its promise ID.
 
 ```rust
-let mut handle = resonate.get::<String>("invocation-id").await?;
+let handle = resonate.get::<String>("invocation-id").await?;
 let result = handle.result().await?;
 ```
 
@@ -367,7 +367,7 @@ async fn main() {
     let resonate = Resonate::local();
     resonate.register(greet).unwrap();
 
-    let result: String = resonate.run("greet-1", greet, "world").await.unwrap();
+    let result: String = resonate.run("greet-1", greet, "world".into()).await.unwrap();
     println!("{result}");
 
     // Required for the process to exit.

--- a/content/docs/develop/rust.mdx
+++ b/content/docs/develop/rust.mdx
@@ -118,7 +118,9 @@ let resonate = Resonate::new(ResonateConfig {
 });
 ```
 
-Workers receive dispatched work over Postgres `LISTEN`/`NOTIFY` (with a periodic fallback poll), and due timers advance whenever a worker is running. This keeps the entire durable-execution stack on infrastructure you already run — a good fit for serverless and Postgres-centric deployments.
+Workers receive dispatched work over Postgres `LISTEN`/`NOTIFY` (with a periodic fallback poll), and due timers advance whenever a worker is running. Because there is no standalone server process, **durable sleeps and timeouts advance only while at least one worker is connected** — with every worker down, they are suspended until a worker reconnects (a standalone Resonate Server advances timers on its own). This keeps the durable-execution stack on infrastructure you already run, with Postgres handling promise state and routing — a good fit for serverless and Postgres-centric deployments.
+
+Like the SDK itself, `resonate-sdk-postgres` is pre-1.0 and in active development; its API may change between releases.
 
 ### Authentication
 

--- a/content/docs/evaluate/coming-from/dbos.mdx
+++ b/content/docs/evaluate/coming-from/dbos.mdx
@@ -925,7 +925,7 @@ The Resonate Rust equivalent awaits a latent durable promise and resolves it fro
 #[resonate::function]
 async fn foo(ctx: &Context) -> Result<()> {
     // Latent durable promise — no function backing it. Resolved externally.
-    let blocking_promise = ctx.promise::<bool>();
+    let blocking_promise = ctx.promise::<bool>().create()?;
     let _promise_id = blocking_promise.id().await?;
     // ...
     // suspend until the promise is resolved (survives crashes)

--- a/content/docs/evaluate/coming-from/dbos.mdx
+++ b/content/docs/evaluate/coming-from/dbos.mdx
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <Callout type="info" title="SDK version">
-This page reflects `@resonatehq/sdk` v0.11.2 (TypeScript, current on npm), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.4.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
+This page reflects `@resonatehq/sdk` v0.11.2 (TypeScript, current on npm), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
 </Callout>
 
 <Callout type="info" title="About the code">
@@ -543,9 +543,9 @@ The Resonate Rust equivalent fans out with `.spawn()`:
 
 ```rust title="Resonate — example-fan-out-fan-in-rs/src/main.rs"
 // fan-out: .spawn() returns a handle immediately
-let h1 = ctx.run(process_item, items[0].clone()).spawn().await?;
-let h2 = ctx.run(process_item, items[1].clone()).spawn().await?;
-let h3 = ctx.run(process_item, items[2].clone()).spawn().await?;
+let h1 = ctx.run(process_item, items[0].clone()).spawn()?;
+let h2 = ctx.run(process_item, items[1].clone()).spawn()?;
+let h3 = ctx.run(process_item, items[2].clone()).spawn()?;
 // fan-in: await each
 let r1 = h1.await?;
 let r2 = h2.await?;

--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -601,7 +601,7 @@ await resonate.promises.resolve(promiseId, { data });
 #[resonate::function]
 async fn foo(ctx: &Context) -> Result<()> {
     // Latent durable promise — no function backing it. Resolved externally.
-    let blocking_promise = ctx.promise::<bool>();
+    let blocking_promise = ctx.promise::<bool>().create()?;
     let _promise_id = blocking_promise.id().await?;
     // ...
     // suspend until the promise is resolved (survives crashes)

--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <Callout type="info" title="SDK version">
-This page reflects `@resonatehq/sdk` v0.11.2 (TypeScript, current on npm), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.4.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
+This page reflects `@resonatehq/sdk` v0.11.2 (TypeScript, current on npm), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
 </Callout>
 
 **Are you coming from Temporal?**
@@ -835,8 +835,8 @@ const results = [yield* emailFuture, yield* smsFuture];
 
 ```rust title="Resonate — example-fan-out-fan-in-rs/src/main.rs"
 // fan-out: .spawn() returns a handle immediately
-let h1 = ctx.run(process_item, items[0].clone()).spawn().await?;
-let h2 = ctx.run(process_item, items[1].clone()).spawn().await?;
+let h1 = ctx.run(process_item, items[0].clone()).spawn()?;
+let h2 = ctx.run(process_item, items[1].clone()).spawn()?;
 // fan-in: await each
 let r1 = h1.await?;
 let r2 = h2.await?;

--- a/content/docs/evaluate/how-resonate-is-tested.mdx
+++ b/content/docs/evaluate/how-resonate-is-tested.mdx
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <Callout type="info" title="Versions">
-This page reflects Resonate Server v0.9.8, `@resonatehq/sdk` v0.11.2 (TypeScript), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.5.0 (Rust), `resonate-sdk` v0.1.1 (Java), and the Resonate Go SDK 0.1.0.
+This page reflects Resonate Server v0.9.8, `@resonatehq/sdk` v0.11.2 (TypeScript), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust), `resonate-sdk` v0.1.1 (Java), and the Resonate Go SDK 0.1.0.
 </Callout>
 
 Resonate's correctness story rests on three foundations that reinforce each other: an executable formal specification of the protocol in Lean 4, differential random testing of the server implementation against a pure in-memory reference model, and deterministic simulation testing of the TypeScript SDK. Unit, integration, and end-to-end test suites across all five SDKs sit alongside these.

--- a/content/docs/get-started/examples/async-agent-tools.mdx
+++ b/content/docs/get-started/examples/async-agent-tools.mdx
@@ -16,7 +16,7 @@ keywords:
 A FastMCP server exposes three tools — start, probe, await — backed by a durable Resonate workflow. The LLM kicks off long jobs, polls them, and collects results without blocking on the work.
 
 <Callout type="info" title="SDK versions">
-Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. TypeScript SDK example repo is forthcoming.
+Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. TypeScript SDK example repo is forthcoming.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/async-http-api-endpoints.mdx
+++ b/content/docs/get-started/examples/async-http-api-endpoints.mdx
@@ -16,7 +16,7 @@ keywords:
 A FastAPI gateway converts every inbound request into a durable workflow, returns a promise ID immediately, and exposes a `/wait` endpoint clients poll for completion.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/deep-research-agent.mdx
+++ b/content/docs/get-started/examples/deep-research-agent.mdx
@@ -17,7 +17,7 @@ keywords:
 A research agent receives a broad topic, asks an LLM to break it into 2–3 subtopics, and recursively dispatches each subtopic to itself. Every LLM call and every recursive subagent is a durable promise — kill the worker mid-research, the tree resumes from the last unanswered branch.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>
@@ -177,7 +177,7 @@ async fn research(ctx: &Context, topic: String, depth: u32) -> Result<String> {
             for tc in tool_calls {
                 let args: Value = serde_json::from_str(tc["function"]["arguments"].as_str().unwrap())?;
                 if tc["function"]["name"] == "research" {
-                    let h = ctx.run(research, (args["topic"].as_str().unwrap().into(), depth - 1)).spawn().await?;
+                    let h = ctx.run(research, (args["topic"].as_str().unwrap().into(), depth - 1)).spawn()?;
                     handles.push((tc.clone(), h));
                 }
             }

--- a/content/docs/get-started/examples/durable-sleep.mdx
+++ b/content/docs/get-started/examples/durable-sleep.mdx
@@ -15,7 +15,7 @@ keywords:
 A workflow yields `ctx.sleep` and the runtime suspends it. Hours, days, or weeks later the worker wakes the workflow up exactly where it stopped — no cron, no scheduler, no external state.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/fan-out-fan-in.mdx
+++ b/content/docs/get-started/examples/fan-out-fan-in.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow spawns four notification channels (email, SMS, Slack, push) in parallel and joins their results. Total wall time approaches the slowest channel, not the sum. If one channel fails and retries, the others stay checkpointed — they don't re-send.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>
@@ -153,9 +153,9 @@ struct WorkResult { id: u32, output: String }
 #[resonate::function]
 async fn fan_out_fan_in(ctx: &Context, items: Vec<WorkItem>) -> Result<Vec<WorkResult>> {
     // Fan-out: spawn three items in parallel.
-    let h1 = ctx.run(process_item, items[0].clone()).spawn().await?;
-    let h2 = ctx.run(process_item, items[1].clone()).spawn().await?;
-    let h3 = ctx.run(process_item, items[2].clone()).spawn().await?;
+    let h1 = ctx.run(process_item, items[0].clone()).spawn()?;
+    let h2 = ctx.run(process_item, items[1].clone()).spawn()?;
+    let h3 = ctx.run(process_item, items[2].clone()).spawn()?;
 
     // Fan-in: each handle is individually durable.
     let r1 = h1.await?;

--- a/content/docs/get-started/examples/hello-world.mdx
+++ b/content/docs/get-started/examples/hello-world.mdx
@@ -15,7 +15,7 @@ keywords:
 The smallest example that exercises the durable execution loop. A registered workflow function calls two leaf functions through `ctx.run`, and Resonate checkpoints each return value.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/human-in-the-loop.mdx
+++ b/content/docs/get-started/examples/human-in-the-loop.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow blocks on a durable promise, prints a callback URL, and resumes the moment a human resolves it — from any process, any machine, any time.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development — published on crates.io as `resonate-sdk`; this example pulls it as a git dependency from `resonate-sdk-rs` to track `main`.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/human-in-the-loop.mdx
+++ b/content/docs/get-started/examples/human-in-the-loop.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow blocks on a durable promise, prints a callback URL, and resumes the moment a human resolves it — from any process, any machine, any time.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development — published on crates.io as `resonate-sdk`; this example pulls it as a git dependency from `resonate-sdk-rs` to track `main`.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development — published on crates.io as `resonate-sdk`; this example pulls it as a git dependency from `resonate-sdk-rs` to track `main`.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/human-in-the-loop.mdx
+++ b/content/docs/get-started/examples/human-in-the-loop.mdx
@@ -133,7 +133,7 @@ use resonate::prelude::*;
 #[resonate::function]
 async fn foo(ctx: &Context, workflow_id: String) -> Result<String> {
     // Latent durable promise — resolved externally.
-    let blocking_promise = ctx.promise::<bool>();
+    let blocking_promise = ctx.promise::<bool>().create()?;
     let promise_id = blocking_promise.id().await?;
 
     // Make the promise ID reachable from outside — email, webhook, log, etc.

--- a/content/docs/get-started/examples/kafka-worker.mdx
+++ b/content/docs/get-started/examples/kafka-worker.mdx
@@ -16,7 +16,7 @@ keywords:
 A consumer pulls messages from a Kafka topic and dispatches each one through a durable Resonate workflow. Per-message state lives in durable promises, so a worker that dies mid-batch resumes cleanly without redoing completed steps.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <Callout type="note" title="Kafka or Redpanda — same code">

--- a/content/docs/get-started/examples/load-balancing.mdx
+++ b/content/docs/get-started/examples/load-balancing.mdx
@@ -15,7 +15,7 @@ keywords:
 Run several workers in the same group. Calls to `target: "poll://any@<group>"` get dispatched to whichever worker claims them first. When a worker dies mid-execution, Resonate reassigns the work to a survivor — no service registry, no leader election, no glue.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/money-transfer.mdx
+++ b/content/docs/get-started/examples/money-transfer.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow debits the source account, credits the target account, and returns confirmations. Each account update is a durable checkpoint, the transfer ID is the idempotency key, and the same ID retried in seconds, hours, or days returns the cached result instead of double-spending.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/recursive-factorial.mdx
+++ b/content/docs/get-started/examples/recursive-factorial.mdx
@@ -15,7 +15,7 @@ keywords:
 A workflow that computes `n!` by calling itself with `n-1`. Each recursive call dispatches via `ctx.rpc` to whichever worker in the group claims it — recursion ends up distributed across machines without any explicit coordination, and every step is checkpointed so a worker crash mid-recursion resumes cleanly.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/schedule.mdx
+++ b/content/docs/get-started/examples/schedule.mdx
@@ -16,7 +16,7 @@ keywords:
 Register a function to run on a cron expression and Resonate handles the rest. Every fired execution is a durable workflow — a worker that crashes mid-run hands off to a survivor, and a missed run because all workers were down still gets dispatched when one comes back.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.4.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/quickstart.mdx
+++ b/content/docs/get-started/quickstart.mdx
@@ -55,7 +55,7 @@ pip install resonate-sdk
 
 ```toml title="Cargo.toml"
 [dependencies]
-resonate = { package = "resonate-sdk", git = "https://github.com/resonatehq/resonate-sdk-rs", branch = "main" }
+resonate = { package = "resonate-sdk", version = "0.6" }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 ```

--- a/content/docs/reference/schedules.mdx
+++ b/content/docs/reference/schedules.mdx
@@ -58,7 +58,7 @@ Every fired promise needs a routing target, or no worker group will ever receive
 ```
 
 <Callout type="note" title="Server version">
-On v0.9.8 (the current release) and earlier, the server **accepts** an untagged `schedule.create` — the schedule fires, but its promises are never dispatched to any worker. SDK releases that carry the schedule fixes (Python `resonate-sdk` ≥0.7.4) enforce the rejection above in their in-process (local) networks regardless of server version.
+On v0.9.8 (the current release) and earlier, the server **accepts** an untagged `schedule.create` — the schedule fires, but its promises are never dispatched to any worker. SDK releases that carry the schedule fixes (Python `resonate-sdk` ≥0.7.4, Rust `resonate-sdk` ≥0.6.0) enforce the rejection above in their in-process (local) networks regardless of server version.
 </Callout>
 
 The value is an address like `poll://any@default` — the same convention as `resonate invoke --target` and the SDKs' `target` option. The high-level `schedule()` APIs that inject this tag for you take the target from the same option surface as `run`/`rpc`; the low-level schedule sub-clients and the CLI require you to pass it explicitly:


### PR DESCRIPTION
Aligns the Rust SDK documentation to `resonate-sdk` 0.6.0 (crates.io).

## What changed
- **Version references** bumped to 0.6.0 across the Rust develop page, the example pages' version notices, and the DBOS/Temporal comparison pages.
- **Parallel-execution examples** updated for the current API: inside a durable function, `ctx.run(...)` / `ctx.rpc(...)` `.spawn()` is synchronous and returns the `DurableFuture` directly — it no longer takes `.await`. Client-side `resonate.run/rpc(...).spawn().await` is unchanged.
- **By-name call arguments** in the `ctx.rpc` / `resonate.rpc` / `.schedule` examples now pass a concrete `Serialize` value instead of `.into()` (the target type of `.into()` can't be inferred for these generic, by-name arguments).
- **New section:** *Postgres-backed durable execution* on the Rust develop page — using `resonate-sdk-postgres` (`PostgresNetwork`) to run durable execution directly on Postgres via [resonate-pg](https://github.com/resonatehq/resonate-pg), with no separate Resonate Server.

## Verification
- All Rust snippets compile against `resonate-sdk` 0.6.0 + `resonate-sdk-postgres` 0.6.0 from crates.io.
- `npm run build` clean; link check 485 links, 0 internal broken.