### PR TITLE
docs(evaluate): SEO titles/descriptions for comparison pages + pillar link

### DIFF
--- a/content/docs/evaluate/coming-from/dbos.mdx
+++ b/content/docs/evaluate/coming-from/dbos.mdx
@@ -1,9 +1,11 @@
 ---
-title: Coming from DBOS
-description: Compare Resonate with DBOS to understand key differences and similarities.
+title: DBOS vs Resonate
+description: A side-by-side comparison of DBOS and Resonate for durable execution — programming model, dependencies, and deployment — to help you evaluate Resonate as a DBOS alternative.
 keywords:
   - evaluate
   - comparison
+  - dbos vs resonate
+  - dbos alternative
 ---
 
 <Callout type="info" title="SDK version">

--- a/content/docs/evaluate/coming-from/dbos.mdx
+++ b/content/docs/evaluate/coming-from/dbos.mdx
@@ -1,6 +1,6 @@
 ---
 title: DBOS vs Resonate
-description: A side-by-side comparison of DBOS and Resonate for durable execution — programming model, dependencies, and deployment — to help you evaluate Resonate as a DBOS alternative.
+description: Side-by-side comparison of DBOS and Resonate — programming model, deployment, and dependencies — to help you evaluate Resonate as a DBOS alternative.
 keywords:
   - evaluate
   - comparison

--- a/content/docs/evaluate/coming-from/index.mdx
+++ b/content/docs/evaluate/coming-from/index.mdx
@@ -8,9 +8,9 @@ keywords:
 ---
 
 <CardGrid>
-  <Card title="Coming from Temporal" description="Understand the differences and similarities between Temporal and Resonate." href="/evaluate/coming-from/temporal" />
-  <Card title="Coming from Restate" description="Compare Resonate with Restate to understand how the platforms differ." href="/evaluate/coming-from/restate" />
-  <Card title="Coming from DBOS" description="Compare Resonate with DBOS to understand key differences and similarities." href="/evaluate/coming-from/dbos" />
+  <Card title="Temporal vs Resonate" description="How Temporal and Resonate differ across programming model, deployment, and guarantees." href="/evaluate/coming-from/temporal" />
+  <Card title="Restate vs Resonate" description="How Restate and Resonate differ across programming model, deployment, and guarantees." href="/evaluate/coming-from/restate" />
+  <Card title="DBOS vs Resonate" description="How DBOS and Resonate differ across programming model, deployment, and dependencies." href="/evaluate/coming-from/dbos" />
   <Card title="Coming from BYODE" description="Compare Resonate with building your own durable execution stack." href="/evaluate/coming-from/byode" />
 </CardGrid>
 

--- a/content/docs/evaluate/coming-from/restate.mdx
+++ b/content/docs/evaluate/coming-from/restate.mdx
@@ -1,6 +1,6 @@
 ---
 title: Restate vs Resonate
-description: A side-by-side comparison of Restate and Resonate for durable execution — programming model, deployment, and guarantees — to help you evaluate Resonate as a Restate alternative.
+description: Side-by-side comparison of Restate and Resonate — programming model, deployment, and guarantees — to help you evaluate Resonate as a Restate alternative.
 keywords:
   - evaluate
   - comparison

--- a/content/docs/evaluate/coming-from/restate.mdx
+++ b/content/docs/evaluate/coming-from/restate.mdx
@@ -1,9 +1,11 @@
 ---
-title: Coming from Restate
-description: Compare Resonate with Restate to understand how the platforms differ.
+title: Restate vs Resonate
+description: A side-by-side comparison of Restate and Resonate for durable execution — programming model, deployment, and guarantees — to help you evaluate Resonate as a Restate alternative.
 keywords:
   - evaluate
   - comparison
+  - restate vs resonate
+  - restate alternative
 ---
 
 <Callout type="info" title="SDK version">

--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -1,9 +1,11 @@
 ---
-title: Coming from Temporal
-description: If you are coming from Temporal, this guide will help you understand the differences and similarities between Temporal and Resonate.
+title: Temporal vs Resonate
+description: A side-by-side comparison of Temporal and Resonate for durable execution — programming model, deployment, and guarantees — to help you evaluate Resonate as a Temporal alternative.
 keywords:
   - evaluate
   - comparison
+  - temporal vs resonate
+  - temporal alternative
 ---
 
 <Callout type="info" title="SDK version">

--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -1,6 +1,6 @@
 ---
 title: Temporal vs Resonate
-description: A side-by-side comparison of Temporal and Resonate for durable execution — programming model, deployment, and guarantees — to help you evaluate Resonate as a Temporal alternative.
+description: Side-by-side comparison of Temporal and Resonate — programming model, deployment, and guarantees — to help you evaluate Resonate as a Temporal alternative.
 keywords:
   - evaluate
   - comparison

--- a/content/docs/evaluate/how-resonate-is-tested.mdx
+++ b/content/docs/evaluate/how-resonate-is-tested.mdx
@@ -1,6 +1,6 @@
 ---
 title: How Resonate is tested
-description: How Resonate uses deterministic simulation testing (DST) to find concurrency and failure bugs conventional tests miss — across the server, every SDK, and a Lean 4 executable specification.
+description: How Resonate uses deterministic simulation testing (DST) to find concurrency and failure bugs conventional tests miss — server, every SDK, and a Lean 4 spec.
 keywords:
   - evaluate
   - testing

--- a/content/docs/evaluate/how-resonate-is-tested.mdx
+++ b/content/docs/evaluate/how-resonate-is-tested.mdx
@@ -1,6 +1,6 @@
 ---
 title: How Resonate is tested
-description: Testing approach across the Resonate server, each SDK, and the Lean 4 executable specification.
+description: How Resonate uses deterministic simulation testing (DST) to find concurrency and failure bugs conventional tests miss — across the server, every SDK, and a Lean 4 executable specification.
 keywords:
   - evaluate
   - testing

--- a/content/docs/evaluate/why-resonate.mdx
+++ b/content/docs/evaluate/why-resonate.mdx
@@ -7,7 +7,7 @@ keywords:
   - agent-native
 ---
 
-**Resonate is the durable execution engine that agents build with, deploy on, and operate &mdash; at a fraction of the cost of anything else.**
+**Resonate is the [durable execution](https://www.resonatehq.io/durable-execution) engine that agents build with, deploy on, and operate &mdash; at a fraction of the cost of anything else.**
 
 It is the implementation of a [distributed async/await](https://distributed-async-await.io/spec) programming model: a formal, language- and transport-agnostic protocol for writing functions that survive process restarts, run for hours or months, and coordinate across many machines.
 


### PR DESCRIPTION
Search-intent tuning for the `/evaluate` section. No body/content changes beyond one internal link.

**Comparison pages** — retitled to lead with the competitor name (people type the incumbent first: "temporal vs…", "dbos alternatives"), rewrote descriptions for vs/alternative intent, added matching keywords:
- `coming-from/temporal.mdx` → **Temporal vs Resonate**
- `coming-from/dbos.mdx` → **DBOS vs Resonate**
- `coming-from/restate.mdx` → **Restate vs Resonate**

**DST hub** — `how-resonate-is-tested.mdx` description now leads with deterministic simulation testing and the bugs it catches.

**Pillar consolidation** — `why-resonate.mdx`: first "durable execution" mention now links to https://www.resonatehq.io/durable-execution.

Competitor names are confined to `/evaluate` (sanctioned) — not mirrored to www or the journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)