### PR TITLE
docs: document resonate:delay tag + Java schedule target caveat (last of #241)

### DIFF
--- a/content/docs/develop/java.mdx
+++ b/content/docs/develop/java.mdx
@@ -372,6 +372,12 @@ daily.delete(); // remove the schedule when no longer needed
 
 The lower-level `r.schedules` sub-client (`create` / `get` / `delete` / `search`) is available for direct schedule manipulation.
 
+Every promise a schedule fires needs a `resonate:target` tag, or no worker group receives it — the server release after v0.9.8 rejects a create without it. Cron expressions are evaluated in **UTC** with Quartz day-of-week numbering (`1` = Sunday); prefer day names like `MON-FRI`. See the [Schedules & cron reference](/reference/schedules) for the expression format, promise-ID templates, and the tags the server injects on fired promises.
+
+<Callout type="caution" title="`schedule()` currently fails against a real server">
+`r.schedule(...)` and `r.schedules.create(...)` send empty `promiseTags`, so the server rejects the create with `400 promiseTags must include a resonate:target tag` (and on older servers the schedule fires but its promises are never dispatched). Tracked in [resonatehq/resonate-sdk-java#6](https://github.com/resonatehq/resonate-sdk-java/issues/6); this page will show the working target-routing form once the fix lands.
+</Callout>
+
 ### `Resonate.stop`
 
 Gracefully shuts down a Resonate instance. Stops the network connection, joins outstanding background jobs, cancels the subscription-refresh loop, and shuts down the heartbeat. Idempotent.

--- a/content/docs/reference/cli.mdx
+++ b/content/docs/reference/cli.mdx
@@ -197,6 +197,19 @@ resonate promises create my-run-002 \
 
 `--param` and `--tags` are parsed as JSON ([`cli.rs:495-498`](https://github.com/resonatehq/resonate/blob/main/src/cli.rs#L495-L498)). The `data` field inside `--param` is automatically base64-encoded ([`cli.rs:500-508`](https://github.com/resonatehq/resonate/blob/main/src/cli.rs#L500-L508)) — pass it as a regular JSON value, the CLI handles encoding.
 
+#### The `resonate:delay` tag
+
+A promise tagged `resonate:delay` has its **task dispatch held back** until the given time — the server waits to send the task to a worker until the deadline elapses, instead of enqueueing it immediately (added in [resonatehq/resonate#844](https://github.com/resonatehq/resonate/pull/844)). The value is an absolute Unix epoch time in **milliseconds**, not a duration:
+
+```shell
+# Create the promise now, but don't dispatch its task until 2026-01-01T00:00:00Z
+resonate promises create nightly-kickoff \
+  --timeout 24h \
+  --tags '{"resonate:target": "poll://any@default", "resonate:delay": "1767225600000"}'
+```
+
+Use it for a one-shot deferred invocation. For recurring work, use a [schedule](#resonate-schedules) instead.
+
 ### `resonate promises resolve | reject | cancel`
 
 All three settle a pending promise; they differ only in the final state ([`cli.rs:642-652`](https://github.com/resonatehq/resonate/blob/main/src/cli.rs#L642-L652)).


### PR DESCRIPTION
Closes out the two remaining open items from #241. The bulk of that issue was already resolved by #242 (cron reference page + CLI guide/reference fixes) and #250 (Python/version alignment); this PR handles what was still genuinely missing after re-checking every checkbox against `main`.

### 1. `reference/cli.mdx` — document the `resonate:delay` tag
The server has supported `resonate:delay` since resonatehq/resonate#844 (hold task dispatch until an absolute epoch-ms deadline) but it appeared in **no** doc. Added a subsection under `resonate promises create` with a worked example and the epoch-ms-not-duration gotcha.

### 2. `develop/java.mdx` — target requirement + known-broken caveat
The Java `schedule()` example showed a cron with no `resonate:target`, which the server rejects (empty `promiseTags`, resonatehq/resonate-sdk-java#6 — still open). Added the UTC/Quartz + `resonate:target` note, a link to the cron reference, and a caution that the call currently fails, to be aligned to the working form once the SDK fix lands.

### Not in this PR (already done on `main`, for reviewer cross-check)
- Cross-SDK cron/schedules reference page — done (#242)
- `python.mdx` / `go.mdx` / `typescript.mdx` schedule sections — done (target routing, delete/search, cron-ref links present)
- CLI guide broken schedule/search examples — fixed (#242)
- `reference/cli.mdx` `--cron` UTC/day-of-week caveat — present
- `get-started/examples/schedule.mdx` stale versions — refreshed to v0.11.2 / v0.7.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)