### PR TITLE
Document server providers: ScyllaDB and NATS

### DIFF
--- a/content/docs/deploy/index.mdx
+++ b/content/docs/deploy/index.mdx
@@ -84,6 +84,8 @@ Start the Resonate server with persistent storage:
 
 The server coordinates work for all your workers.
 
+Already run ScyllaDB or NATS and would rather not add a database beside it? Resonate publishes a separate server implementation of the protocol for each, source-available under BUSL-1.1. See [Server providers](/deploy/providers).
+
 ### 3. Deploy workers
 
 Workers execute your application code:

--- a/content/docs/deploy/providers/index.mdx
+++ b/content/docs/deploy/providers/index.mdx
@@ -1,0 +1,44 @@
+---
+title: Server providers
+description: Run the Resonate protocol on infrastructure you already operate — the core server, or a provider implementation built for a specific platform.
+keywords:
+  - deploy
+  - providers
+  - server
+  - scylladb
+  - nats
+---
+
+## TL;DR
+
+Durable execution is a protocol, not a product. Any platform that gives you durable storage and an atomic compare-and-swap can implement the Resonate server protocol. A **provider** is one of those implementations: a separate server binary built for a specific platform, not a storage flag on the core server. Resonate builds and maintains the two below, independently of the platforms they run on.
+
+Most teams should run the core server. Reach for a provider when the platform it targets is one you already operate and would rather not add a database beside.
+
+## What ships today
+
+| Provider | Storage | Transport | License | Drop-in? |
+|---|---|---|---|---|
+| [Core server](/deploy/run-server) | Postgres, MySQL, SQLite | HTTP | Apache 2.0 | — |
+| [ScyllaDB](/deploy/providers/scylladb) | ScyllaDB (CQL) | HTTP | Source-available (BUSL-1.1) | Yes |
+| [NATS](/deploy/providers/nats) | NATS JetStream | NATS | Source-available (BUSL-1.1) | No |
+
+"Drop-in" means the provider speaks the same HTTP/JSON protocol the core server speaks, so your SDK and your application code do not change. Workers point at a different `RESONATE_URL`.
+
+The NATS provider is not drop-in. It replaces both storage *and* transport, so it has no HTTP interface at all and workers connect over NATS using the `NatsNetwork` client built into the SDK. Your workflow code is unchanged; the client wiring is not, and only the TypeScript and Python SDKs have that client today.
+
+## What a provider is not
+
+- **Not a plugin.** There is no adapter interface to register a new backend against the core server. A provider is an independent implementation of the published protocol.
+- **Not a configuration flag.** You do not get ScyllaDB by passing an option to `resonate serve`. You run a different binary.
+- **Not necessarily Apache 2.0.** The core server is Apache 2.0. The ScyllaDB and NATS providers are source-available under BUSL-1.1 — free for development, testing, and evaluation, with production use requiring a commercial license until each version's Change Date. Read the license in the repository before you plan a production rollout.
+
+## Maturity
+
+The core server is the reference implementation and the default recommendation. The providers are newer. Both implement the core of the protocol, but neither implements search, neither has server-side authentication, and neither has a production reference deployment yet. They are also not equally proven — the ScyllaDB provider ships oracle-diff, crash, and linearizability suites; the NATS provider has unit tests only.
+
+Each provider page has a "What's not there yet" section. Read it before you commit to one.
+
+## Building your own
+
+The protocol is public. If you want durable execution on a platform that isn't listed here, the [server specification](https://distributed-async-await.io/) is the contract to implement, and the existing providers are worked examples of what a complete implementation looks like.

--- a/content/docs/deploy/providers/meta.json
+++ b/content/docs/deploy/providers/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Server providers",
+  "pages": ["scylladb", "nats"]
+}

