### PR TITLE
Add Postgres to the server providers surface

### DIFF
--- a/content/docs/deploy/index.mdx
+++ b/content/docs/deploy/index.mdx
@@ -84,7 +84,7 @@ Start the Resonate server with persistent storage:
 
 The server coordinates work for all your workers.
 
-Already run ScyllaDB or NATS and would rather not add a database beside it? Resonate publishes a separate server implementation of the protocol for each, source-available under BUSL-1.1. See [Server providers](/deploy/providers).
+Already run ScyllaDB, NATS, or Postgres and would rather not add a database beside it? Resonate publishes a separate server implementation of the protocol for each. The ScyllaDB and NATS providers are source-available under BUSL-1.1; the Postgres provider is Apache 2.0. See [Server providers](/deploy/providers).
 
 ### 3. Deploy workers
 

--- a/content/docs/deploy/providers/index.mdx
+++ b/content/docs/deploy/providers/index.mdx
@@ -7,11 +7,12 @@ keywords:
   - server
   - scylladb
   - nats
+  - postgres
 ---
 
 ## TL;DR
 
-Durable execution is a protocol, not a product. Any platform that gives you durable storage and an atomic compare-and-swap can implement the Resonate server protocol. A **provider** is one of those implementations: a separate server binary built for a specific platform, not a storage flag on the core server. Resonate builds and maintains the two below, independently of the platforms they run on.
+Durable execution is a protocol, not a product. Any platform that gives you durable storage and an atomic compare-and-swap can implement the Resonate server protocol. A **provider** is one of those implementations: a separate artifact built for a specific platform — its own server binary, or in one case a SQL file you load into the database — not a storage flag on the core server. Resonate builds and maintains the three below, independently of the platforms they run on.
 
 Most teams should run the core server. Reach for a provider when the platform it targets is one you already operate and would rather not add a database beside.
 
@@ -22,20 +23,33 @@ Most teams should run the core server. Reach for a provider when the platform it
 | [Core server](/deploy/run-server) | Postgres, MySQL, SQLite | HTTP | Apache 2.0 | — |
 | [ScyllaDB](/deploy/providers/scylladb) | ScyllaDB (CQL) | HTTP | Source-available (BUSL-1.1) | Yes |
 | [NATS](/deploy/providers/nats) | NATS JetStream | NATS | Source-available (BUSL-1.1) | No |
+| [Postgres](/deploy/providers/postgres) | Postgres | HTTP push (`pg_net`) | Apache 2.0 | No |
 
 "Drop-in" means the provider speaks the same HTTP/JSON protocol the core server speaks, so your SDK and your application code do not change. Workers point at a different `RESONATE_URL`.
 
 The NATS provider is not drop-in. It replaces both storage *and* transport, so it has no HTTP interface at all and workers connect over NATS using the `NatsNetwork` client built into the SDK. Your workflow code is unchanged; the client wiring is not, and only the TypeScript and Python SDKs have that client today.
 
+The Postgres provider is not drop-in either, for a different reason. There is no server process to point a URL at — workers reach the protocol by calling a function inside the database, which needs a client that speaks SQL rather than HTTP. Only the TypeScript SDK has one today.
+
+<Callout type="info" title="Postgres appears twice, and the difference matters">
+The core server *supports* Postgres: you run a binary, and Postgres is where it keeps its state. The Postgres provider *is* Postgres: there is no binary at all. Storage, queue, and timer are the database itself, with `pg_cron` driving all three. If you want a Resonate server that happens to store data in Postgres, run the core server. If you want durable execution with no process to deploy beside your database, read on.
+</Callout>
+
 ## What a provider is not
 
 - **Not a plugin.** There is no adapter interface to register a new backend against the core server. A provider is an independent implementation of the published protocol.
