### PR TITLE
docs: update Go SDK release-status references to v0.1.0

### DIFF
--- a/content/docs/evaluate/coming-from/dbos.mdx
+++ b/content/docs/evaluate/coming-from/dbos.mdx
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <Callout type="info" title="SDK version">
-This page reflects `@resonatehq/sdk` v0.11.4 (TypeScript, current on npm), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
+This page reflects `@resonatehq/sdk` v0.11.4 (TypeScript, current on npm), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust, on crates.io), and the Resonate Go SDK 0.1.0.
 </Callout>
 
 <Callout type="info" title="About the code">
@@ -819,7 +819,7 @@ dbos.RegisterWorkflow(dbosCtx, func(ctx dbos.DBOSContext, scheduledTime time.Tim
 ```
 
 <Callout type="caution" title="No Resonate Go schedule example yet">
-There is no `example-schedule-go` yet. The Go SDK's schedules API landed recently (it tracks `main`); until a worked example ships, treat the Go scheduling cell as a known gap rather than a verified sample.
+There is no `example-schedule-go` yet. The Go SDK's schedules API shipped in the tagged `0.1.0` release; until a worked example ships, treat the Go scheduling cell as a known gap rather than a verified sample.
 </Callout>
 
 </TabItem>
@@ -985,8 +985,8 @@ func foo(ctx *resonate.Context, _ struct{}) (string, error) {
 <SeeItInAction repo="example-human-in-the-loop-go" />
 
 ```shell
-# The Go SDK has no high-level promises sub-client yet (pre-release), so
-# resolve the latent promise from outside via the Resonate CLI or server API:
+# Resolve the latent promise from outside the running program — e.g. a human
+# approving the request via the Resonate CLI or server API:
 resonate promises resolve <promise-id> --value '{"headers": {}, "data": "\"approved\""}'
 ```
 

--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <Callout type="info" title="SDK version">
-This page reflects `@resonatehq/sdk` v0.11.4 (TypeScript, current on npm), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust, on crates.io), and the Resonate Go SDK (pre-release — no semver tag yet; tracks `main`).
+This page reflects `@resonatehq/sdk` v0.11.4 (TypeScript, current on npm), `resonate-sdk` v0.7.4 (Python), `resonate-sdk` v0.6.0 (Rust, on crates.io), and the Resonate Go SDK 0.1.0.
 </Callout>
 
 **Are you coming from Temporal?**
@@ -652,8 +652,8 @@ func foo(ctx *resonate.Context, _ struct{}) (string, error) {
 <SeeItInAction repo="example-human-in-the-loop-go" />
 
 ```shell
-# The Go SDK has no high-level promises sub-client yet (pre-release), so
-# resolve the latent promise from outside via the Resonate CLI or server API.
+# Resolve the latent promise from outside the running program — e.g. a human
+# approving the request via the Resonate CLI or server API.
 # `data` must be a JSON-quoted string: the CLI base64-encodes it before storing,
 # and the worker's codec base64-decodes then JSON-parses it. A bare "approved"
 # would decode to the bytes `approved`, which is not valid JSON (DecodingError).

--- a/content/docs/get-started/examples/fan-out-fan-in.mdx
+++ b/content/docs/get-started/examples/fan-out-fan-in.mdx
@@ -16,7 +16,7 @@ keywords:
 A workflow spawns four notification channels (email, SMS, Slack, push) in parallel and joins their results. Total wall time approaches the slowest channel, not the sum. If one channel fails and retries, the others stay checkpointed — they don't re-send.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: `0.1.0` is tagged, but the tag lacks the `v` prefix Go's module resolver requires, so the example pins a `main` commit instead (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/load-balancing.mdx
+++ b/content/docs/get-started/examples/load-balancing.mdx
@@ -15,7 +15,7 @@ keywords:
 Run several workers in the same group. Calls to `target: "poll://any@<group>"` get dispatched to whichever worker claims them first. When a worker dies mid-execution, Resonate reassigns the work to a survivor — no service registry, no leader election, no glue.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: `0.1.0` is tagged, but the tag lacks the `v` prefix Go's module resolver requires, so the example pins a `main` commit instead (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/examples/recursive-factorial.mdx
+++ b/content/docs/get-started/examples/recursive-factorial.mdx
@@ -15,7 +15,7 @@ keywords:
 A workflow that computes `n!` by calling itself with `n-1`. Each recursive call dispatches via `ctx.rpc` to whichever worker in the group claims it — recursion ends up distributed across machines without any explicit coordination, and every step is checkpointed so a worker crash mid-recursion resumes cleanly.
 
 <Callout type="info" title="SDK versions">
-TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: pre-release — no semver tag yet, so the example pins a specific commit (see [Go SDK](/develop/go)).
+TypeScript: `@resonatehq/sdk` v0.11.4 (current). Python: `resonate-sdk` v0.7.4 (current). Rust: 0.6.0, in active development. Go: `0.1.0` is tagged, but the tag lacks the `v` prefix Go's module resolver requires, so the example pins a `main` commit instead (see [Go SDK](/develop/go)).
 </Callout>
 
 <CloneRepoGrid>

--- a/content/docs/get-started/quickstart.mdx
+++ b/content/docs/get-started/quickstart.mdx
@@ -71,7 +71,7 @@ go mod init countdown
 go get github.com/resonatehq/resonate-sdk-go@latest
 ```
 
-No semver tag is published yet — `@latest` resolves to the latest `main` commit. See the [Go SDK guide](/develop/go) for details.
+The `0.1.0` git tag lacks the `v` prefix Go's module resolver requires, so `@latest` resolves to a pseudo-version pinned to the latest `main` commit instead. See the [Go SDK guide](/develop/go) for details.
 
 </TabItem>
 


### PR DESCRIPTION
The coming-from-DBOS, coming-from-Temporal, quickstart, and Go example pages described the Go SDK as pre-release with no semver tag, tracking `main`. That's stale: `resonate-sdk-go` tagged `0.1.0` on 2026-06-17 (https://github.com/resonatehq/resonate-sdk-go/releases/tag/0.1.0).

Updates the version callouts to cite `0.1.0`, matching how `how-resonate-is-tested.mdx` and `develop/go.mdx` already cite it. Also corrects two related stale claims found by the same audit: the schedules API shipped in the `0.1.0` tag (not just on `main`), and the SDK's `Promises` sub-client (Resolve/Reject/Cancel) already exists, so the human-in-the-loop CLI examples now explain resolving from outside the running program rather than citing a missing SDK feature. The "pins a commit" notes on the quickstart/example pages are preserved as accurate, since the `0.1.0` tag lacks the `v` prefix Go's module resolver requires, so `go get ...@latest` still resolves to a `main` pseudo-version.

No other content changed.