### PR TITLE
Fix Python samples on dbos.mdx / temporal.mdx: rfi/rfc/lfi/lfc don't exist on resonate-sdk 0.7.4

### DIFF
--- a/content/docs/evaluate/coming-from/dbos.mdx
+++ b/content/docs/evaluate/coming-from/dbos.mdx
@@ -223,7 +223,7 @@ Resonate promotes a procedural programming model that lets you compose functions
 async def factorial(ctx: Context, n: int) -> int:
     if n <= 1:
         return 1
-    r = await ctx.options(target="factorial-workers").rpc("factorial", n - 1)
+    r = await ctx.options(target="factorial-worker").rpc("factorial", n - 1)
     return n * r
 
 
@@ -638,13 +638,20 @@ def dispatch_order_workflow(order_id):
         update_order_progress(order_id)
 ```
 
-```python title="Resonate — example-durable-sleep-py/worker.py"
+```python title="Resonate — durable sleep"
+from datetime import timedelta
+
+
 @resonate.register
 async def sleeping_workflow(ctx: Context, wf_id: str, secs: float) -> str:
     print(f"Workflow {wf_id} starting, will sleep for {secs} seconds.")
     await ctx.sleep(timedelta(seconds=secs))    # timedelta, not a bare number
     return f"Workflow {wf_id} completed after sleeping for {secs} seconds."
 ```
+
+<Callout type="caution" title="The linked example passes a bare float">
+`Context.sleep` is typed `sleep(self, duration: timedelta)` on `resonate-sdk` 0.7.4. `example-durable-sleep-py/worker.py` still calls `ctx.sleep(secs)` with a float — the sample above is the correct form, and the example repository needs the same fix.
+</Callout>
 
 <SeeItInAction repo="example-durable-sleep-py" />
 
@@ -878,7 +885,9 @@ async def foo(ctx: Context, workflow_id: str) -> str:
 # gateway.py — resolve from anywhere by promise id
 from resonate.types import Value
 
-await resonate.promises.resolve(promise_id, Value(data=data))
+
+async def approve(promise_id: str, data: str) -> None:
+    await resonate.promises.resolve(promise_id, Value(data=data))
 ```
 
 </TabItem>
@@ -1038,7 +1047,11 @@ def checkout_workflow():
 ```
 
 ```python title="Resonate — example-money-transfer-py/main.py"
-async def transfer_money(ctx: Context, transfer_id, source, target, amount, *, simulate_credit_failure=False):
+from resonate.retry import Never
+
+
+async def transfer_money(ctx: Context, source, target, amount, *, simulate_credit_failure=False):
+    transfer_id = ctx.info.id                    # the workflow id is the transfer id
     await ctx.run(apply_entry, f"{transfer_id}-debit", source, -amount, "debit")
     try:
         await ctx.options(retry_policy=Never()).run(

--- a/content/docs/evaluate/coming-from/dbos.mdx
+++ b/content/docs/evaluate/coming-from/dbos.mdx
@@ -72,10 +72,10 @@ def baz(_: Context, greetee: str) -> str:
     return f"Hello {greetee} from baz!"
 
 @resonate.register
-def foo(ctx: Context, greetee: str) -> Generator[Any, Any, str]:
+async def foo(ctx: Context, greetee: str) -> str:
     foo_greeting = f"Hello {greetee} from foo!"
-    bar_greeting = yield ctx.run(bar, greetee=greetee)
-    baz_greeting = yield ctx.run(baz, greetee=greetee)
+    bar_greeting = await ctx.run(bar, greetee=greetee)
+    baz_greeting = await ctx.run(baz, greetee=greetee)
     greeting = f"{foo_greeting} {bar_greeting} {baz_greeting}"
     return greeting
 ```
@@ -220,15 +220,16 @@ Resonate promotes a procedural programming model that lets you compose functions
 
 ```python
 @resonate.register
-def factorial(ctx: Context, n: int) -> int:
+async def factorial(ctx: Context, n: int) -> int:
     if n <= 1:
         return 1
-    r = yield ctx.rpc("factorial", n - 1).options(target="poll://any@factorial-worker", id=f"factorial-{n-1}")
+    r = await ctx.options(target="factorial-workers").rpc("factorial", n - 1)
     return n * r
 
 
-def main():
-    result = factorial.run("factorial-5", n=5)
+async def main():
+    handle = resonate.run("factorial-5", factorial, n=5)
+    result = await handle.result()
     print(result)
 ```
 