-- **Not a configuration flag.** You do not get ScyllaDB by passing an option to `resonate serve`. You run a different binary.
-- **Not necessarily Apache 2.0.** The core server is Apache 2.0. The ScyllaDB and NATS providers are source-available under BUSL-1.1 — free for development, testing, and evaluation, with production use requiring a commercial license until each version's Change Date. Read the license in the repository before you plan a production rollout.
+- **Not a configuration flag.** You do not get ScyllaDB by passing an option to `resonate serve`. You run a different binary. You do not get the Postgres provider by pointing `resonate serve` at a Postgres database — that is the core server using Postgres for storage, which is a different thing.
+- **Licensing varies.** The core server and the Postgres provider are Apache 2.0. The ScyllaDB and NATS providers are source-available under BUSL-1.1 — free for development, testing, and evaluation, with production use requiring a commercial license until each version's Change Date. Read the license in the repository before you plan a production rollout.
 
 ## Maturity
 
-The core server is the reference implementation and the default recommendation. The providers are newer. Both implement the core of the protocol, but neither implements search, neither has server-side authentication, and neither has a production reference deployment yet. They are also not equally proven — the ScyllaDB provider ships oracle-diff, crash, and linearizability suites; the NATS provider has unit tests only.
+The core server is the reference implementation and the default recommendation. The providers are newer, and they are not equally proven.
+
+- **ScyllaDB** ships oracle-diff, crash, and linearizability suites — the deepest test coverage of the three.
+- **NATS** has unit tests over the store, schedules, and tasks, but none of those suites.
+- **Postgres** has no test suite in the repository at all. What it ships is a shim that lets an external conformance harness drive the database, and there are open correctness issues against task leasing and settlement that the tracker records honestly.
+
+None of the three has a production reference deployment yet. Neither ScyllaDB nor NATS implements search; the Postgres provider does. Server-side authentication is absent from ScyllaDB and NATS, while the Postgres provider inherits Postgres's own — a dedicated role and an explicit grant surface.
 
 Each provider page has a "What's not there yet" section. Read it before you commit to one.
 

--- a/content/docs/deploy/providers/index.mdx
+++ b/content/docs/deploy/providers/index.mdx
@@ -23,7 +23,7 @@ Most teams should run the core server. Reach for a provider when the platform it
 | [Core server](/deploy/run-server) | Postgres, MySQL, SQLite | HTTP | Apache 2.0 | — |
 | [ScyllaDB](/deploy/providers/scylladb) | ScyllaDB (CQL) | HTTP | Source-available (BUSL-1.1) | Yes |
 | [NATS](/deploy/providers/nats) | NATS JetStream | NATS | Source-available (BUSL-1.1) | No |
-| [Postgres](/deploy/providers/postgres) | Postgres | HTTP push (`pg_net`) | Apache 2.0 | No |
+| [Postgres](/deploy/providers/postgres) | Postgres | SQL (`resonate_rpc`); optional HTTP push | Apache 2.0 | No |
 
 "Drop-in" means the provider speaks the same HTTP/JSON protocol the core server speaks, so your SDK and your application code do not change. Workers point at a different `RESONATE_URL`.
 

--- a/content/docs/deploy/providers/meta.json
+++ b/content/docs/deploy/providers/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Server providers",
-  "pages": ["scylladb", "nats"]
+  "pages": ["scylladb", "nats", "postgres"]
 }

--- a/content/docs/deploy/providers/nats.mdx
+++ b/content/docs/deploy/providers/nats.mdx
@@ -162,7 +162,8 @@ Subjects are case-sensitive end to end, and nothing normalizes case for you, so 
 ## See also
 
 - [Server providers](/deploy/providers) — what a provider is and what else ships