--- a/content/docs/deploy/providers/nats.mdx
+++ b/content/docs/deploy/providers/nats.mdx
@@ -1,0 +1,168 @@
+---
+title: Resonate on NATS
+description: Run the Resonate protocol on NATS JetStream — setup, partitioning, the SDK client, and what to know before production.
+keywords:
+  - deploy
+  - providers
+  - nats
+  - jetstream
+---
+
+## TL;DR
+
+[`resonate-on-nats`](https://github.com/resonatehq/resonate-on-nats) is a Go server that implements the Resonate protocol on NATS JetStream. JetStream KV holds the state and NATS carries the messages, so the provider needs no separate database.
+
+Unlike the [ScyllaDB provider](/deploy/providers/scylladb), this one is **not drop-in**. It has no HTTP interface at all — workers reach it over NATS using the `NatsNetwork` client built into the TypeScript and Python SDKs. Your workflow code is unchanged; the client wiring is not.
+
+It is source-available under BUSL-1.1, not Apache 2.0, and it is early. Read [What's not there yet](#whats-not-there-yet) before you plan a production rollout.
+
+## When to use it
+
+Use it when NATS is already your backbone and you would rather not add a database and an HTTP service beside it. If you aren't already running NATS, run the [core server](/deploy/run-server) on Postgres instead.
+
+If you want durable execution without changing how your workers connect, the ScyllaDB provider speaks the same HTTP/JSON protocol as the core server and is the smaller change.
+
+## Requirements
+
+- **nats-server 2.14.x with JetStream enabled.** Durable timers use JetStream's built-in message schedules, and schedules carry cron-style recurrence, which landed in 2.14. The repository builds against 2.14.2, so treat 2.14 as the supported floor.
+- Go 1.25+ to build from source.
+
+## Run it
+
+Build the binary:
+
+```shell
+git clone https://github.com/resonatehq/resonate-on-nats
+cd resonate-on-nats
+go build -o resonate-on-nats .
+```
+
+For local development, `dev` starts an embedded NATS server with a fresh store in a temporary directory, discarded on exit:
+
+```shell
+./resonate-on-nats dev
+```
+
+Against a NATS deployment you already operate:
+
+```shell
+./resonate-on-nats serve --nats-url nats://localhost:4222
+```
+
+### Flags
+
+| Flag | `serve` default | `dev` default | Purpose |
+|---|---|---|---|
+| `--nats-url` | `nats://127.0.0.1:4222` | — | NATS server to connect to |
+| `--partitions` | `16` | `1` | Total partition count for the stream |
+| `--subscribe` | all | all | Partition indices this instance handles |
+| `--debug` | `false` | `true` | Enables deterministic testing endpoints |
+| `--port` | — | `4222` | Port for the embedded NATS server |
+| `--log-level` | `info` | `info` | Global flag — `debug`, `info`, `warn`, `error` |
+
+`--debug` exposes endpoints that let tests drive logical time (`debug.start`, `debug.stop`, `debug.reset`, `debug.tick`, `debug.snap`). It defaults **on** in `dev` and **off** in `serve`.
+
+<Callout type="caution" title="Debug mode is a remote wipe switch">
+`debug.reset` purges the entire stream and every key in the KV bucket, and `debug.start` halts outbox delivery server-wide. Since the server has no authentication of its own, anyone who can publish to the request subject can invoke both. Never enable `--debug` on `serve`.
+</Callout>
+
+## Partitioning across instances
+
+State lives in JetStream KV, partitioned across instances. Each instance subscribes to a subset of partitions and processes messages **serially per origin**, using optimistic concurrency for conflict-free multi-instance deployments.
+
+To run several instances, give them all the same `--partitions` and split the work with `--subscribe`:
+
+```shell
+./resonate-on-nats serve --partitions 16 --subscribe 0,1,2,3
+./resonate-on-nats serve --partitions 16 --subscribe 4,5,6,7
+```
+
+Every instance must agree on `--partitions`. Treat it the way you'd treat any partition count: pick it with room to grow, because changing it later means resharding.
+
+## Connecting workers
+
+Workers connect over NATS, not HTTP, using `NatsNetwork` — which ships inside the main SDKs rather than as a separate package.
+
+### TypeScript
+
+Requires `@resonatehq/sdk` and the `@nats-io/transport-node` peer dependency.
+
+```typescript title="worker.ts"
+import { Resonate } from "@resonatehq/sdk";
+import { NatsNetwork } from "@resonatehq/sdk/nats";
+import { connect } from "@nats-io/transport-node";
+
+const conn = await connect({ servers: "nats://localhost:4222" });
+
+const resonate = new Resonate({
+  network: new NatsNetwork({ conn }),
+});
+```
+
+### Python
+
+Requires the `nats` extra, which pulls in `nats-py`:
+
+```shell
+uv add "resonate-sdk[nats]"
+```
+
+```python title="worker.py"
+import asyncio
+
+import nats
+from resonate.resonate import Resonate
+from resonate.network.nats import NatsNetwork
+
+
+async def main():
+    conn = await nats.connect("nats://localhost:4222")
+    resonate = Resonate(network=NatsNetwork(conn))
+    ...
+
+
+asyncio.run(main())
+```
+
+`Resonate` is imported from `resonate.resonate`, not the package root, and it has to be constructed inside a running event loop — its `__init__` schedules background tasks.
+
+<Callout type="caution" title="Don't pass a URL alongside the network">
+In the Python SDK, network selection resolves `url` before `network` before the `RESONATE_URL` environment variable. If you pass a `url` **and** a `network`, the URL wins and your `NatsNetwork` is silently ignored. Pass one or the other.
+</Callout>
+
+### Other languages
+
+`NatsNetwork` exists in the TypeScript and Python SDKs only. The Go, Rust, and Java SDKs have no NATS support, so a team on those languages can't use this provider today.
+
+## Subjects and addressing
+
+Worth knowing if you run a NATS deployment with subject-level permissions.
+
+- Requests go to `resonate.requests.{base64url(origin)}`, where the encoding is unpadded base64url. The request carries a `Resonate-Reply-To` header naming a private inbox, and the reply comes back on that inbox — the server ignores the NATS reply subject.
+- Workers receive on two subjects: a unicast `resonate.recv.{group}.{pid}` and an anycast `resonate.recv.{group}`, queue-subscribed on the group so exactly one member gets each anycast message.
+- Task addresses use the `nats://` scheme; the server maps `nats://{subject}` back to a subject.
+
+Both prefixes are configurable per client (`serverTopic` / `server_topic` and `workerTopic` / `worker_topic`), and the request timeout defaults to 30 seconds.
+
+<Callout type="info" title="Keep custom group and pid values lowercase">
+Subjects are case-sensitive end to end, and nothing normalizes case for you, so a publisher and a subscriber that disagree on capitalization will not find each other. Default pids are lowercase hex, so staying lowercase keeps hand-set values consistent with them.
+</Callout>
+
+## What's not there yet
+
+- **No production reference deployments.** Nobody is running this in production yet.
+- **No search.** Neither `promise.search` nor `task.search` is a recognized kind, so both come back as `400 bad request`. Unlike the ScyllaDB provider there is no `501` stub to probe for. Anything that depends on querying promises by tag will not work.
+- **Lighter test coverage than the ScyllaDB provider.** There are unit tests over the store, schedules, and tasks, but no oracle-diff, crash, or linearizability suites of the kind [that provider ships](/deploy/providers/scylladb#how-its-tested).
+- **No authentication.** The server has no auth layer of its own. Anything protecting it has to come from your NATS deployment — accounts, users, and subject permissions.
+- **No HTTP interface.** There is no REST surface, no health endpoint, and no way to point an HTTP-based SDK client at it.
+- **TypeScript and Python only.** `NatsNetwork` ships in those two SDKs. The Go, Rust, and Java SDKs have no NATS client, so a team on those languages cannot use this provider today.
+- **The layout is not settled.** This is a young repository, and the subject scheme and partition model can still change. Check open pull requests before you build tooling against them.
+- **Source-available under BUSL-1.1, not Apache 2.0.** All non-production use is free, including modifying and redistributing. There is no additional production use grant, so production use requires a commercial license from Resonate HQ until the Change Date (2030-07-01), when each released version converts to Apache 2.0. Contact `licensing@resonatehq.io`.
+
+## See also
+
+- [Server providers](/deploy/providers) — what a provider is and what else ships
+- [Resonate on ScyllaDB](/deploy/providers/scylladb) — the other provider
+- [Durable Execution on NATS](https://www.resonatehq.io/providers/nats) — the overview page
+- [resonatehq/resonate-on-nats](https://github.com/resonatehq/resonate-on-nats) — the source
+- [resonatehq/nats-demos](https://github.com/resonatehq/nats-demos) — runnable TypeScript and Python examples

--- a/content/docs/deploy/providers/scylladb.mdx
+++ b/content/docs/deploy/providers/scylladb.mdx
@@ -1,0 +1,172 @@
+---
+title: Resonate on ScyllaDB
+description: Run the Resonate server protocol against a ScyllaDB cluster — setup, configuration, and what to know before production.
+keywords:
+  - deploy
+  - providers
+  - scylladb
+  - cql
+---
+
+## TL;DR
+
+[`resonate-on-scylladb`](https://github.com/resonatehq/resonate-on-scylladb) is a Go server that implements the Resonate protocol against ScyllaDB. It speaks the same HTTP/JSON protocol as the core server, so **your application code and SDK do not change** — you point `RESONATE_URL` at it.
+
+It is source-available under BUSL-1.1, not Apache 2.0, and it is early. Read [What's not there yet](#whats-not-there-yet) before you plan a production rollout.
+
+## When to use it
+
+Use it when you already run ScyllaDB and would rather not stand up a second database for durable execution. If you don't already run ScyllaDB, run the [core server](/deploy/run-server) on Postgres instead — it is the reference implementation and the default recommendation.
+
+## Requirements
+
+- A ScyllaDB cluster reachable over CQL.
+- Docker and Docker Compose for the local stack below.
+- Go 1.25.4+ to build the binary from source.
+
+## Run it locally
+
+```shell title="Start the server against a local ScyllaDB"
+git clone https://github.com/resonatehq/resonate-on-scylladb
+cd resonate-on-scylladb
+docker compose --profile server up
+```
+
+<Callout type="info" title="The server service sits behind a Compose profile">
+`docker compose up` on its own starts ScyllaDB and nothing else. The `server` service in the bundled `docker-compose.yaml` declares `profiles: [server]`, so you have to name the profile — or the service — to get a server.
+</Callout>
+
+The server listens on `:8001`. Point a worker at it exactly as you would the core server:
+
+```shell
+RESONATE_URL=http://localhost:8001
+```
+
+## Schema provisioning
+
+This is the part to get right before you go anywhere near a cluster that matters.
+
+The server only touches DDL when `--debug` (or `SERVER_DEBUG`) is set. In that mode it **drops the keyspace and recreates it** on every connect, then applies the tables. The bundled `server` service runs `serve --debug`, which is why the local stack above comes up with a working schema — and also why a local restart starts from empty.
+
+<Callout type="caution" title="Never run with debug against a cluster you care about">
+Debug mode issues `DROP KEYSPACE IF EXISTS` before creating anything. Pointing a debug-mode server at a populated keyspace destroys it. Debug mode is for local development and the test suites only.
+</Callout>
+
+Outside debug mode the server applies no DDL at all — it opens a keyspace-bound session and assumes the schema is already there. So for any real deployment, **you provision the schema yourself**.
+
+## Run against an existing cluster
+
+Create the keyspace yourself, with a replication strategy you chose deliberately — leaving it to a default is rarely right on a multi-datacenter cluster. The bundled `internal/dbms/schema.cql` opens with a bare `CREATE KEYSPACE IF NOT EXISTS resonate;` and a `USE resonate;`, so do not apply it as-is unless both the name and the default replication are what you want:
+
+```shell
+cqlsh -e "CREATE KEYSPACE resonate WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3};"
+```
+
+Then apply the table definitions into it. The first three lines of the file are the `CREATE KEYSPACE` and `USE` you just replaced, so skip them:
+
+```shell
+tail -n +4 internal/dbms/schema.cql > tables.cql
+cqlsh -k resonate -f tables.cql
+```
+
+Build the binary and start it pointed at the cluster, with debug off. The keyspace you provisioned has to match `SCYLLADB_KEYSPACE`:
+
+```shell
+go build -o resonate ./cmd/resonate
+
+SCYLLADB_HOSTS=node-0.example.com,node-1.example.com,node-2.example.com \
+SCYLLADB_KEYSPACE=resonate \
+SCYLLADB_TLS_ENABLED=true \
+./resonate serve
+```
+
+<Callout type="info" title="This is not the core server binary">
+The provider's CLI is also called `resonate`, and it also takes `serve` — but it is built from `resonatehq/resonate-on-scylladb`, not from the core server repository. Make sure the binary on your `PATH` is the one you meant.
+</Callout>
+
+`SCYLLADB_REPLICATION` is only read when the server creates the keyspace, which means only in debug mode. Since you provision the keyspace yourself, that setting does nothing on this path.
+
+## Configuration
+
+Configuration resolves in priority order: CLI flags, then environment variables, then an optional `resonate.yaml`, then built-in defaults.
+
+| Variable | Description |
+|---|---|
+| `SERVER_ADDR` | Server listen address (default `:8001`) |
+| `SERVER_DEBUG` | Debug mode — **drops and recreates the keyspace on connect**; never enable against real data |
+| `SERVER_LOG_LEVEL` | `debug`, `info`, `warn`, or `error` (default `info`); any other value is a fatal startup error |
+| `SCYLLADB_HOSTS` | Comma-separated seed hosts |
+| `SCYLLADB_PORT` | CQL port |
+| `SCYLLADB_USERNAME` | Username |
+| `SCYLLADB_PASSWORD` | Password |
+| `SCYLLADB_TLS_ENABLED` | Enable TLS |
+| `SCYLLADB_TLS_INSECURE` | Skip certificate verification |
+| `SCYLLADB_KEYSPACE` | Keyspace name |
+| `SCYLLADB_REPLICATION` | Replication clause used when creating the keyspace — debug mode only |
+| `TIMEOUTS_BUCKET_WIDTH` | Timeout bucket width (e.g. `1h`, `30m`) |
+| `TIMEOUTS_BUCKET_LOOKBACK` | Past buckets to scan |
+| `TIMEOUTS_SHARDS` | Shard count for the timeout tables — must match across all server instances |
+| `WORKER_TTL` | Worker row TTL (e.g. `15s`) |
+| `WORKER_TICK_INTERVAL` | Coordinator tick interval (e.g. `1s`) |
+
+The equivalent `resonate.yaml` keys are nested under `server:`, `scylladb:`, `timeouts:`, and `worker:`.
+
+## How state is stored
+
+The schema has six tables.
+
+- **`promises`** — one row per durable promise, keyed `PRIMARY KEY (origin, id)`. State fans out across many small partitions rather than concentrating into a fixed few.
+- **Task state lives on the promise row.** The `task_*` columns sit in `promises`, so acquiring, fencing, or completing a task is a single-row operation.
+- **`promise_timeouts`, `task_timeouts`, `schedule_timeouts`** — keyed `PRIMARY KEY ((bucket, shard), timeout_at, …)`. Durable timers are bucketed by time and sharded, so an expiry scan is a clustering-key range read inside one partition.
+- **`schedules`** — recurring schedules, keyed the same way as promises.
+- **`workers`** — worker liveness, with a row TTL set by `WORKER_TTL`.
+
+There is no per-execution event log. State is the current row, not a sequence to replay, so nothing accumulates without bound and a long-running execution has no history-size ceiling.
+
+`TIMEOUTS_SHARDS` sets how many partitions the timeout scan spreads across. `TIMEOUTS_BUCKET_WIDTH` and `TIMEOUTS_BUCKET_LOOKBACK` together decide how much of the recent past each tick re-scans.
+
+<Callout type="caution" title="Fix TIMEOUTS_SHARDS before data lands">
+The shard is a hash of the record id, baked into the partition key of every timeout row. Every instance must use the same value, and changing it on a populated cluster strands existing rows in partitions no server scans — durable timers stop firing, silently.
+</Callout>
+
+## How it's tested
+
+The repository ships three test suites, all runnable from a clone under Docker Compose:
+
+```shell title="Diff tests — every step checked against an in-memory oracle"
+docker compose -f docker-compose.test.yml -p resonate-diff --profile diff \
+  up --build --abort-on-container-exit --exit-code-from tester-diff
+```
+
+```shell title="Kill tests — crash mid-transaction, assert invariants on what survives"
+docker compose -f docker-compose.test.yml -p resonate-kill --profile kill \
+  up --build --abort-on-container-exit --exit-code-from tester-kill
+```
+
+```shell title="Linearizability — concurrent interleavings, model-checked"
+docker compose -f docker-compose.test.yml -p resonate-linz --profile linearizability \
+  up --build --abort-on-container-exit --exit-code-from tester-linearizability
+```
+
+The kill tests abort an operation at every cooperative yield checkpoint — reads, cursor scans, non-transactional pre-inserts, lightweight-transaction commits, rollbacks, cleanups and batches — a thousand iterations by default, and check named state invariants on whatever is left. Nine of those invariants describe *accepted* orphans: states that are harmless after an abort, because the recovery design writes a timeout entry before the transaction that commits the state change. An abort in that gap leaves a stale entry to be cleaned up rather than losing state.
+
+Linearizability is checked with the [Porcupine](https://github.com/anishathalye/porcupine) model checker against the same oracle the diff tests use.
+
+## What's not there yet
+
+Read this section before you plan a production rollout.
+
+- **No production reference deployments.** Nobody is running this in production yet.
+- **Search is unimplemented.** `task.search` returns `501`. `promise.search` and `schedule.search` aren't recognized kinds at all, so they come back as `400` with `unknown kind: <kind>` rather than `501` — worth knowing if you plan to probe for capability. Anything that depends on querying promises by tag will not work.
+- **No authentication.** An auth hook exists in the code, but nothing wires it up and its check is an unimplemented stub, so every request reaching the server is served. Put it behind your own network controls.
+- **Behavior under database-layer failure is an open question.** A repair path exists in the code but is not wired into the running server, so a lost node or a partition is not something the current tests characterize.
+- **Known bug:** deleting a schedule can leave stale rows in `schedule_timeouts`.
+- **The schema is not settled.** This is a young repository. Check open pull requests before you build tooling against the column layout above.
+- **Source-available under BUSL-1.1, not Apache 2.0.** All non-production use is free, including modifying and redistributing. There is no additional production use grant, so production use requires a commercial license from Resonate HQ until the Change Date (2030-07-01), when each released version converts to Apache 2.0. Contact `licensing@resonatehq.io`.
+
+## See also
+
+- [Server providers](/deploy/providers) — what a provider is and what else ships
+- [Resonate on NATS](/deploy/providers/nats) — the other provider
+- [Durable Execution on ScyllaDB](https://www.resonatehq.io/providers/scylladb) — the overview page
+- [resonatehq/resonate-on-scylladb](https://github.com/resonatehq/resonate-on-scylladb) — the source


### PR DESCRIPTION
The docs had no home for the server implementations built on other platforms — no page explained that they exist, how they differ from the core server, or what running one involves. This adds a **Server providers** section under Deploy.

## `deploy/providers/index.mdx`

What a provider is, a table of what ships today (core server, ScyllaDB, NATS) with storage / transport / license / drop-in status, and a section on what a provider *is not*:

- not a plugin — there is no adapter interface to register against the core server
- not a config flag — you run a different binary, not `resonate serve --storage scylladb`
- not Apache 2.0 — the providers are source-available under BUSL-1.1

It also marks the NATS provider as **not** drop-in, since it replaces transport as well as storage and needs a NATS-aware client. Resonate builds and maintains both providers, independently of the platforms they run on.

## `deploy/providers/scylladb.mdx`

- requirements, the local Compose run, and the out-of-band schema path for an existing cluster
- the full environment-variable table
- how state is laid out: one row per promise keyed `(origin, id)`, task state on the promise row, timeout tables keyed `((bucket, shard), timeout_at, …)`, no per-execution event log
- the timeout settings, including that `TIMEOUTS_SHARDS` must match across instances and stay fixed once data lands
- the three test suites and what the kill tests cover
- a "What's not there yet" section

## `deploy/providers/nats.mdx`

- requirements (nats-server 2.14+ with JetStream, Go 1.25+ to build) and the `dev` vs `serve` split
- the flag table for both subcommands, and why `--debug` must stay off in `serve`
- partitioning across instances with `--partitions` and `--subscribe`
- wiring workers with `NatsNetwork` in TypeScript and Python, which are the only SDKs that have it
- the subject layout, for anyone running subject-level permissions
- a "What's not there yet" section

## `deploy/providers/meta.json` and `deploy/index.mdx`

`meta.json` orders the two provider pages under the section index. `deploy/index.mdx` gains one paragraph in step 2 pointing readers who already run ScyllaDB or NATS at the new section.

## What the pages state plainly

Both providers are source-available under BUSL-1.1 with no additional production use grant, both are early, and neither has a production reference deployment. Neither implements search and neither has server-side authentication. The pages also state the asymmetry between them: ScyllaDB ships oracle-diff, kill and linearizability suites, NATS has unit tests only. The core server on Postgres stays the default recommendation.

## Where the content comes from

Written against the provider sources and the published SDK artifacts rather than the repositories' READMEs, which are wrong in a few of these places:

- The ScyllaDB server applies DDL only when debug mode is on, and debug mode runs `DROP KEYSPACE IF EXISTS` on every connect. Real deployments provision the schema themselves. `schema.cql` hardcodes the keyspace name and omits a replication clause, so the page splits keyspace creation from table DDL.
- The bundled `server` service sits behind a Compose profile, so a bare `docker compose up` starts ScyllaDB alone.
- The provider's CLI is also named `resonate` and also takes `serve`, so the page makes the build step explicit.
- The NATS Python sample imports `Resonate` from `resonate.resonate` and runs inside `asyncio.run` — the package root does not re-export it, and the constructor needs a running event loop.
- `debug.reset` purges the NATS stream and KV bucket, so `--debug` on `serve` is destructive rather than inert.
- NATS subjects are case-sensitive and nothing normalizes them; `net/url` lowercases the scheme, not the host.

## Verification

`npm run build` clean. The link checker reports **0 internal broken links** across 508 checked; the 8 external warnings are pre-existing `localhost` URLs on the metrics and tracing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