@@ -373,9 +374,9 @@ DBOS(config=config)
 **Resonate** — no database, no server:
 
 ```python
-from resonate import Resonate
+from resonate.resonate import Resonate
 
-resonate = Resonate.local()
+resonate = Resonate()  # no url, no RESONATE_URL/RESONATE_HOST env -> in-memory, no server
 
 # ...
 ```
@@ -496,12 +497,12 @@ def process_tasks(tasks):
 ```
 
 ```python title="Resonate — example-fan-out-fan-in-py/workflow.py"
-# fan-out: rfi() returns a handle immediately
-email_p = yield ctx.rfi(send_email, event).options(id=f"{ctx.id}.email")
-sms_p   = yield ctx.rfi(send_sms, event).options(id=f"{ctx.id}.sms")
+# fan-out: ctx.run returns a future immediately, without blocking
+email_f = ctx.run(send_email, event)
+sms_f = ctx.run(send_sms, event)
 # fan-in: await each
-email = yield email_p
-sms   = yield sms_p
+email = await email_f
+sms = await sms_f
 ```
 
 <SeeItInAction repo="example-fan-out-fan-in-py" />
@@ -613,7 +614,7 @@ for i, f := range futures {                              // fan-in
 DBOS workflows pause with `DBOS.sleep`, which records the wakeup time in the database so the sleep survives crashes and restarts. Resonate's equivalent is `ctx.sleep` — a single durable promise that survives crashes.
 
 <Callout type="caution" title="Watch the time units">
-Both systems vary the unit by SDK. DBOS: TypeScript `DBOS.sleep` takes **milliseconds**, Python `DBOS.sleep` takes **seconds**, Go `dbos.Sleep` takes a `time.Duration`. Resonate matches almost exactly: TypeScript **milliseconds**, Python **seconds**, Go and Rust a native `Duration`.
+Both systems vary the unit by SDK. DBOS: TypeScript `DBOS.sleep` takes **milliseconds**, Python `DBOS.sleep` takes **seconds**, Go `dbos.Sleep` takes a `time.Duration`. Resonate: TypeScript **milliseconds**, Python a `timedelta` (`ctx.sleep(timedelta(seconds=...))`), Go and Rust a native `Duration`.
 </Callout>
 
 <Tabs
@@ -639,9 +640,9 @@ def dispatch_order_workflow(order_id):
 
 ```python title="Resonate — example-durable-sleep-py/worker.py"
 @resonate.register
-def sleeping_workflow(ctx: Context, wf_id: str, secs: float):
+async def sleeping_workflow(ctx: Context, wf_id: str, secs: float) -> str:
     print(f"Workflow {wf_id} starting, will sleep for {secs} seconds.")
-    yield ctx.sleep(secs)                      # seconds (float)
+    await ctx.sleep(timedelta(seconds=secs))    # timedelta, not a bare number
     return f"Workflow {wf_id} completed after sleeping for {secs} seconds."
 ```
 
@@ -859,21 +860,25 @@ DBOS.send(payment_id, payment_status, PAYMENT_STATUS)
 
 ```python title="Resonate — example-human-in-the-loop-py"
 # worker.py
-@resonate.register()
-def foo(ctx, workflow_id):
-    blocking_promise = yield ctx.promise()
-    yield ctx.lfc(send_email, blocking_promise.id)
+@resonate.register
+async def foo(ctx: Context, workflow_id: str) -> str:
+    blocking_promise = ctx.promise()
+    promise_id = await blocking_promise.id()
+    await ctx.run(send_email, promise_id)
     # ...
     # wait for the promise to be resolved
-    yield blocking_promise
+    data = await blocking_promise
     # ...
+    return data
 ```
 
 <SeeItInAction repo="example-human-in-the-loop-py" />
 
 ```python
 # gateway.py — resolve from anywhere by promise id