-- [Resonate on ScyllaDB](/deploy/providers/scylladb) — the other provider
+- [Resonate on ScyllaDB](/deploy/providers/scylladb) — the drop-in provider
+- [Resonate on Postgres](/deploy/providers/postgres) — the in-database provider
 - [Durable Execution on NATS](https://www.resonatehq.io/providers/nats) — the overview page
 - [resonatehq/resonate-on-nats](https://github.com/resonatehq/resonate-on-nats) — the source
 - [resonatehq/nats-demos](https://github.com/resonatehq/nats-demos) — runnable TypeScript and Python examples

--- a/content/docs/deploy/providers/postgres.mdx
+++ b/content/docs/deploy/providers/postgres.mdx
@@ -1,0 +1,151 @@
+---
+title: Resonate on Postgres
+description: Run the Resonate protocol inside Postgres itself — one SQL file, no server process, with pg_cron driving the timers.
+keywords:
+  - deploy
+  - providers
+  - postgres
+  - supabase
+  - pg_cron
+---
+
+## TL;DR
+
+[`resonate-pg`](https://github.com/resonatehq/resonate-pg) implements the Resonate protocol as a schema of stored procedures. You load one SQL file into a Postgres 16+ database and the database becomes the server: storage, queue, and timer, with `pg_cron` driving all three. There is no process to deploy, no port to expose, and no binary to keep running.
+
+This is not the same thing as running the [core server](/deploy/run-server) on Postgres. There, you run a binary and Postgres is where it keeps its state. Here, there is no binary — the protocol *is* the database.
+
+It is **not drop-in**, for the opposite reason the [NATS provider](/deploy/providers/nats) isn't. NATS has no HTTP interface because it replaced the transport; this has no HTTP interface because there is no server process to host one. Workers call `resonate.resonate_rpc()` over a database connection, which needs a client that speaks SQL. Only the TypeScript SDK has one today.
+
+It is Apache 2.0, unlike the other two providers. It is also the youngest of the three — read [What's not there yet](#whats-not-there-yet) before you plan a production rollout.
+
+## When to use it
+
+Use it when you already run Postgres and want durable execution without deploying anything beside it. That is a real category: a Supabase project, a managed Postgres instance with no accompanying compute, a small service where one more process to operate is one too many.
+
+If you are willing to run a process, run the [core server](/deploy/run-server) on Postgres instead. It is the reference implementation, it has the deepest production track record, and every SDK can talk to it. Reach for this provider when *no process* is the requirement, not when Postgres is.
+
+If you are on Python, Go, Rust, or Java, this provider is not usable today — see [Connecting workers](#connecting-workers).
+
+## Requirements
+
+- **Postgres 16+.**
+- **`pg_cron`** — required. It is the sole timer driver. Without it, timers never fire: durable sleeps never wake, task timeouts never expire, and nothing tells you at runtime.
+- **`pg_net` or `pgsql_http`** — optional, and either one will do. These enable HTTP push delivery, which is how the database reaches out to your workers. Without one of them there is no push, and workers have to poll.
+
+## Run it
+
+Install the extensions, then apply the schema:
+
+```shell
+psql -d yourdb -c "create extension if not exists pg_cron; create extension if not exists pg_net;"
+psql -d yourdb -f resonate.sql
+```
+
+Applying the file also schedules the timer job — it registers `resonate_process_timeouts` with `pg_cron` to run every five seconds.
+
+<Callout type="caution" title="A missing pg_cron is a warning, not an error">
+If `pg_cron` isn't available, the install still succeeds. It raises a warning and leaves the timer unscheduled, which means promises are created and settled normally while every durable sleep hangs forever. Check for the `resonate: pg_cron enabled` notice in the install output, and confirm the job exists in `cron.job` before you trust a timer.
+
+Scheduling also degrades quietly. The installer prefers `cron.schedule_in_database` at a five-second interval and falls back through plain `cron.schedule` to a once-a-minute schedule if the shorter interval is refused. A minute-granularity fallback still works, but timer resolution drops accordingly.
+</Callout>
+
+### Supabase quickstart
+
+Supabase is the shortest path to a running instance, because both extensions are available and the whole install goes over the Management API with no connection string:
+
+```shell
+supabase projects create resonate-countdown
+supabase link --project-ref <project-ref>
+supabase db query --linked "create extension if not exists pg_cron; create extension if not exists pg_net;"
+supabase db query --linked -f resonate.sql
+```
+
+Workers then run as Edge Functions. The repository's [`example/countdown`](https://github.com/resonatehq/resonate-pg/tree/main/example/countdown) goes from an empty project to a running durable workflow in about five minutes.
+
+Supabase is a convenient host, not a boundary — `resonate-pg` is plain Postgres and runs anywhere Postgres 16+ and `pg_cron` do.
+
+## Connecting workers
+
+Workers do not point at a `RESONATE_URL`. They open a database connection and reach the protocol through a single function:
+
+```sql
+SELECT resonate.resonate_rpc('{"kind":"promise.get","head":{},"data":{"id":"invoke:foo"}}');
+```
+
+### TypeScript
+
+The [`@resonatehq/supabase`](https://jsr.io/@resonatehq/supabase) package on JSR wraps `@resonatehq/sdk` with a `Network` implementation that speaks `resonate_rpc` over a Postgres connection, plus an HTTP handler for hosting the worker in an Edge Function. Despite the name it is a Postgres client, not a Supabase-only one.
+
+The package is pre-1.0. Expect its surface to move.
+
+### Other languages
+
+There is no `resonate_rpc` client in the Python, Go, Rust, or Java SDKs, so teams on those languages cannot use this provider today. Each is tracked as an open issue on the repository.
+
+<Callout type="caution" title="The repository's SDK list is broader than what works">
+`resonate-pg`'s README links all five Resonate SDKs under "SDK" without qualification. Only TypeScript has a client that can reach `resonate_rpc`. Treat that list as the SDKs Resonate publishes, not the SDKs this provider supports.
+</Callout>
+
+## Starting a workflow
+
+Invocations start from SQL, and delivery is push-based — the database calls out to the address you give it:
+
+```sql
+SELECT resonate.invoke(
+  'countdown-1',                                    -- promise id
+  'countdown',                                      -- registered function name
+  '[3]'::jsonb,                                     -- arguments
+  'https://<project-ref>.functions.supabase.co/countdown');  -- worker address
+```
+
+The last two parameters, `version` and `timeout`, default to `1` and **24 hours from now**. A workflow still running when its timeout lands is timed out, so pass an explicit `timeout` for anything long-lived — a multi-day sleep will otherwise expire mid-run.
+
+Push delivery goes through `pg_net`'s `net.http_post` where available, falling back to `pgsql_http`. A failed push is logged as a warning rather than raised, so the workflow does not fail — but a persistently unreachable worker shows up in the Postgres log, not in your application.
+
+## How state is stored
+
+Seven tables in a `resonate` schema: `promises`, `tasks`, `task_resumes`, `callbacks`, `listeners`, `schedules`, and `outbox`. Every protocol action is a stored procedure over them, dispatched by kind through `resonate.resonate_rpc()`.
+
+The outbox is the delivery queue. `pg_cron` calls `resonate.process_timeouts()` on its schedule, which expires what is due and enqueues what is now runnable; a trigger on the outbox performs the HTTP push.
+
+Search is implemented — `promise.search`, `task.search`, and `schedule.search` all return results rather than an error, which is not true of the other two providers.
+
+## Access control
+
+Authentication is Postgres's, not the server's, and the schema is set up for that rather than left open. The install revokes all table, sequence, and function privileges from `PUBLIC`, creates a `resonate_worker` role, and grants it usage on the schema plus execute on the six functions a worker actually needs. `resonate_rpc` and the two dequeue functions are `SECURITY DEFINER`, and every function in the schema has its `search_path` pinned.
+
+Give workers the `resonate_worker` role rather than a superuser connection. Anyone who can execute `resonate_rpc` can drive the whole protocol, so the database connection is the security boundary.
+
+## How it's tested
+
+`resonate-pg` has **no test suite in the repository**. What it ships is `test/conformance.py` — a shim that exposes `resonate_rpc` over HTTP so an external, model-based conformance harness can drive the database as if it were a Resonate server. Running it means standing up that harness separately.
+
+That is materially less than either sibling: there are no unit tests of the kind the NATS provider has, and none of the oracle-diff, crash, or linearizability suites [the ScyllaDB provider ships](/deploy/providers/scylladb#how-its-tested).
+
+## What's not there yet
+
+- **Open correctness issues against task lifecycle.** The tracker carries several confirmed bugs in task leasing and settlement — a task that can be halted after it reports fulfilled, a lease claimed by `task.create` that `task.acquire` then refuses as timed out, timeout handlers redispatching workflows that are already finished, and a settlement cascade that can wake an awaiter whose own promise is already dead. Read the [open issues](https://github.com/resonatehq/resonate-pg/issues) before you commit to this provider.
+- **No test suite in the repository.** See [How it's tested](#how-its-tested).
+- **No production reference deployments.** Nobody is running this in production yet.
+- **TypeScript only.** No other SDK has a client that can reach `resonate_rpc`.
+- **The worker client is pre-1.0.** `@resonatehq/supabase` has not reached a stable release.
+- **Timers depend entirely on `pg_cron`.** There is no in-database fallback. If the cron job is unscheduled, paused, or lost in a restore, durable sleeps stop waking and nothing surfaces the failure.
+- **Retention is yours to run.** Completed workflows stay in the database until you delete them, and ids are idempotent only while their row exists — so a garbage-collection horizon shorter than your retry window turns a duplicate submission into a second execution. Schedule it deliberately:
+
+  ```sql
+  -- daily at 03:00: delete workflows finished more than 7 days ago
+  select cron.schedule('resonate-gc', '0 3 * * *',
+    $$select resonate.gc((extract(epoch from now())*1000 - 7*86400000)::bigint)$$);
+  ```
+
+- **No horizontal story beyond Postgres's own.** Throughput, connection limits, and failover are whatever your Postgres deployment provides. There is nothing to scale independently of the database.
+
+## See also
+
+- [Server providers](/deploy/providers) — what a provider is and what else ships
+- [Run the core server](/deploy/run-server) — the reference implementation, including on Postgres
+- [Resonate on NATS](/deploy/providers/nats) — the other non-drop-in provider
+- [Resonate on ScyllaDB](/deploy/providers/scylladb) — the drop-in provider
+- [Durable Execution on Postgres](https://www.resonatehq.io/providers/postgres) — the overview page
+- [resonatehq/resonate-pg](https://github.com/resonatehq/resonate-pg) — the source

--- a/content/docs/deploy/providers/postgres.mdx
+++ b/content/docs/deploy/providers/postgres.mdx
@@ -77,6 +77,20 @@ SELECT resonate.resonate_rpc('{"kind":"promise.get","head":{},"data":{"id":"invo
 
 The [`@resonatehq/supabase`](https://jsr.io/@resonatehq/supabase) package on JSR wraps `@resonatehq/sdk` with a `Network` implementation that speaks `resonate_rpc` over a Postgres connection, plus an HTTP handler for hosting the worker in an Edge Function. Despite the name it is a Postgres client, not a Supabase-only one.
 
+```typescript
+import { type Context, Resonate } from "jsr:@resonatehq/supabase@0.4.1";
+
+const resonate = new Resonate();
+
+resonate.register("countdown", async function countdown(ctx: Context, n: number) {
+  // ... your workflow
+});
+
+resonate.httpHandler();
+```
+
+There is no URL to configure — the connection comes from the environment. The full worker is in [`example/countdown/index.ts`](https://github.com/resonatehq/resonate-pg/blob/main/example/countdown/index.ts).
+
 The package is pre-1.0. Expect its surface to move.
 
 ### Other languages

--- a/content/docs/deploy/providers/scylladb.mdx
+++ b/content/docs/deploy/providers/scylladb.mdx
@@ -167,6 +167,7 @@ Read this section before you plan a production rollout.
 ## See also
 
 - [Server providers](/deploy/providers) — what a provider is and what else ships
-- [Resonate on NATS](/deploy/providers/nats) — the other provider
+- [Resonate on NATS](/deploy/providers/nats) — the provider that replaces the transport
+- [Resonate on Postgres](/deploy/providers/postgres) — the in-database provider
 - [Durable Execution on ScyllaDB](https://www.resonatehq.io/providers/scylladb) — the overview page
 - [resonatehq/resonate-on-scylladb](https://github.com/resonatehq/resonate-on-scylladb) — the source


### PR DESCRIPTION
Adds `resonate-pg` as the third provider: a new `deploy/providers/postgres` page, a fourth row on the index, and the amendments the index needed to hold it.

## The definition needed widening first

The index defined a provider as *"a separate server **binary** built for a specific platform."* `resonate-pg` is not a binary — it is a SQL file you `psql -f` into a database (`resonate-pg/README.md:36`). Widened to *"a separate artifact built for a specific platform — its own server binary, or in one case a SQL file you load into the database."* Both disqualifiers are untouched: still not a plugin, still not a flag on `resonate serve`.

## The collision this page has to survive

Postgres now appears twice on the index — the core server row already lists it as a storage backend. A "Postgres provider" beside that reads as a duplicate unless the difference lands immediately, so it leads the page TL;DR and gets a callout on the index:

> The core server *supports* Postgres: you run a binary, and Postgres is where it keeps its state. The Postgres provider *is* Postgres: there is no binary at all.

## Two claims that contradict the sibling pages

Both were established from the repo rather than carried over from `nats.mdx`/`scylladb.mdx`. Copying the neighbours would have published two false statements:

**Search works.** The index previously said "neither implements search" as a shared provider gap. Not true of this one:
```
$ grep -n "FUNCTION promise_search\|FUNCTION task_search\|FUNCTION schedule_search" resonate.sql
522:CREATE OR REPLACE FUNCTION promise_search(p_req jsonb, p_now bigint) RETURNS jsonb
821:CREATE OR REPLACE FUNCTION task_search(p_req jsonb, p_now bigint) RETURNS jsonb
880:CREATE OR REPLACE FUNCTION schedule_search(p_req jsonb, p_now bigint) RETURNS jsonb
```
Dispatched at `resonate.sql:1089`, `:1116`, `:1126`. The Maturity section now attributes gaps per-provider instead of asserting them across all three.

**Authentication exists — Postgres's own.** `resonate.sql:1303-1333` revokes all privileges from `PUBLIC` (including default privileges on future functions), grants a `resonate_worker` role `EXECUTE` on exactly six functions, marks `resonate_rpc`/`dequeue_execute`/`dequeue_unblock` `SECURITY DEFINER`, and pins `search_path` on every function in the schema.

## Licence bullet reworded

"Not necessarily Apache 2.0" implied the permissive licence was the exception. With a row that *is* Apache 2.0 it read backwards, so it is now "Licensing varies," naming which provider is which.

## Two silent-failure modes get callouts

Neither surfaces at runtime, which is why they are callouts rather than prose:

- **A missing `pg_cron` still installs cleanly.** `resonate.sql:1200-1203` raises a `WARNING` and returns. Promises create and settle normally; every durable sleep hangs forever. The page gives the `cron.job` query to verify. Scheduling also degrades silently through three fallbacks (`:1211-1220`) down to once-a-minute resolution.
- **`invoke`'s timeout defaults to 24 hours.** `resonate.sql:1173`, `:1177` — `COALESCE(timeout, now + 86400000)`. A multi-day durable sleep expires mid-run unless the caller passes an explicit timeout.

## "What's not there yet"

Written from the repository. Open task-lifecycle issues on the tracker; `test/conformance.py` is a 108-line shim exposing `resonate_rpc` over HTTP for an external harness, not a test suite — so this has neither the NATS provider's unit tests nor ScyllaDB's oracle-diff/crash/linearizability suites; no production reference deployments; TypeScript-only, on a pre-1.0 client. No latency or throughput figure appears anywhere, here or on the index.

## Verification

```bash
npm run build     # exit 0 — check-links: 515 links, 0 internal broken, 8 external warn-only (pre-existing localhost refs in deploy/metrics + deploy/tracing)
```

Source checks:
```bash
git clone https://github.com/resonatehq/resonate-pg && cd resonate-pg
sed -n '1167,1189p' resonate.sql     # invoke signature, 24h default timeout
sed -n '1196,1225p' resonate.sql     # pg_cron warning path + scheduling fallbacks
sed -n '1303,1333p' resonate.sql     # PUBLIC revokes, resonate_worker grants
wc -l test/conformance.py            # 108 — the shim
```

Sibling page `resonatehq.io#110` adds the matching `/providers/postgres` marketing page this one links to.

