### PR TITLE
Correct falsifiable claims in the Temporal comparison

### DIFF
--- a/content/docs/evaluate/coming-from/temporal.mdx
+++ b/content/docs/evaluate/coming-from/temporal.mdx
@@ -1443,8 +1443,9 @@ This belief drives many of the design decisions in Resonate, and has resulted in
 
 This smaller API surface and desire for simplicity have also resulted in a much smaller set of components.
 
-For example, Temporal SDKs have tens of thousands of lines of code needed to manage the complexity of their implementation.
-Resonate SDKs, on the other hand, have but a few hundred lines of code.
+For example, Temporal SDKs run to tens of thousands of lines of code to manage the complexity of their implementation — roughly 48,000 in TypeScript, 69,000 in Python, and 84,000 in Go.
+The Resonate SDKs are between about 6,000 and 14,000 lines depending on the language.
+(SDK source only, excluding tests and generated protobuf bindings, measured at the time of writing — clone the repos and check.)
 
 A Temporal Service is a complex system consisting of multiple individual components, each consisting of tens of thousands of lines of code, that need to be configured, deployed, and scaled independently.
 A Resonate Server, on the other hand, is a single binary that is easy to deploy. And the Resonate system can scale by just adding more Resonate Servers, each with an underlying database.
@@ -1452,8 +1453,11 @@ A Resonate Server, on the other hand, is a single binary that is easy to deploy.
 Additionally, Temporal exposes many complex APIs to the developer which they are required to use for failure detection, load balancing, and more.
 Resonate's belief in simplicity means that much of this complexity is pushed into the platform and automatically handled for you.
 
-For example, Temporal requires the developer to work with at least 4 different timeouts to detect and handle Activity Execution failures.
-It also requires the developer to manually develop heartbeats in the Activity, and tune the performance of Workers.
-Whereas, Resonate exposes a single timeout to the developer for the resolution of the Durable Promise, and it automatically handles failure detection, heartbeating, and load balancing across Workers.
+For example, Temporal defines four separate Activity timeouts — schedule-to-close, start-to-close, schedule-to-start, and heartbeat.
+Only one of them is strictly required (either schedule-to-close or start-to-close), but each covers a different failure mode, so choosing the right combination is a decision you make per Activity.
+Long-running Activities that need failure detected before the timeout expires record heartbeats themselves, and Workers expose a set of concurrency and rate-limiting knobs to tune.
+
+Resonate exposes a single timeout to the developer — the resolution deadline of the Durable Promise.
+Failure detection, heartbeating, and load balancing across Workers are handled by the platform: the SDK heartbeats the task lease, the server notices a dead Worker, and the task is re-dispatched without any application code.
 
 Ultimately, as a developer, you will find many areas where Resonate has chosen to promote a specific model for the sake of simplicity, and to avoid indulging in what we believe to be unnecessary complexity.


### PR DESCRIPTION
The **System complexity** section of `evaluate/coming-from/temporal.mdx` made two claims that a Temporal user can falsify in about a minute. The rest of the page is a fair, well-sourced comparison, which is exactly why these stand out — one checkable error invites a reader to discount everything around it.

### SDK size

The page said Resonate SDKs "have but a few hundred lines of code". Measured source, excluding tests and generated protobuf bindings:

| SDK | Resonate | Temporal |
|---|---:|---:|
| Go | ~6,000 | ~84,000 |
| Python | ~6,500 | ~69,000 |
| Java | ~7,700 | — |
| TypeScript | ~7,900 | ~48,000 |
| Rust | ~13,800 | — |

"A few hundred" is off by roughly an order of magnitude and is disproved by cloning a repo. Worth noting the direction of the error: the claim about *Temporal* ("tens of thousands") was correct and if anything understated. The gap is genuinely close to 10x, so the accurate figures make the argument on their own. Both sides are now stated with the counting method, and the reader is invited to check.

### Timeouts

The page said Temporal "requires the developer to work with at least 4 different timeouts to detect and handle Activity Execution failures". Temporal *defines* four Activity timeouts — schedule-to-close, start-to-close, schedule-to-start, heartbeat — but *requires* exactly one: either schedule-to-close or start-to-close. The other two are optional, and Temporal's own guidance is that schedule-to-start is rarely worth setting.

Reframed onto the claim that does hold: each timeout covers a different failure mode, so choosing the combination is a per-Activity decision. That is a real difference from a single promise deadline, and it survives scrutiny.

### Heartbeating

The page said Temporal "requires the developer to manually develop heartbeats in the Activity". Activity heartbeating is opt-in and scoped to long-running Activities; short ones typically do not heartbeat at all. The accurate contrast is level and default — per-Activity and opt-in, versus Resonate's per-worker automatic task-lease heartbeat — so the Resonate side now says concretely what the platform does instead of asserting it is "automatic".

### Notes for review

- Prose only. No code samples, no structural changes.
- Branched from `main`, independent of #260 (which touches the Python samples on this same file, in a different section). No overlap; either can merge first.
- The one thing I did **not** change: the page still has no statement of Resonate's at-least-once recovery tradeoff — that work in a function body, rather than inside `ctx.run`, can re-run after a crash. The page already carries honest caveats elsewhere, so it would not be out of character, but adding a tradeoff section to a comparison page is a positioning call rather than a factual fix. Happy to draft it as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)