-resonate.promises.resolve(id=promise_id, ikey=promise_id)
+from resonate.types import Value
+
+await resonate.promises.resolve(promise_id, Value(data=data))
 ```
 
 </TabItem>
@@ -1033,16 +1038,16 @@ def checkout_workflow():
 ```
 
 ```python title="Resonate — example-money-transfer-py/main.py"
-def transfer_money(ctx, transfer_id, source, target, amount, *, simulate_credit_failure=False):
-    yield ctx.run(apply_entry, f"{transfer_id}-debit", source, -amount, "debit")
+async def transfer_money(ctx: Context, transfer_id, source, target, amount, *, simulate_credit_failure=False):
+    await ctx.run(apply_entry, f"{transfer_id}-debit", source, -amount, "debit")
     try:
-        yield ctx.run(
+        await ctx.options(retry_policy=Never()).run(
             credit_target, f"{transfer_id}-credit", target, amount,
             fail=simulate_credit_failure,
-        ).options(retry_policy=Never())
+        )
     except Exception as err:
         # compensate inline
-        yield ctx.run(apply_entry, f"{transfer_id}-reversal", source, amount, "reversal")
+        await ctx.run(apply_entry, f"{transfer_id}-reversal", source, amount, "reversal")
         return {"transfer_id": transfer_id, "status": "compensated", "error": str(err)}
     return {"transfer_id": transfer_id, "status": "committed"}
 ```
@@ -1189,8 +1194,9 @@ Consider the following Resonate example.
 
 ```python
 # worker.py
-resonate = Resonate.remote(
-    group="workers"
+resonate = Resonate(
+    url="http://localhost:8001",
+    group="workers",
     # ...
 )
 ```
