### PR TITLE
TypeScript SDK 0.11.4: Postgres network docs + sitewide version alignment

### DIFF
--- a/content/docs/develop/typescript.mdx
+++ b/content/docs/develop/typescript.mdx
@@ -11,14 +11,14 @@ keywords:
 ---
 
 <Callout type="info" title="SDK version">
-This page reflects `@resonatehq/sdk` v0.11.2 (current on npm). APIs are subject to change in future releases.
+This page reflects `@resonatehq/sdk` v0.11.4 (current on npm). APIs are subject to change in future releases.
 </Callout>
 
 <Callout type="note" title="Two execution engines">
 Since v0.11.0, the SDK ships two interchangeable engines: the **generator engine** (`function*` with `yield* ctx.run(fn)`, documented throughout this page) and an **async/await engine** where workflows are ordinary `async` functions and durable steps are `await ctx.run(myFn, ...args)`. The async engine is imported from `@resonatehq/sdk/async`. See [Async/await engine](#asyncawait-engine) at the end of this page for a full walkthrough and migration guide.
 </Callout>
 
-**Requires Node.js 22 or later.**
+**Requires Node.js 22 or later and npm 10 or later.**
 
 Whether you are a human or an AI agent, this skill guide will help you develop applications using the Resonate TypeScript SDK.
 Though this _is_ a skill guide, and not a detailed API reference and you will still likely need to refer to the detailed [Resonate TypeScript SDK API reference](https://resonatehq.github.io/resonate-sdk-ts/) for type definitions, defaults, and other technical details.
@@ -127,6 +127,42 @@ const resonate = new Resonate();
 Local development mode can be suitable for awhile.
 However, when you want to run multiple worker processes, persist state across restarts, or share work between machines, you will need to connect to a Resonate Server.
 See the [Quickstart guide](/get-started/quickstart) or [How to run a Resonate Server](/deploy/run-server) for guidance on getting a server up and running.
+
+### Postgres-backed durable execution
+
+Alongside the in-memory local network and a remote Resonate Server, the TypeScript SDK can run durable execution directly on **Postgres** — with no separate Resonate Server process.
+The Resonate protocol runs as stored procedures in a `resonate` schema in your database (see [resonate-pg](https://github.com/resonatehq/resonate-pg)), and your workers talk to Postgres directly.
+
+The Postgres network ships as a separate package export and connects through [`pg`](https://www.npmjs.com/package/pg), which is a peer dependency — install it alongside the SDK:
+
+```shell
+npm install @resonatehq/sdk pg
+```
+
+Apply the `resonate.sql` schema (from [resonate-pg](https://github.com/resonatehq/resonate-pg)) to a Postgres 16+ database, then wire a `PostgresNetwork` into the Resonate Client:
+
+```ts title="index.ts"
+import { Resonate } from "@resonatehq/sdk";
+import { PostgresNetwork } from "@resonatehq/sdk/postgres";
+
+// Pass your Postgres connection string (for example, from the DATABASE_URL environment variable).
+const network = new PostgresNetwork({
+  connectionString: process.env.DATABASE_URL ?? "postgres://localhost:5432/mydb",
+  group: "workers", // a task targets the group (anycast); defaults to "default"
+});
+
+const resonate = new Resonate({ network });
+```
+
+`PostgresNetwork` also accepts `pid` (this process's id, which callbacks and listeners target directly; defaults to a random id), `tickMs` (the fallback poll interval, in milliseconds), and `logger`.
+
+Both execution engines work over the Postgres network — pass the same `network` option to the `Resonate` class from [`@resonatehq/sdk/async`](#asyncawait-engine).
+
+Workers receive dispatched work over Postgres `LISTEN`/`NOTIFY` (with a periodic fallback poll, so a missed notification still gets picked up), and due timers advance whenever a worker is running.
+Because there is no standalone server process, **durable sleeps and timeouts advance only while at least one worker is connected** — with every worker down, they are suspended until a worker reconnects (a standalone Resonate Server advances timers on its own).
+This keeps the durable-execution stack on infrastructure you already run, with Postgres handling promise state and routing — a good fit for serverless and Postgres-centric deployments.
+
+Like the SDK itself, the Postgres network is pre-1.0 and in active development; its API may change between releases.
 
 ### Authentication
 

--- a/content/docs/develop/typescript.mdx
+++ b/content/docs/develop/typescript.mdx
@@ -166,9 +166,9 @@ Like the SDK itself, the Postgres network is pre-1.0 and in active development; 
 
 ### Authentication
 
-The TypeScript SDK supports both **token-based** and **basic** authentication when connecting to a secured Resonate Server.
+The TypeScript SDK authenticates to a secured Resonate Server with a **token**.
 
-#### Token-based authentication (recommended)
+#### Token-based authentication
 
 Use JWT bearer tokens for production deployments:
 
@@ -183,6 +183,12 @@ const resonate = new Resonate({
 
 <Callout type="tip" title="Token-based authentication is recommended for production. See the [Security & Authentication](/deploy/security) guide for detailed configuration, best practices, and server setup.">
 
+</Callout>
+
+<Callout type="caution" title="Upgrading from v0.9.x">
+Earlier releases accepted `auth: { username, password }` and read `RESONATE_USERNAME` / `RESONATE_PASSWORD`, sending an `Authorization: Basic` header.
+That was removed in **v0.10.0** along with the rest of the networking rewrite, and the constructor now ignores unknown options rather than rejecting them.
+An `auth` block carried forward from v0.9.x therefore raises no error — the client simply sends unauthenticated requests. Replace it with `token`.
 </Callout>
 
 ### Concurrency

--- a/content/docs/evaluate/coming-from/dbos.mdx
+++ b/content/docs/evaluate/coming-from/dbos.mdx
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <Callout type="info" title="SDK version">
-This page reflects `@resonatehq/sdk` v0.11.2 (TypeScript, current on npm), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
+This page reflects `@resonatehq/sdk` v0.11.4 (TypeScript, current on npm), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
 </Callout>
 
 <Callout type="info" title="About the code">

--- a/content/docs/evaluate/coming-from/restate.mdx
+++ b/content/docs/evaluate/coming-from/restate.mdx
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <Callout type="info" title="SDK version">
-This page reflects `@resonatehq/sdk` v0.11.2 (current on npm) and `resonate-sdk` v0.7.4 for Python.
+This page reflects `@resonatehq/sdk` v0.11.4 (current on npm) and `resonate-sdk` v0.7.4 for Python.
 </Callout>
 
 <Callout type="note" title="Two execution engines">

--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <Callout type="info" title="SDK version">
-This page reflects `@resonatehq/sdk` v0.11.2 (TypeScript, current on npm), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
+This page reflects `@resonatehq/sdk` v0.11.4 (TypeScript, current on npm), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
 </Callout>
 
 **Are you coming from Temporal?**

--- a/content/docs/evaluate/how-resonate-is-tested.mdx
+++ b/content/docs/evaluate/how-resonate-is-tested.mdx
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <Callout type="info" title="Versions">
-This page reflects Resonate Server v0.9.8, `@resonatehq/sdk` v0.11.2 (TypeScript), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust), `resonate-sdk` v0.1.1 (Java), and the Resonate Go SDK 0.1.0.
+This page reflects Resonate Server v0.9.8, `@resonatehq/sdk` v0.11.4 (TypeScript), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust), `resonate-sdk` v0.1.1 (Java), and the Resonate Go SDK 0.1.0.
 </Callout>
 
 Resonate's correctness story rests on three foundations that reinforce each other: an executable formal specification of the protocol in Lean 4, differential random testing of the server implementation against a pure in-memory reference model, and deterministic simulation testing of the TypeScript SDK. Unit, integration, and end-to-end test suites across all five SDKs sit alongside these.

--- a/content/docs/get-started/examples/async-http-api-endpoints.mdx
+++ b/content/docs/get-started/examples/async-http-api-endpoints.mdx
@@ -16,7 +16,7 @@ keywords:
 A FastAPI gateway converts every inbound request into a durable workflow, returns a promise ID immediately, and exposes a `/wait` endpoint clients poll for completion.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/async-rpc.mdx
+++ b/content/docs/get-started/examples/async-rpc.mdx
@@ -16,7 +16,7 @@ keywords:
 A gateway calls service A, which calls service B, which calls service C. Each step uses Resonate's remote function invocation APIs, so the entire chain is durable — a crash on any service resumes the call without re-running prior steps.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current).
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/deep-research-agent.mdx
+++ b/content/docs/get-started/examples/deep-research-agent.mdx
@@ -17,7 +17,7 @@ keywords:
 A research agent receives a broad topic, asks an LLM to break it into 2–3 subtopics, and recursively dispatches each subtopic to itself. Every LLM call and every recursive subagent is a durable promise — kill the worker mid-research, the tree resumes from the last unanswered branch.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/durable-serverless-cloud-run-workers.mdx
+++ b/content/docs/get-started/examples/durable-serverless-cloud-run-workers.mdx
@@ -17,7 +17,7 @@ keywords:
 A countdown workflow running as a single Google Cloud Function. The function sleeps between notifications via `ctx.sleep`, terminating the container while suspended. Resonate fires the function back up at the right time and the workflow continues from the next iteration — long-running logic on short-lived compute.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 + `@resonatehq/gcp` for the Cloud Functions adapter. Python and Rust adapters are forthcoming.
+TypeScript: `@resonatehq/sdk` v0.11.4 + `@resonatehq/gcp` for the Cloud Functions adapter. Python and Rust adapters are forthcoming.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/durable-serverless-lambda-workers.mdx
+++ b/content/docs/get-started/examples/durable-serverless-lambda-workers.mdx
@@ -16,7 +16,7 @@ keywords:
 A Lambda function behind API Gateway acts as a stateless trigger. `POST /process-document` fires a durable Resonate workflow and returns `202` immediately. The workflow itself — download, OCR, LLM analysis, storage, notification — runs on a Resonate worker that doesn't share Lambda's 15-minute ceiling.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/durable-sleep.mdx
+++ b/content/docs/get-started/examples/durable-sleep.mdx
@@ -15,7 +15,7 @@ keywords:
 A workflow yields `ctx.sleep` and the runtime suspends it. Hours, days, or weeks later the worker wakes the workflow up exactly where it stopped — no cron, no scheduler, no external state.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/fan-out-fan-in.mdx
+++ b/content/docs/get-started/examples/fan-out-fan-in.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow spawns four notification channels (email, SMS, Slack, push) in parallel and joins their results. Total wall time approaches the slowest channel, not the sum. If one channel fails and retries, the others stay checkpointed — they don't re-send.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/hello-world.mdx
+++ b/content/docs/get-started/examples/hello-world.mdx
@@ -15,7 +15,7 @@ keywords:
 The smallest example that exercises the durable execution loop. A registered workflow function calls two leaf functions through `ctx.run`, and Resonate checkpoints each return value.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/human-in-the-loop.mdx
+++ b/content/docs/get-started/examples/human-in-the-loop.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow blocks on a durable promise, prints a callback URL, and resumes the moment a human resolves it — from any process, any machine, any time.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/kafka-worker.mdx
+++ b/content/docs/get-started/examples/kafka-worker.mdx
@@ -16,7 +16,7 @@ keywords:
 A consumer pulls messages from a Kafka topic and dispatches each one through a durable Resonate workflow. Per-message state lives in durable promises, so a worker that dies mid-batch resumes cleanly without redoing completed steps.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <Callout type="note" title="Kafka or Redpanda — same code">

--- a/content/docs/get-started/examples/load-balancing.mdx
+++ b/content/docs/get-started/examples/load-balancing.mdx
@@ -15,7 +15,7 @@ keywords:
 Run several workers in the same group. Calls to `target: "poll://any@<group>"` get dispatched to whichever worker claims them first. When a worker dies mid-execution, Resonate reassigns the work to a survivor — no service registry, no leader election, no glue.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/money-transfer.mdx
+++ b/content/docs/get-started/examples/money-transfer.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow debits the source account, credits the target account, and returns confirmations. Each account update is a durable checkpoint, the transfer ID is the idempotency key, and the same ID retried in seconds, hours, or days returns the cached result instead of double-spending.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/multi-agent-orchestration.mdx
+++ b/content/docs/get-started/examples/multi-agent-orchestration.mdx
@@ -16,7 +16,7 @@ keywords:
 Three specialist agents — researcher, writer, reviewer — chained through an orchestrator. Each agent's output is a durable checkpoint, so a flaky LLM call mid-pipeline retries only the failing agent and the prior outputs stay cached.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/recursive-factorial.mdx
+++ b/content/docs/get-started/examples/recursive-factorial.mdx
@@ -15,7 +15,7 @@ keywords:
 A workflow that computes `n!` by calling itself with `n-1`. Each recursive call dispatches via `ctx.rpc` to whichever worker in the group claims it — recursion ends up distributed across machines without any explicit coordination, and every step is checkpointed so a worker crash mid-recursion resumes cleanly.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/schedule.mdx
+++ b/content/docs/get-started/examples/schedule.mdx
@@ -16,7 +16,7 @@ keywords:
 Register a function to run on a cron expression and Resonate handles the rest. Every fired execution is a durable workflow — a worker that crashes mid-run hands off to a survivor, and a missed run because all workers were down still gets dispatched when one comes back.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development.
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/webhook-handler.mdx
+++ b/content/docs/get-started/examples/webhook-handler.mdx
@@ -16,7 +16,7 @@ keywords:
 A webhook receives a payment event, kicks off a durable workflow keyed by the provider's event ID, and acknowledges immediately. Duplicate deliveries (network retries, slow ACKs) reconnect to the in-flight execution rather than re-charging the card. A crash mid-processing resumes from the next unfinished step.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.2 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust example repo is forthcoming.
 </Callout>
 
 <CloneRepoGrid>


### PR DESCRIPTION
The TypeScript SDK shipped `0.11.3` and `0.11.4`. This aligns the docs to what is on npm, fills the one real content gap the releases opened, and corrects the Authentication section.

## The gap

`0.11.3` added a **`PostgresNetwork` transport**. It had no coverage anywhere in the docs. The Rust SDK's equivalent is already documented under `develop/rust.mdx` ("Postgres-backed durable execution"), so a TypeScript reader had no way to discover that the same capability exists for them.

`develop/typescript.mdx` gets a matching section, placed in the same position as the Rust one — after zero-dependency local development, before authentication. It covers:

- `pg` as a peer dependency, so the install line is `npm install @resonatehq/sdk pg`
- the `@resonatehq/sdk/postgres` package export
- wiring `PostgresNetwork` into the client
- the remaining config options (`pid`, `tickMs`, `logger`)
- that both execution engines work over the same network
- the operational caveat: with no standalone server process, durable sleeps and timeouts advance only while at least one worker is connected

`0.11.4` also raised the package's engine requirement to npm 10. The installation note now says so alongside the existing Node.js 22 line.

## Authentication

The section opened by saying the SDK "supports both token-based and basic authentication," then documented only the token path. On `0.11.4` there is no basic-auth path to document: the constructor destructures `url, group, pid, ttl, token, timeout, verbose, logLevel, logger, encryptor, network, prefix`, `RESONATE_TOKEN` is the only auth-related environment variable, and the HTTP network never builds a `Basic` header.

**That is a removal, not an absence.** Through `0.9.6` the constructor did accept `auth: { username, password }`, did read `RESONATE_USERNAME` / `RESONATE_PASSWORD`, and did send an `Authorization: Basic` header — which the server of that era validated on its REST routes and its poll endpoint. The `0.10.0` networking rewrite removed all of it with no deprecation warning.

The distinction matters because the failure is silent in both directions. An unknown constructor option does not throw, so a reader following the old sentence, or upgrading a working `0.9.x` client, gets no error and no clue while the client sends unauthenticated requests. A caution callout now gives the version boundary and the replacement.

## Version claims

`v0.11.2` → `v0.11.4` across the develop page, the three comparison pages, the testing page, and the sixteen example pages. 20 files, one line each.

## Verification

Everything here was run against `@resonatehq/sdk@0.11.4`, not read off release notes.

| Check | Result |
|---|---|
| New Postgres fence, `tsc --strict` | clean |
| Generator engine over `PostgresNetwork`, Postgres 16 + resonate-pg schema, **no Resonate Server running** | workflow completed; promise rows resolved in the `resonate` schema |
| Async engine over the same network | completed |
| Durable sleep with a worker connected | advanced (3086ms for a 3s sleep) |
| Durable sleep with **every worker disconnected** | still `pending` 12s after a 5s sleep was due; completed 22ms after a worker reconnected |
| Existing async-engine fences (register/run/handle, eager `ctx.run` + `Promise.all`, `ctx.options({ retryPolicy: new Exponential() })`) | pass |
| Existing generator fences (`ctx.run`/`ctx.sleep`, `beginRun`, `promises.create`/`get`/`resolve`) | pass |
| `auth: { username, password }` on `0.9.6`, against a local listener | sent `Authorization: Basic`; absent on `0.10.0` |
| Type definitions, `0.11.2` → `0.11.4` | all 31 shared `.d.ts` files content-identical; only addition is `network/postgres.d.ts` |
| `npm run build` + link check | 490 links, 0 internal broken |

The type-definition comparison is worth stating explicitly, because every bumped version claim on this page rests on it: the delta between the two releases is additive plus packaging. No changed default, no removed export, no altered signature. Nothing that was correct on `0.11.2` became wrong on `0.11.4`.

## Not in this PR

- **The example repositories still pin `^0.10.0`.** Sixteen example pages now say `v0.11.4` while the repos they link to resolve to `0.10.4`. That gap is real but not urgent: the `0.10.x` → `0.11.4` public surface delta is additive, and none of the `^0.10.0`-pinned repos imports a symbol that only exists on `0.11.x`, so a reader who clones one and runs `npm install` gets working code. The one repo that does use a `0.11`-only export is already pinned `^0.11.0`. Bumping the pins is a separate change across many repositories.
- **Two paragraphs in the new section are inherited verbatim from `develop/rust.mdx`** — the timer caveat's plain-paragraph treatment (rather than a callout) and the closing "a good fit for serverless and Postgres-centric deployments." Both were copied deliberately to keep the two pages parallel. They are worth revisiting, but on both pages at once rather than only here.
- The FaaS adapters (`@resonatehq/aws`, `/gcp`, `/cloudflare`) now publish out of the SDK monorepo as of `0.11.4`. Package names and exports are unchanged, so every install and import instruction in `deploy/serverless-workers.mdx` still verifies correct — no doc change needed.
- Python's Postgres network is still an open PR upstream, so `develop/python.mdx` is untouched.