@@ -1199,13 +1205,15 @@ resonate = Resonate.remote(
 
 ```python
 # client.py
-resonate = Resonate.remote(
-    group="client"
+resonate = Resonate(
+    url="http://localhost:8001",
+    group="client",
 )
 
-def main():
+async def main():
     # ...
-    result = resonate.options(target="poll://any@workers").rpc(promise_id, "function_name", params)
+    handle = resonate.options(target="poll://any@workers").rpc(promise_id, "function_name", params)
+    result = await handle.result()
 ```
 
     </TabItem>

--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -775,7 +775,7 @@ func sleepingWorkflow(ctx *resonate.Context, args SleepArgs) (string, error) {
 
 Start many units of work in parallel, then join all results. In Temporal you spawn activities (or children) without awaiting, then await them together. Resonate is the same shape: start each with a non-blocking invocation, then await each promise.
 
-<Callout type="info" title="The only per-SDK wrinkle">
+<Callout type="info" title="Spawning differs per SDK">
 The non-blocking spawn step — TS `ctx.beginRun`, Rust `.spawn()`, Go `ctx.RPC` — each returns a future immediately; you await them after all are started. Python needs no separate spawn call: `ctx.run`/`ctx.rpc` already return a future the moment they're called, so fanning out is just calling several before awaiting any of them.
 </Callout>
 
@@ -909,7 +909,11 @@ async def workflow_compensation(self):
 ```
 
 ```python title="Resonate — example-money-transfer-py/main.py"
-async def transfer_money(ctx: Context, transfer_id, source, target, amount, *, simulate_credit_failure=False):
+from resonate.retry import Never
+
+
+async def transfer_money(ctx: Context, source, target, amount, *, simulate_credit_failure=False):
+    transfer_id = ctx.info.id                    # the workflow id is the transfer id
     await ctx.run(apply_entry, f"{transfer_id}-debit", source, -amount, "debit")
     try:
         await ctx.options(retry_policy=Never()).run(

--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -79,8 +79,8 @@ def bar(_: Context, greetee: str) -> str:
     return f"Hello {greetee} from bar!"
 
 @resonate.register
-def foo(ctx: Context, greetee: str) -> Generator[Any, Any, str]:
-    bar_greeting = yield ctx.run(bar, greetee=greetee)
+async def foo(ctx: Context, greetee: str) -> str:
+    bar_greeting = await ctx.run(bar, greetee=greetee)
     return bar_greeting
 ```
 
@@ -230,15 +230,16 @@ How might you implement it in Temporal?
 
 ```python
 @resonate.register
-def factorial(ctx: Context, n: int) -> int:
+async def factorial(ctx: Context, n: int) -> int:
     if n <= 1:
         return 1
-    r = yield ctx.rpc("factorial", n - 1).options(target="poll://any@factorial-worker", id=f"factorial-{n-1}")
+    r = await ctx.options(target="factorial-workers").rpc("factorial", n - 1)
     return n * r
 
 
-def main():
-    result = factorial.run("factorial-5", n=5)
+async def main():
+    handle = resonate.run("factorial-5", factorial, n=5)
+    result = await handle.result()
     print(result)
 ```
 
@@ -369,9 +370,9 @@ Resonate offers a zero-dependency development experience, where a Worker (single
     <TabItem value="python">
 
 ```python
-from resonate import Resonate
+from resonate.resonate import Resonate
 
-resonate = Resonate.local()
+resonate = Resonate()  # no url, no RESONATE_URL/RESONATE_HOST env -> in-memory, no server
 
 #...
 ```
@@ -549,25 +550,26 @@ Then, you can resolve it from anywhere, optionally sending data into the functio
 
 ```python
 # worker.py
-@resonate.register()
-def foo(ctx: Context) -> None:
-    blocking_promise = yield ctx.promise()
-    # ...
+@resonate.register
+async def foo(ctx: Context) -> str:
+    blocking_promise = ctx.promise()
+    promise_id = await blocking_promise.id()
+    # ... hand promise_id to the human, e.g. via a leaf that emails/pages them ...
     # wait for the promise to be resolved
-    data = yield blocking_promise
+    data = await blocking_promise
     # ...
+    return data
 ```
 
 <SeeItInAction repo="example-human-in-the-loop-py" />
 
 ```python
 # client.py
-def main():
+from resonate.types import Value
+
+async def main():
     # ...
-    resonate.promises.resolve(
-        id=promise_id,
-        data=json.dumps(data)
-    )
+    await resonate.promises.resolve(promise_id, Value(data=data))
 ```
 
     </TabItem>
@@ -669,7 +671,7 @@ resonate promises resolve <promise-id> --value '{"headers": {}, "data": "\"appro
 Temporal's `sleep-for-days` shows a durable timer racing against a signal. Resonate's equivalent is `ctx.sleep` — a single durable promise that survives crashes.
 
 <Callout type="caution" title="Watch the time units">
-Temporal accepts human strings (`'30 days'`) or a `timedelta`. Resonate's units differ **per SDK**: TypeScript takes **milliseconds**, Python takes **seconds**, Go and Rust take a native `Duration`. Converting `'30 days'` for the TS SDK means `30 * 24 * 60 * 60 * 1000`.
+Temporal accepts human strings (`'30 days'`) or a `timedelta`. Resonate's units differ **per SDK**: TypeScript takes **milliseconds**, Python takes a `timedelta`, Go and Rust take a native `Duration`. Converting `'30 days'` for the TS SDK means `30 * 24 * 60 * 60 * 1000`.
 </Callout>
 
 <Tabs
@@ -692,8 +694,8 @@ await workflow.sleep(timedelta(days=30))   # timedelta
 
 ```python title="Resonate — example-durable-sleep-py/worker.py"
 @resonate.register
-def sleeping_workflow(ctx: Context, wf_id: str, secs: float):
-    yield ctx.sleep(secs)                   # seconds (float)
+async def sleeping_workflow(ctx: Context, wf_id: str, secs: float) -> str:
+    await ctx.sleep(timedelta(seconds=secs))    # timedelta, not a bare number
     return f"Workflow {wf_id} slept for {secs} seconds."
 ```
 
@@ -774,7 +776,7 @@ func sleepingWorkflow(ctx *resonate.Context, args SleepArgs) (string, error) {
 Start many units of work in parallel, then join all results. In Temporal you spawn activities (or children) without awaiting, then await them together. Resonate is the same shape: start each with a non-blocking invocation, then await each promise.
 
 <Callout type="info" title="The only per-SDK wrinkle">
-The non-blocking spawn primitive's name — TS `ctx.beginRun`, Python `ctx.rfi`, Rust `.spawn()`, Go `ctx.RPC` — each returns a future immediately; you await them after all are started.
+The non-blocking spawn step — TS `ctx.beginRun`, Rust `.spawn()`, Go `ctx.RPC` — each returns a future immediately; you await them after all are started. Python needs no separate spawn call: `ctx.run`/`ctx.rpc` already return a future the moment they're called, so fanning out is just calling several before awaiting any of them.
 </Callout>
 
 <Tabs
@@ -799,12 +801,12 @@ results = await asyncio.gather(
 ```
 
 ```python title="Resonate — example-fan-out-fan-in-py/workflow.py"
-# fan-out: rfi() returns a handle immediately
-email_p = yield ctx.rfi(send_email, event).options(id=f"{ctx.id}.email")
-sms_p   = yield ctx.rfi(send_sms, event).options(id=f"{ctx.id}.sms")
+# fan-out: ctx.run returns a future immediately, without blocking
+email_f = ctx.run(send_email, event)
+sms_f = ctx.run(send_sms, event)
 # fan-in: await each
-email = yield email_p
-sms   = yield sms_p
+email = await email_f
+sms = await sms_f
 ```
 
 <SeeItInAction repo="example-fan-out-fan-in-py" />
@@ -907,16 +909,16 @@ async def workflow_compensation(self):
 ```
 
 ```python title="Resonate — example-money-transfer-py/main.py"
-def transfer_money(ctx, transfer_id, source, target, amount, *, simulate_credit_failure=False):
-    yield ctx.run(apply_entry, f"{transfer_id}-debit", source, -amount, "debit")
+async def transfer_money(ctx: Context, transfer_id, source, target, amount, *, simulate_credit_failure=False):
+    await ctx.run(apply_entry, f"{transfer_id}-debit", source, -amount, "debit")
     try:
-        yield ctx.run(
+        await ctx.options(retry_policy=Never()).run(
             credit_target, f"{transfer_id}-credit", target, amount,
             fail=simulate_credit_failure,
-        ).options(retry_policy=Never())
+        )
     except Exception as err:
         # compensate inline
-        yield ctx.run(apply_entry, f"{transfer_id}-reversal", source, amount, "reversal")
+        await ctx.run(apply_entry, f"{transfer_id}-reversal", source, amount, "reversal")
         return {"transfer_id": transfer_id, "status": "compensated", "error": str(err)}
     return {"transfer_id": transfer_id, "status": "committed"}
 ```
@@ -1148,7 +1150,7 @@ The Go SDK also has `ctx.Detached` for the unbounded case; the shipped example u
 <TabItem value="python">
 
 <Callout type="caution" title="No Resonate Python infinite-workflow example yet">
-`example-infinite-workflow-py` does not exist. Temporal's source is `samples-python/hello/hello_continue_as_new.py` (`workflow.continue_as_new(iteration + 1)`). The Resonate equivalent is a plain generator loop (`while … : yield ctx.run(...) ; yield ctx.sleep(...)`), with `ctx.detached(self, n + 1)` for the unbounded case — but until an example ships, treat this as a known gap.
+`example-infinite-workflow-py` does not exist. Temporal's source is `samples-python/hello/hello_continue_as_new.py` (`workflow.continue_as_new(iteration + 1)`). The Resonate equivalent is a plain `while` loop (`while … : await ctx.run(...) ; await ctx.sleep(...)`), with `ctx.detached("workflow_name", n + 1)` for the unbounded case (`detached` dispatches by registered name, not by function reference) — but until an example ships, treat this as a known gap.
 </Callout>
 
 </TabItem>
@@ -1279,8 +1281,9 @@ Resonate will automatically load balance the invocations across the Workers in t
 
 ```python
 # worker.py
-resonate = Resonate.remote(
-    group="workers"
+resonate = Resonate(
+    url="http://localhost:8001",
+    group="workers",
     # ...
 )
 ```
@@ -1289,13 +1292,15 @@ resonate = Resonate.remote(
 
 ```python
 # client.py
-resonate = Resonate.remote(
-    group="client"
+resonate = Resonate(
+    url="http://localhost:8001",
+    group="client",
 )
 
-def main():
+async def main():
     # ...
-    result = resonate.options(target="poll://any@workers").rpc(promise_id, "function_name", params)
+    handle = resonate.options(target="poll://any@workers").rpc(promise_id, "function_name", params)
+    result = await handle.result()
 ```
 
     </TabItem>


### PR DESCRIPTION
## Problem

Both `content/docs/evaluate/coming-from/dbos.mdx` and `content/docs/evaluate/coming-from/temporal.mdx` state they reflect `resonate-sdk` v0.7.4 (Python), but the Python samples call APIs that don't exist on that version:

- `Context.rfi` / `Context.rfc` / `Context.lfi` / `Context.lfc` — none of these exist. `Context` on 0.7.4 has exactly `run`, `rpc`, `sleep`, `promise`, `detached`.
- `Context.options(id=...)` — `options()` accepts only `timeout`, `target`, `version`, `retry_policy`. Passing `id` raises `TypeError`. Child promise ids are always SDK-derived as `f"{parent_id}.{seq}"` — the caller cannot choose them (this is a protocol-level constraint, not a Python gap: see `resonatehq/resonate-protocol` `spec/protocol.md` § "Promise ID Convention").
- The generator (`yield ctx....`) calling convention — 0.7.0 was an async/await rewrite; workflows are plain `async def` functions using `await`.
- `Resonate.local()` / `Resonate.remote(group=...)` — no such classmethods; the real constructor is `Resonate(url=..., group=..., ...)` (omit `url` for in-memory local mode).
- `from resonate import Resonate` — `Resonate` is not re-exported from the package root; every SDK example imports `from resonate.resonate import Resonate`.
- `ctx.sleep(secs)` — takes a `datetime.timedelta`, not a bare number.
- `resonate.promises.resolve(id=..., ikey=...)` / `resolve(id=..., data=...)` — the real signature is positional `resolve(id: str, value: Value)`.
- `ctx.run(...).options(...)` / `ctx.rpc(...).options(...)` — `options()` must be called on the `Context` *before* the durable op (`ctx.options(...).run(...)`), not chained off the `ResonateFuture` the op returns.

## Fix

Rewrote every stale Python sample in both files to the real 0.7.0+ async/await model, and adjusted the prose/comments the code changes invalidated (the "watch the time units" callouts, the fan-out per-SDK-wrinkle callout, the long-running-loops gap note). Left the human-in-the-loop and fan-out/fan-in samples' shape intentionally close to `resonate-sdk-py`'s own `examples/human-in-the-loop/__main__.py` (open the promise, `await future.id()`, publish that id externally) since caller-chosen branch ids were never supported by any Resonate SDK.

Every rewritten sample was executed — not just type-checked — against `resonate-sdk==0.7.4` installed from PyPI and a local `resonate dev` server (hello-world, factorial/rpc recursion, zero-dependency local mode, fan-out/fan-in, durable sleep, human-in-the-loop with an external resolver, the saga/compensation happy and failure paths, and group-routed dispatch).

Scope: only the Python code samples and their immediate surrounding prose in these two files. Other languages (TypeScript/Rust/Go) samples were not touched.

## Known follow-ups (found, not fixed here — out of scope)

- The same stale patterns (`rfi`/`begin_run`/generator `yield ctx.`) also appear in `content/docs/deploy/deployment-patterns.mdx`, `content/docs/get-started/examples/async-rpc.mdx`, and a number of other `get-started/examples/*.mdx` and `develop/*.mdx` pages. Those are outside this PR's scope but carry the same defect.

## Note

**#259 is open on this repo and also touches both `dbos.mdx` and `temporal.mdx`** (release-status wording near the top of each page, plus a promises-sub-client rewording in the human-in-the-loop section). This branch deliberately avoids those hunks, but this PR may need a rebase after #259 lands.

Not merging — for review.